### PR TITLE
Enable Copilot code-review skill for SmartHome

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: code-review
+description: Repository-specific guidance for Copilot pull request review in SmartHome.
+---
+
+# SmartHome code review skill
+
+Use this checklist when reviewing pull requests in this repository:
+
+1. Verify Homie payload/topic compatibility and retained message behavior are preserved.
+2. Check startup, reconnection, and availability state transitions for regressions.
+3. Validate configuration-driven behavior stays backward compatible unless explicitly documented.
+4. Confirm logging remains actionable and avoids leaking credentials or secrets.
+5. Ensure new async flows handle cancellation, timeout, and error propagation explicitly.
+6. Prefer focused findings on correctness, protocol behavior, safety, and runtime reliability.


### PR DESCRIPTION
## Summary

Add a repository `code-review` skill so Copilot PR review can analyze SmartHome changes with project-specific context instead of returning no-file review results.

Closes #<!-- issue number -->

## Changes

- Add `.github/skills/code-review/SKILL.md` with focused review guidance for Homie protocol behavior, availability transitions, compatibility, secure logging, and async error handling.
- Keep guidance targeted to high-signal correctness and reliability findings for this repository.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [x] Infrastructure / tooling

## Testing Done

- Triggered a fresh `@copilot review` on PR #5 after adding the skill.

## Checklist

- [x] Code compiles without errors
- [x] Relevant tests pass (or N/A for non-code changes)
- [x] No secrets or credentials committed
- [x] PR title is descriptive (will be used as merge commit message)