### PR TITLE
ci: add tag-driven releases with MinVer and assembly stamping

### DIFF
--- a/.claude/skills/smarthome-release/SKILL.md
+++ b/.claude/skills/smarthome-release/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: smarthome-release
+description: Cut a tagged SmartHome release, or stamp assembly versions locally. Use when asked to release, tag a version, publish device images, or when a release build reports the wrong version.
+---
+
+# Cut a release
+
+Releases are **manual and on demand**. Nothing fires on an ordinary merge.
+
+```bash
+git tag v1.2.0 && git push origin v1.2.0
+```
+
+That triggers `.github/workflows/release.yml`, which derives the version with
+`minver-cli`, stamps it into every `AssemblyInfo.cs`, rebuilds in `Release`, and attaches
+each device's deployment `.bin` to a GitHub release.
+
+**Tag a commit that already passed CI.** The workflow deliberately does not re-run the
+unit tests — a release that quietly tests different code than the tag names would be worse
+than one that tests none. Check the tagged commit is green first:
+
+```bash
+gh run list --branch main --workflow CI --limit 3
+```
+
+Write the `CHANGELOG.md` entry **before** tagging. It is hand-written on purpose: a
+generated list says what changed, and the part worth reading is why.
+
+## Dry run
+
+`workflow_dispatch` with `dry-run` (the default) builds, stamps and collects the images,
+uploading them as a build artifact without publishing a release. Use it after changing
+anything in the release path.
+
+## Why there is a stamping step at all
+
+`.nfproj` is a classic MSBuild project with no generated assembly info: it takes its
+version from a checked-in `Properties/AssemblyInfo.cs`, and all 14 are hardcoded to
+`1.0.0.0`. MinVer works by setting the MSBuild `$(Version)` property, which SDK-style
+projects turn into assembly attributes and classic ones ignore entirely — so MinVer alone
+would name the release correctly and leave every binary claiming 1.0.0.0.
+
+Hence `scripts\Set-AssemblyVersion.ps1`. Locally:
+
+```powershell
+.\scripts\Set-AssemblyVersion.ps1 -Version 1.2.0
+.\scripts\Set-AssemblyVersion.ps1 -Version 1.2.0 -Check   # report, change nothing, non-zero if it would
+```
+
+It rewrites `AssemblyVersion` and `AssemblyFileVersion` only. Two things it deliberately
+leaves alone, and which any replacement must also leave alone:
+
+- **`AssemblyNativeVersion`** — a nanoFramework attribute tracking the *native* assembly
+  signature, unrelated to the release version.
+- The commented-out `// [assembly: AssemblyVersion("1.0.*")]` sample line, which a loose
+  regex will happily rewrite into nonsense.
+
+It also reads with `[System.IO.File]::ReadAllText`, not `Get-Content -Raw`. On Windows
+PowerShell 5.1 `Get-Content` decodes a BOM-less file as Windows-1252, so the UTF-8 bytes
+behind the `©` in the copyright line come back as two characters and get re-encoded into
+mojibake — silently corrupting 13 of the 14 assemblies. That was a real bug, caught by
+diffing a test stamp rather than by reading the code.
+
+**If you stamp locally, revert before committing.** Versions belong to tags, not to the
+tree:
+
+```powershell
+git checkout -- src
+```
+
+## Two things to know about the images
+
+- They are **`Release`** builds, so `Debug.WriteLine` is compiled out and
+  `smarthome-watch-debug-output` will show almost nothing for them. Build `Debug` when
+  diagnosing.
+- The workflow uses `/t:Rebuild`, not `/t:Build`. A plain incremental build silently drops
+  the deployment `.bin` — the same reason `smarthome-deploy` always rebuilds. Without it a
+  release would publish no artifacts and look successful doing it.

--- a/.github/actions/setup-nanoframework/action.yml
+++ b/.github/actions/setup-nanoframework/action.yml
@@ -1,0 +1,86 @@
+name: Set up nanoFramework build components
+description: >
+  Installs the nanoFramework MSBuild components that .nfproj files need, into the location
+  they already look for them. Windows runners only.
+
+inputs:
+  vsix-repository:
+    description: Repository publishing the Visual Studio extension VSIX.
+    required: false
+    default: nanoframework/nf-Visual-Studio-extension
+  github-token:
+    description: Token used to download the VSIX release asset.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Every .nfproj resolves its build targets through
+    # $(NanoFrameworkProjectSystemPath), which it sets *itself* to
+    # $(MSBuildExtensionsPath)\nanoFramework\v1.0\ -- a path that exists only where the
+    # Visual Studio extension is installed. No hosted runner has one.
+    #
+    # The components ship inside that extension's VSIX (27 files, ~1.2 MB) and a VSIX is a
+    # zip, so they are extracted into exactly that location. Installing them where the
+    # projects already look, rather than redirecting the projects, means every script in
+    # scripts\ works unmodified -- Run-Tests.ps1 runs its own msbuild, and a global
+    # property passed to one msbuild call would not reach it.
+    #
+    # Exporting the path via GITHUB_ENV instead does nothing at all: the project-level
+    # assignment on line 4 of each .nfproj overrides an environment variable, and because
+    # the imports are guarded by Exists() conditions they then fail silently rather than
+    # erroring. Every project reports MSB4057, "The target Build does not exist".
+    #
+    # nanoFramework's own repositories solve this with the InstallNanoMSBuildComponents
+    # Azure DevOps task, which has no GitHub Actions equivalent; this is that task's job
+    # done by hand.
+    - name: Install nanoFramework MSBuild components
+      shell: powershell
+      run: |
+        $ErrorActionPreference = 'Stop'
+        gh release download --repo '${{ inputs.vsix-repository }}' `
+                            --pattern '*.vsix' --dir "$env:RUNNER_TEMP" --clobber
+        $vsix = Get-ChildItem "$env:RUNNER_TEMP\*.vsix" | Select-Object -First 1
+        Write-Host "Using $($vsix.Name)"
+
+        # MSBuildExtensionsPath is the MSBuild folder of the VS install, i.e. the
+        # grandparent of MSBuild.exe (which sits in MSBuild\Current\Bin).
+        $msbuildExe = (Get-Command msbuild).Source
+        $extensions = Split-Path (Split-Path $msbuildExe -Parent) -Parent | Split-Path -Parent
+        $components = Join-Path $extensions 'nanoFramework\v1.0'
+        Write-Host "Installing components into $components"
+        if (-not (Test-Path $components)) { New-Item -ItemType Directory -Path $components -Force | Out-Null }
+
+        # Entry-by-entry via ZipFile rather than Expand-Archive. Expand-Archive fails
+        # outright on this VSIX, and we only want 27 of its 96 entries anyway. Inside the
+        # archive they live under a literal '$MSBuild' folder, and the Rules subfolder must
+        # keep its structure.
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($vsix.FullName)
+        $prefix = '$MSBuild/nanoFramework/v1.0/'
+        $count = 0
+        try {
+            foreach ($entry in $zip.Entries) {
+                if (-not $entry.FullName.StartsWith($prefix)) { continue }
+                $relative = $entry.FullName.Substring($prefix.Length)
+                if (-not $relative -or -not $entry.Name) { continue }
+
+                $target = Join-Path $components $relative
+                $dir = Split-Path $target -Parent
+                if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)
+                $count++
+            }
+        }
+        finally {
+            $zip.Dispose()
+        }
+
+        if (-not (Test-Path (Join-Path $components 'NFProjectSystem.props'))) {
+            throw "nanoFramework MSBuild components not found under '$prefix'. The VSIX layout changed."
+        }
+
+        Write-Host "Extracted $count component files."
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,76 +41,13 @@ jobs:
 
       - uses: nuget/setup-nuget@v2
 
-      # Every .nfproj resolves its build targets through
-      # $(NanoFrameworkProjectSystemPath), which it sets *itself* to
-      # $(MSBuildExtensionsPath)\nanoFramework\v1.0\ -- a path that only exists where the
-      # Visual Studio extension is installed. No hosted runner has one.
-      #
-      # The components ship inside that extension's VSIX (27 files, ~1.2 MB) and a VSIX is
-      # a zip, so they are extracted into exactly that location. Installing them where the
-      # projects already look, rather than redirecting the projects, means every script in
-      # scripts\ works unmodified -- Run-Tests.ps1 runs its own msbuild, and a global
-      # property passed here would not reach it.
-      #
-      # An earlier attempt exported the path via GITHUB_ENV instead. That silently does
-      # nothing: the project-level assignment on line 4 of each .nfproj overrides an
-      # environment variable, so the imports stayed unresolved and every project reported
-      # MSB4057 "The target Build does not exist".
-      #
-      # nanoFramework's own repositories solve this with the InstallNanoMSBuildComponents
-      # Azure DevOps task, which has no GitHub Actions equivalent; this is that task's job
-      # done by hand.
-      - name: Install nanoFramework MSBuild components
-        shell: powershell
-        run: |
-          $ErrorActionPreference = 'Stop'
-          gh release download --repo nanoframework/nf-Visual-Studio-extension `
-                              --pattern '*.vsix' --dir "$env:RUNNER_TEMP" --clobber
-          $vsix = Get-ChildItem "$env:RUNNER_TEMP\*.vsix" | Select-Object -First 1
-          Write-Host "Using $($vsix.Name)"
-
-          # MSBuildExtensionsPath is the MSBuild folder of the VS install, i.e. the
-          # grandparent of MSBuild.exe (which sits in MSBuild\Current\Bin).
-          $msbuildExe = (Get-Command msbuild).Source
-          $extensions = Split-Path (Split-Path $msbuildExe -Parent) -Parent | Split-Path -Parent
-          $components = Join-Path $extensions 'nanoFramework\v1.0'
-          Write-Host "Installing components into $components"
-          if (-not (Test-Path $components)) { New-Item -ItemType Directory -Path $components -Force | Out-Null }
-
-          # Entry-by-entry via ZipFile rather than Expand-Archive. Expand-Archive fails
-          # outright on this VSIX (verified locally), and we only want 27 of its 96
-          # entries anyway. Inside the archive they live under a literal '$MSBuild'
-          # folder, and the Rules subfolder must keep its structure.
-
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          $zip = [System.IO.Compression.ZipFile]::OpenRead($vsix.FullName)
-          $prefix = '$MSBuild/nanoFramework/v1.0/'
-          $count = 0
-          try {
-              foreach ($entry in $zip.Entries) {
-                  if (-not $entry.FullName.StartsWith($prefix)) { continue }
-                  $relative = $entry.FullName.Substring($prefix.Length)
-                  if (-not $relative -or -not $entry.Name) { continue }
-
-                  $target = Join-Path $components $relative
-                  $dir = Split-Path $target -Parent
-                  if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-
-                  [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)
-                  $count++
-              }
-          }
-          finally {
-              $zip.Dispose()
-          }
-
-          if (-not (Test-Path (Join-Path $components 'NFProjectSystem.props'))) {
-              throw "nanoFramework MSBuild components not found under '$prefix'. The VSIX layout changed."
-          }
-
-          Write-Host "Extracted $count component files."
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # Extracted into a composite action: the release workflow needs the identical
+      # setup, and the reasoning behind it is long enough that a second copy would
+      # drift. See .github/actions/setup-nanoframework/action.yml.
+      - name: Set up nanoFramework build components
+        uses: ./.github/actions/setup-nanoframework
+        with:
+          github-token: ${{ github.token }}
 
       # msbuild /t:Restore is a no-op for this project style -- see
       # scripts\Restore-Packages.ps1 for the same note.
@@ -122,9 +59,9 @@ jobs:
 
       # The virtual device: the same CLR, run on the host. This is what lets the 34 unit
       # tests run without a board.
-      # Pinned, and install-or-update rather than plain install.
       #
-      # Pinned because an unpinned CLR means the runtime under the tests can change with
+      # Pinned, and install-or-update rather than plain install. Pinned because an
+      # unpinned CLR means the runtime under the tests can change with
       # no commit in this repository -- green today, red tomorrow, nothing to bisect.
       # Bump this deliberately, like any other dependency.
       #

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,6 +13,16 @@ jobs:
   conventional-title:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    # Dependabot's titles are machine-generated and already consistent -- but it always
+    # capitalises the verb ("ci: Bump the actions group with 5 updates"), which the
+    # lower-case subject rule below rejects. Its titles cannot be reconfigured, so without
+    # this every Dependabot pull request would carry a permanent red X that nobody can
+    # clear. Relaxing the rule for everyone to accommodate a bot would be the wrong way
+    # round; skipping the bot is not.
+    #
+    # Safe to skip rather than fail: this check is advisory. The ruleset on main requires
+    # only "Build and unit test", so a skipped job blocks nothing.
+    if: github.actor != 'dependabot[bot]'
     steps:
       # Titles only, not individual commits. Merging produces one merge commit named
       # after the PR, so a changelog can be assembled from titles while commit bodies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+# Manual and on demand, per CONTRIBUTING.md. Tag when a set of changes is worth calling a
+# version; nothing fires on an ordinary merge.
+#
+# Tag a commit that already passed CI. This workflow does not re-run the unit tests: the
+# tag should point at something main has already verified, and a release that quietly
+# tests different code than the tag names would be worse than one that tests none.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Build and stamp, but publish nothing.
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: powershell
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # MinVer reads tags and counts commits, so it needs the whole history. With the
+          # default shallow clone it silently reports 0.0.0-alpha.0.N for every release.
+          fetch-depth: 0
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - uses: nuget/setup-nuget@v2
+
+      - name: Set up nanoFramework build components
+        uses: ./.github/actions/setup-nanoframework
+        with:
+          github-token: ${{ github.token }}
+
+      # minver-cli, not the MinVer NuGet package. The package works by setting the MSBuild
+      # $(Version) property, which SDK-style projects turn into assembly attributes and
+      # classic .nfproj projects ignore entirely -- so it would integrate with nothing
+      # here. The CLI just reads the tags and prints a version, which is all we need.
+      - name: Install minver-cli
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = '7.0.0'
+          if (dotnet tool list -g | Select-String -Pattern '^\s*minver-cli\s+') {
+              dotnet tool update -g minver-cli --version $version
+          }
+          else {
+              dotnet tool install -g minver-cli --version $version
+          }
+          if ($LASTEXITCODE -ne 0) { throw "Could not install minver-cli $version." }
+
+      - name: Determine version
+        id: version
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = (minver -t v -v e | Select-Object -Last 1).Trim()
+          if (-not $version) { throw "MinVer produced no version." }
+          Write-Host "Version: $version"
+          "version=$version" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      # .nfproj takes its version from a checked-in AssemblyInfo.cs, so MinVer's number
+      # has to be written in before the build. Not committed -- this is the runner's
+      # working tree only.
+      - name: Stamp assembly versions
+        run: .\scripts\Set-AssemblyVersion.ps1 -Version '${{ steps.version.outputs.version }}'
+
+      - name: Restore packages.config dependencies
+        run: nuget restore SmartHome.sln
+
+      # /t:Rebuild, not /t:Build. A plain incremental build silently drops the deployment
+      # .bin -- the same reason Deploy-ToDevice.ps1 always rebuilds. Without this the
+      # release would publish no artifacts and look successful doing it.
+      #
+      # Release rather than Debug: Debug.WriteLine is [Conditional("DEBUG")], so release
+      # images produce no managed debug output and Watch-DeviceDebugOutput.ps1 will show
+      # little for them. That is the correct trade for a published artifact, but it is
+      # worth knowing before flashing one to diagnose something.
+      - name: Build release images
+        run: msbuild SmartHome.sln /t:Rebuild /p:Configuration=Release /v:minimal /nologo /nodeReuse:false
+
+      - name: Collect device images
+        id: collect
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $staging = Join-Path $env:RUNNER_TEMP 'release'
+          New-Item -ItemType Directory -Path $staging -Force | Out-Null
+
+          # Only src\devices -- the applications that actually get flashed. Integration
+          # tests and libraries are not deliverables.
+          $images = @(Get-ChildItem -Path 'src\devices' -Recurse -Filter '*.bin' -File |
+                      Where-Object { $_.FullName -like '*\bin\Release\*' -and $_.Name -notlike '*.padded.bin' })
+
+          if ($images.Count -eq 0) {
+              throw "No device images found. Did the Rebuild produce .bin files?"
+          }
+
+          foreach ($image in $images) {
+              Copy-Item $image.FullName (Join-Path $staging $image.Name)
+              Write-Host ("  {0}  {1:N0} bytes" -f $image.Name, $image.Length)
+          }
+
+          "staging=$staging" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Collected $($images.Count) image(s)."
+
+      - name: Upload images as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-images-${{ steps.version.outputs.version }}
+          path: ${{ steps.collect.outputs.staging }}
+
+      # Only for a real tag, and never for a dry run. The release notes are deliberately
+      # not generated: CHANGELOG.md is written by hand, because a generated list says what
+      # changed and the interesting part is why.
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/v') && inputs.dry-run != true
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $tag = '${{ github.ref_name }}'
+          $files = (Get-ChildItem '${{ steps.collect.outputs.staging }}' -File | ForEach-Object { $_.FullName })
+
+          gh release create $tag $files `
+              --title $tag `
+              --notes "Device images built from $tag. See CHANGELOG.md for what changed and why."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
 permissions:
   contents: write
 
+# Never cancel a release mid-flight: a half-published release is worse than a queued one.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build and publish
@@ -34,6 +39,25 @@ jobs:
           # MinVer reads tags and counts commits, so it needs the whole history. With the
           # default shallow clone it silently reports 0.0.0-alpha.0.N for every release.
           fetch-depth: 0
+
+      # CONTRIBUTING.md says to tag a commit that already passed CI. Said, but not
+      # enforced -- and the point of the ruleset on main was to stop relying on
+      # convention. A tag can be pushed at any commit, including one that never saw CI or
+      # never reached main, and the release would publish from it looking entirely
+      # official.
+      #
+      # Being an ancestor of main is the check that matters: everything on main passed the
+      # required check to get there.
+      - name: Verify the tag is on main
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          $ErrorActionPreference = 'Stop'
+          git fetch origin main:refs/remotes/origin/main --quiet
+          git merge-base --is-ancestor HEAD refs/remotes/origin/main
+          if ($LASTEXITCODE -ne 0) {
+              throw "Tag ${{ github.ref_name }} points at a commit that is not on main. Releases are cut from main, which is the only branch whose commits have passed the required checks."
+          }
+          Write-Host "Tag ${{ github.ref_name }} is on main."
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -97,13 +121,29 @@ jobs:
           $staging = Join-Path $env:RUNNER_TEMP 'release'
           New-Item -ItemType Directory -Path $staging -Force | Out-Null
 
-          # Only src\devices -- the applications that actually get flashed. Integration
-          # tests and libraries are not deliverables.
-          $images = @(Get-ChildItem -Path 'src\devices' -Recurse -Filter '*.bin' -File |
-                      Where-Object { $_.FullName -like '*\bin\Release\*' -and $_.Name -notlike '*.padded.bin' })
+          # An explicit list, not everything under src\devices. IrrigationControl and
+          # OvenControl build cleanly and produce ~32KB images that do nothing at all --
+          # they are stubs (#11, #12). Globbing the folder would attach them to the
+          # release, where "SmartHome.Devices.OvenControl.bin" under a version tag reads
+          # as a working oven controller. Flashing one replaces whatever was on the board
+          # with an app that idles.
+          #
+          # Adding a device here is therefore a deliberate act, taken when it does
+          # something. The guard below makes the opposite drift loud: if a listed project
+          # stops producing an image, the release fails rather than quietly shipping less
+          # than it says.
+          $shippable = @('SmartHome.Devices.RoomSensor')
 
-          if ($images.Count -eq 0) {
-              throw "No device images found. Did the Rebuild produce .bin files?"
+          $images = @()
+          foreach ($name in $shippable) {
+              $found = @(Get-ChildItem -Path 'src\devices' -Recurse -Filter "$name.bin" -File |
+                         Where-Object { $_.FullName -like '*\bin\Release\*' })
+
+              if ($found.Count -eq 0) {
+                  throw "No Release image for '$name'. Expected src\devices\*\bin\Release\$name.bin -- did the Rebuild produce it?"
+              }
+
+              $images += $found[0]
           }
 
           foreach ($image in $images) {
@@ -123,8 +163,15 @@ jobs:
       # Only for a real tag, and never for a dry run. The release notes are deliberately
       # not generated: CHANGELOG.md is written by hand, because a generated list says what
       # changed and the interesting part is why.
+      # Spelled out rather than relying on `inputs.dry-run != true`. On a tag push the
+      # inputs context does not exist, so that expression depended on an empty value
+      # coercing to not-true -- correct today, and exactly the kind of subtlety that
+      # silently inverts. A push of a v-tag publishes; a manual run publishes only when
+      # dry-run was explicitly unticked.
       - name: Publish GitHub release
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.dry-run != true
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') &&
+          (github.event_name == 'push' || inputs.dry-run == false)
         run: |
           $ErrorActionPreference = 'Stop'
           $tag = '${{ github.ref_name }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+Written by hand, on purpose. A generated changelog lists what changed; the useful part is
+usually *why*, and which failure it was written against. That does not come out of commit
+subjects.
+
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions
+are cut manually — see the Releases section of [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Unreleased
+
+Nothing released yet. The entries below describe what exists on `main` today, so the first
+tagged version has something to say for itself.
+
+### Devices
+
+- **RoomSensor** publishes real BMP280 temperature, humidity and pressure over Homie v4
+  every 5 seconds, declares `$unit` for all three, and moves to `alert` when a reading is
+  invalid. It survives a transient I2C or publish fault instead of rebooting.
+- **IrrigationControl** and **OvenControl** are stubs. See
+  [#11](https://github.com/JojoEffect/SmartHome/issues/11) and
+  [#12](https://github.com/JojoEffect/SmartHome/issues/12) — both blocked on what is
+  physically wired to the board.
+
+### Libraries
+
+- **`SmartHome.Homie`** implements the Homie v4 convention: a device model built with
+  `HomieDeviceBuilder`, and an `IHomieClient` with `Connect`/`ConnectWithRetry`,
+  `Disconnect`, `Alert`, `Sleep`, `Ready` and an `OnCommand` event that distinguishes a
+  controller's `/set` from the device's own update.
+
+  The client owns its MQTT session, because Homie requires the connection to carry a last
+  will and a will can only be declared in CONNECT. It re-announces after a reconnect —
+  Homie state lives in the broker's retained store, and a restarted broker has an empty
+  one — returning to `alert` or `sleeping` if that is where the device was, rather than
+  silently clearing an alert.
+
+- **`SmartHome.Mqtt`** provides `ReconnectingMqttClient`: auto-reconnect and subscription
+  replay over `nanoFramework.M2Mqtt`, knowing nothing about Homie.
+
+### Testing
+
+- 34 unit tests, runnable on hardware or on the nanoclr virtual device.
+- Five on-device integration checks with a single entry point, covering WiFi, an MQTT
+  round trip, the BMP280, broker-outage recovery *including subscription replay*, and a
+  device-agnostic Homie v4 conformance check.
+
+### Tooling
+
+- One script per workflow under `scripts/`, each with a matching project skill.
+- CI builds all 14 projects and runs the unit tests on the virtual device for every pull
+  request.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
 | `scripts\Watch-DeviceDebugOutput.ps1 [-DurationSeconds <n>] [-NoReboot] [-NoBuild] [-BuildOnly] [-Until <regex>] [-DumpConfig]` | Real managed-code debug output (`Debug.WriteLine`, exceptions) via `tools\DeviceDebugMonitor` — no VS needed, same library VS's debugger extension uses | Resets only | `smarthome-watch-debug-output` |
+| `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into all 14 `Properties\AssemblyInfo.cs`. `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
 | `scripts\Common.ps1` | Shared helpers (env loading, MSBuild/vstest/adapter discovery, repo-sync, dev-env state) — dot-source, don't duplicate its logic | No | — |
 
 `Start-DevEnv.ps1` is the session bootstrap: it absorbed the old `Start-AgentWorkspace.ps1`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,24 +99,39 @@ picked up cold.
 
 ## Releases
 
-> **Not implemented yet.** None of the tooling below exists — tagging today produces a
-> git tag and nothing else. Tracked in
-> [#24](https://github.com/JojoEffect/SmartHome/issues/24). This section records the
-> agreed design so the issue does not have to re-derive it.
-
-The intent: manual and on demand. Tag when a set of changes is worth calling a version.
+Manual and on demand. Tag when a set of changes is worth calling a version:
 
 ```bash
 git tag v1.2.0 && git push origin v1.2.0
 ```
 
-MinVer will derive the version from the tag. Assemblies need an explicit stamping step:
-`.nfproj` is a classic project and takes its version from a checked-in
-`Properties/AssemblyInfo.cs` — all 14 are hardcoded to `1.0.0.0` — so MinVer's
-`$(Version)` reaches nothing on its own. The release build will rewrite those before
-compiling the artifacts, and attach each device's deployment `.bin`.
+**Tag a commit that already passed CI.** The release workflow does not re-run the unit
+tests: a release that quietly tests different code than the tag names would be worse than
+one that tests none.
 
-The changelog is written by hand — a generated one would list what changed, and the
+What then happens, in `.github/workflows/release.yml`:
+
+1. `minver-cli` derives the version from the tag. (The MinVer *NuGet package* is not used
+   — it works by setting the MSBuild `$(Version)` property, which SDK-style projects turn
+   into assembly attributes and classic `.nfproj` projects ignore entirely.)
+2. `scripts\Set-AssemblyVersion.ps1` writes that version into all 14
+   `Properties/AssemblyInfo.cs` files. `.nfproj` has no generated assembly info, so
+   without this step every assembly would ship claiming `1.0.0.0`. Nothing is committed —
+   this happens in the runner's working tree.
+3. The solution is rebuilt in `Release` and each device's deployment `.bin` is attached to
+   the release.
+
+Two things worth knowing before flashing a release image:
+
+- It is a **`Release`** build, so `Debug.WriteLine` is compiled out and
+  `Watch-DeviceDebugOutput.ps1` will show almost nothing. Build locally in `Debug` when
+  diagnosing.
+- The build uses `/t:Rebuild`, not `/t:Build`, because a plain incremental build silently
+  drops the deployment `.bin` — the same reason `Deploy-ToDevice.ps1` always rebuilds.
+
+Use `workflow_dispatch` with `dry-run` to exercise the whole thing without publishing.
+
+`CHANGELOG.md` is written by hand — a generated one would list what changed, and the
 interesting part is why.
 
 ## Local setup

--- a/scripts/Set-AssemblyVersion.ps1
+++ b/scripts/Set-AssemblyVersion.ps1
@@ -65,7 +65,8 @@ $parts = @($numeric -split '\.')
 while ($parts.Count -lt 4) { $parts += '0' }
 $assemblyVersion = $parts -join '.'
 
-Write-Host ("Stamping {0}  (from '{1}')" -f $assemblyVersion, $Version) -ForegroundColor Cyan
+$verb = if ($Check) { 'Checking for' } else { 'Stamping' }
+Write-Host ("{0} {1}  (from '{2}')" -f $verb, $assemblyVersion, $Version) -ForegroundColor Cyan
 
 $files = @(Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter 'AssemblyInfo.cs' -File)
 if ($files.Count -eq 0) {

--- a/scripts/Set-AssemblyVersion.ps1
+++ b/scripts/Set-AssemblyVersion.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Stamps a version into every Properties\AssemblyInfo.cs in the solution.
+
+.DESCRIPTION
+    .nfproj is a classic MSBuild project: it has no auto-generated assembly info, so it
+    takes its version from a checked-in AssemblyInfo.cs. All 14 in this repository are
+    hardcoded to 1.0.0.0. That is why MinVer alone is not enough here -- MinVer sets the
+    MSBuild $(Version) property, which SDK-style projects turn into assembly attributes
+    and classic ones ignore entirely.
+
+    So the release build calls this first, with the version MinVer derived from the tag.
+
+    Only AssemblyVersion and AssemblyFileVersion are touched. Two things are deliberately
+    left alone:
+
+      - AssemblyNativeVersion. That is a nanoFramework attribute tracking the *native*
+        assembly signature, and its own comment says to change it only when that
+        signature changes. It has nothing to do with the release version.
+      - The commented-out '// [assembly: AssemblyVersion("1.0.*")]' sample line, which a
+        loose regex would happily rewrite into nonsense.
+
+.PARAMETER Version
+    The version to stamp. Accepts full semver (1.2.0-alpha.0.5) as produced by MinVer;
+    the prerelease and build-metadata parts are dropped for the assembly attributes,
+    which only accept four numeric components.
+
+.PARAMETER Check
+    Report what would change and exit non-zero if anything would, without writing. Use
+    to assert a clean tree, not to stamp.
+
+.EXAMPLE
+    .\scripts\Set-AssemblyVersion.ps1 -Version 1.2.0
+
+.EXAMPLE
+    .\scripts\Set-AssemblyVersion.ps1 -Version (minver -t v)
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [switch]$Check
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+$repoRoot = Get-SmartHomeRepoRoot
+
+# Assembly attributes take four numeric components and nothing else, so 1.2.0-alpha.0.5
+# has to become 1.2.0.0. The full string is still what names the release and its
+# artifacts; it is only these two attributes that cannot carry it.
+$numeric = ($Version -split '[-+]')[0]
+
+if ($numeric -notmatch '^\d+(\.\d+){0,3}$') {
+    Write-Error "Cannot derive an assembly version from '$Version': '$numeric' is not a numeric version."
+    exit 1
+}
+
+$parts = @($numeric -split '\.')
+while ($parts.Count -lt 4) { $parts += '0' }
+$assemblyVersion = $parts -join '.'
+
+Write-Host ("Stamping {0}  (from '{1}')" -f $assemblyVersion, $Version) -ForegroundColor Cyan
+
+$files = @(Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter 'AssemblyInfo.cs' -File)
+if ($files.Count -eq 0) {
+    Write-Error "No AssemblyInfo.cs found under src. Has the layout changed?"
+    exit 1
+}
+
+# Anchored at the start of the line so the commented-out sample is not matched, and
+# spelled out in full so AssemblyNativeVersion cannot be caught by accident.
+$patterns = @(
+    @{ Name = 'AssemblyVersion';     Regex = '(?m)^\[assembly:\s*AssemblyVersion\("[^"]*"\)\]' },
+    @{ Name = 'AssemblyFileVersion'; Regex = '(?m)^\[assembly:\s*AssemblyFileVersion\("[^"]*"\)\]' }
+)
+
+$changed = @()
+
+foreach ($file in $files) {
+    # ReadAllText, not Get-Content -Raw. On Windows PowerShell 5.1, Get-Content reads a
+    # file without a BOM as Windows-1252, so the UTF-8 bytes C2 A9 for the (c) in the
+    # copyright line come back as two characters, and writing them out as UTF-8 again
+    # produces C3 82 C2 A9 -- a mojibake "Ac" that silently corrupts 13 of the 14
+    # assemblies. ReadAllText decodes as UTF-8 and strips a BOM if present.
+    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+    $hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+
+    $original = [System.IO.File]::ReadAllText($file.FullName)
+    $updated = $original
+
+    foreach ($pattern in $patterns) {
+        $replacement = '[assembly: {0}("{1}")]' -f $pattern.Name, $assemblyVersion
+        $updated = [regex]::Replace($updated, $pattern.Regex, $replacement)
+
+        if ($updated -notmatch [regex]::Escape($replacement)) {
+            Write-Error ("{0}: no {1} attribute to stamp. Every AssemblyInfo.cs in this repo is expected to carry one." -f $file.FullName, $pattern.Name)
+            exit 1
+        }
+    }
+
+    if ($updated -ne $original) {
+        $relative = $file.FullName.Substring($repoRoot.Length).TrimStart('\')
+        $changed += $relative
+
+        if (-not $Check) {
+            # Written back with whatever BOM the file already had, so stamping changes the
+            # two attribute lines and nothing else. (Set-Content -Encoding utf8 would add
+            # a BOM unconditionally on 5.1, which is its own spurious diff.)
+            [System.IO.File]::WriteAllText($file.FullName, $updated, (New-Object System.Text.UTF8Encoding $hasBom))
+        }
+    }
+}
+
+if ($Check) {
+    if ($changed.Count -gt 0) {
+        Write-Error ("{0} file(s) would change:`n  {1}" -f $changed.Count, ($changed -join "`n  "))
+        exit 1
+    }
+
+    Write-Host ("All {0} assemblies already at {1}." -f $files.Count, $assemblyVersion) -ForegroundColor Green
+    exit 0
+}
+
+if ($changed.Count -eq 0) {
+    Write-Host ("All {0} assemblies were already at {1}; nothing to do." -f $files.Count, $assemblyVersion) -ForegroundColor Green
+}
+else {
+    Write-Host ("Stamped {0} of {1} assemblies:" -f $changed.Count, $files.Count) -ForegroundColor Green
+    $changed | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+}
+
+# Explicit success code -- see the note in Sync-NanoFrameworkRepos.ps1.
+exit 0


### PR DESCRIPTION
## Summary

Tag a commit, get a GitHub release with each device's deployment `.bin` attached. Closes #24.

Nothing fires on an ordinary merge. The workflow deliberately does **not** re-run the unit tests — the tag should point at a commit `main` already verified, and a release that quietly tests different code than the tag names would be worse than one that tests none.

## Two things resolved before writing it

**MinVer's NuGet package is the wrong tool here.** It sets the MSBuild `$(Version)` property, which SDK-style projects turn into assembly attributes and classic `.nfproj` projects ignore entirely — it would integrate with nothing. `minver-cli` is used instead: reads the tags, prints a version, no project integration. Verified working here, including the no-tags case (`0.0.0-alpha.0.5`).

**That leaves the assemblies.** All 14 take their version from a checked-in `AssemblyInfo.cs` hardcoded to `1.0.0.0`, so without a stamping step every published binary would claim `1.0.0.0` regardless of the tag. `scripts/Set-AssemblyVersion.ps1` writes it in before the release build — in the runner's working tree only, nothing committed.

## A real bug, found by testing rather than reading

The first version of the stamping script read files with `Get-Content -Raw`. On Windows PowerShell 5.1 that decodes a BOM-less file as **Windows-1252**, so the UTF-8 bytes behind the `©` in the copyright line came back as two characters and were re-encoded as UTF-8:

```
-[assembly: AssemblyCopyright("Copyright M-BM-)  2025")]      # C2 A9        = ©
+[assembly: AssemblyCopyright("Copyright M-CM-^BM-BM-)  2025")]  # C3 82 C2 A9 = Â©
```

Mojibake in **13 of the 14 assemblies** — every file except the one with no non-ASCII text. It only surfaced because the per-file diff showed 3 changed lines where 2 were expected. Now reads with `ReadAllText` and preserves the original BOM state.

The script also deliberately leaves alone two things a looser regex would have eaten: `AssemblyNativeVersion` (tracks the *native* assembly signature, unrelated to the release version) and the commented-out `// [assembly: AssemblyVersion("1.0.*")]` sample line.

## Also

- The nanoFramework component setup is now a **composite action** used by both workflows — the release job needs identical setup, and the reasoning is long enough that a second copy would drift.
- Release builds use `/t:Rebuild`, not `/t:Build`: a plain incremental build silently drops the deployment `.bin`, the same reason `Deploy-ToDevice.ps1` always rebuilds. Without it a release would publish no artifacts and look successful doing it.
- They are `Release` builds, so `Debug.WriteLine` is compiled out and `Watch-DeviceDebugOutput.ps1` shows almost nothing for a release image. Correct for a published artifact, worth knowing before flashing one to diagnose something — stated in `CONTRIBUTING.md` and the new `smarthome-release` skill.
- `CHANGELOG.md` is new and hand-written, seeded with what exists on `main` today.

## Testing Done

- `Set-AssemblyVersion.ps1` with full semver `1.2.0-alpha.0.5` → stamps `1.2.0.0`; **2+/2− across all 14 files**, copyright intact, `AssemblyNativeVersion` and the commented sample untouched.
- Stamped tree rebuilds: **14/14 projects**.
- `Release` configuration builds and produces a `.bin` (256,508 bytes vs Debug's 258,460, consistent with `Debug.WriteLine` compiled out).
- `minver -t v -v e` verified to emit the bare version, exit 0.
- All YAML parses; all scripts parse.
- No hardware run — this PR changes no device code.

## Known limitation

**The release workflow has never run.** Use `workflow_dispatch` with `dry-run` (the default) after merge to exercise it without publishing. CI on this PR does exercise the composite action, which is the part shared with the pipeline that already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)