### PR TITLE
Improve nanoFramework repo sync branch fallback

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -115,6 +115,9 @@ function Invoke-GitCloneOrUpdate {
         git clone --branch $Branch --single-branch $repoUrl $targetPath
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "Branch '$Branch' not found for $Repository. Falling back to default branch."
+            if (Test-Path $targetPath) {
+                Remove-Item $targetPath -Recurse -Force
+            }
             git clone $repoUrl $targetPath
         }
         if ($LASTEXITCODE -ne 0) {
@@ -134,6 +137,11 @@ function Invoke-GitCloneOrUpdate {
     git -C $targetPath checkout $Branch
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Branch '$Branch' not found in $Repository. Keeping repository on its current/default branch."
+        git -C $targetPath pull --ff-only
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to pull $Repository"
+            exit $LASTEXITCODE
+        }
         return
     }
 

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -114,6 +114,10 @@ function Invoke-GitCloneOrUpdate {
         Write-Host "Cloning $Repository..." -ForegroundColor Cyan
         git clone --branch $Branch --single-branch $repoUrl $targetPath
         if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Branch '$Branch' not found for $Repository. Falling back to default branch."
+            git clone $repoUrl $targetPath
+        }
+        if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to clone $Repository"
             exit $LASTEXITCODE
         }
@@ -129,8 +133,8 @@ function Invoke-GitCloneOrUpdate {
 
     git -C $targetPath checkout $Branch
     if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to checkout $Branch in $Repository"
-        exit $LASTEXITCODE
+        Write-Warning "Branch '$Branch' not found in $Repository. Keeping repository on its current/default branch."
+        return
     }
 
     git -C $targetPath pull --ff-only origin $Branch


### PR DESCRIPTION
## Summary\n- make companion repo sync resilient when a configured branch does not exist in a target repo\n- fall back to cloning the repo default branch when git clone --branch <configured> fails\n- warn and keep current/default branch when checkout of configured branch fails during updates\n\n## Motivation\nStart-AgentWorkspace.ps1 failed when SMARTHOME_NANOFW_BRANCH=main was used against repositories that do not expose main (for example 
anoframework.github.io).\n\n## Result\nBootstrap and sync scripts continue and complete with explicit warnings instead of hard failure, matching the selected best-effort policy.