### PR TITLE
fix(tests): require the retain flag, and stop paying an IPv6 timeout

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -333,7 +333,18 @@ function Get-SmartHomeSubscriberArguments {
     # ("All messages MUST be sent as retained, UNLESS stated otherwise") and only the
     # broker can confirm it, but -v prints topic and payload only. Lines become
     # "<topic> <0|1> <payload>", which readers still match by topic prefix.
-    return @('-h', 'localhost', '-p', $Port, '-t', $SmartHomeHomieTopic, '-F', '%t %r %p')
+    # 127.0.0.1, not 'localhost'. Measured, not guessed: 'localhost' resolves to ::1
+    # first, and Start-DevEnv.ps1 binds the broker to 0.0.0.0 -- IPv4 only, deliberately,
+    # so a real device on the LAN can reach it. Every client therefore attempts IPv6,
+    # waits out the connect timeout, and only then falls back.
+    #
+    #   mosquitto_sub -h localhost   first message after 2.03s, 2.03s, 2.06s
+    #   mosquitto_sub -h 127.0.0.1   first message after 0.02s, 0.02s, 0.12s
+    #
+    # Two seconds on every subscriber and every publish. The integration suite takes
+    # about a dozen retained-store snapshots per conformance run, so this alone was
+    # roughly half that test's duration.
+    return @('-h', '127.0.0.1', '-p', $Port, '-t', $SmartHomeHomieTopic, '-F', '%t %r %p')
 }
 
 # ── Dev environment: state ────────────────────────────────────────────────────

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -298,6 +298,25 @@ function Invoke-GitCloneOrUpdate {
 $SmartHomeDevEnvPrefix = 'smarthome'
 $SmartHomeHomieTopic = 'homie/#'
 
+# The address host-side mosquitto clients dial. 127.0.0.1, not 'localhost'. Measured, not
+# guessed: 'localhost' resolves to ::1 first, and Start-DevEnv.ps1 binds the broker to
+# 0.0.0.0 -- IPv4 only, deliberately, so a real device on the LAN can reach it. Every
+# client therefore attempts IPv6, waits out the connect timeout, and only then falls back.
+#
+#   mosquitto_sub -h localhost   first message after 2.03s, 2.03s, 2.06s
+#   mosquitto_sub -h 127.0.0.1   first message after 0.02s, 0.02s, 0.12s
+#
+# Two seconds on every subscriber and every publish, and worse than slow: a 2s snapshot
+# window used to be spent almost entirely connecting, so it captured nearly nothing and
+# the polling loops only hid that by retrying.
+#
+# Deliberately NOT the SMARTHOME_MQTT_BROKER setting, and not configurable. That variable
+# is the address the *device* dials to reach this machine (192.168.1.238 here); pointing
+# host-side clients at it would send them out over the LAN to reach a broker on the same
+# box, and break the moment the DHCP lease changes. The port is genuinely shared -- both
+# sides must agree on it -- the host is not.
+$SmartHomeLocalBrokerHost = '127.0.0.1'
+
 function Get-SmartHomeDevEnvPath {
     param(
         [Parameter(Mandatory = $true)]
@@ -333,18 +352,10 @@ function Get-SmartHomeSubscriberArguments {
     # ("All messages MUST be sent as retained, UNLESS stated otherwise") and only the
     # broker can confirm it, but -v prints topic and payload only. Lines become
     # "<topic> <0|1> <payload>", which readers still match by topic prefix.
-    # 127.0.0.1, not 'localhost'. Measured, not guessed: 'localhost' resolves to ::1
-    # first, and Start-DevEnv.ps1 binds the broker to 0.0.0.0 -- IPv4 only, deliberately,
-    # so a real device on the LAN can reach it. Every client therefore attempts IPv6,
-    # waits out the connect timeout, and only then falls back.
     #
-    #   mosquitto_sub -h localhost   first message after 2.03s, 2.03s, 2.06s
-    #   mosquitto_sub -h 127.0.0.1   first message after 0.02s, 0.02s, 0.12s
-    #
-    # Two seconds on every subscriber and every publish. The integration suite takes
-    # about a dozen retained-store snapshots per conformance run, so this alone was
-    # roughly half that test's duration.
-    return @('-h', '127.0.0.1', '-p', $Port, '-t', $SmartHomeHomieTopic, '-F', '%t %r %p')
+    # Host from $SmartHomeLocalBrokerHost, which carries the reasoning for why it is not
+    # 'localhost'.
+    return @('-h', $SmartHomeLocalBrokerHost, '-p', $Port, '-t', $SmartHomeHomieTopic, '-F', '%t %r %p')
 }
 
 # ── Dev environment: state ────────────────────────────────────────────────────

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -488,8 +488,16 @@ function Get-HomieRetainedSnapshot {
     # for the handle-inheritance reason documented in Start-DevEnv.ps1.
     param(
         [string]$Port,
+
+        # Ceiling, not a fixed wait. See the polling note below.
         [int]$SettleSeconds = 3
     )
+
+    # How long the output has to stay unchanged before the replay is considered finished.
+    # The store arrives as one contiguous burst on localhost, so a quarter of a second of
+    # silence after the last line is a comfortable margin -- the gap between lines within
+    # a burst is sub-millisecond.
+    $quietMilliseconds = 250
 
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
     Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
@@ -506,7 +514,39 @@ function Get-HomieRetainedSnapshot {
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
-    Start-Sleep -Seconds $SettleSeconds
+    # Wait for the replay to finish, rather than waiting out a fixed window. The broker
+    # sends its whole retained store within milliseconds of SUBACK on localhost, so the
+    # flat Start-Sleep this replaces was almost entirely idle -- and it was paid on every
+    # poll iteration of Wait-ForRetainedValue, which is what made HomieClientCheck the
+    # slowest test in the suite.
+    #
+    # Stop once the file has been quiet for $quietMilliseconds, with $SettleSeconds as the
+    # ceiling. An empty store still costs the full ceiling, unavoidably: "nothing is
+    # retained" and "nothing has arrived yet" look identical from here, and returning
+    # early on the second would report an announcing device as silent.
+    $deadline = (Get-Date).AddSeconds($SettleSeconds)
+    $lastSize = -1
+    $lastChange = Get-Date
+
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 50
+
+        $size = 0
+        if (Test-Path $out) {
+            $size = (Get-Item $out).Length
+        }
+
+        if ($size -ne $lastSize) {
+            $lastSize = $size
+            $lastChange = Get-Date
+            continue
+        }
+
+        if ($size -gt 0 -and ((Get-Date) - $lastChange).TotalMilliseconds -ge $quietMilliseconds) {
+            break
+        }
+    }
+
     Stop-SmartHomeProcessTree -ProcessId $process.Id
 
     $snapshot = @{}
@@ -534,7 +574,10 @@ function Publish-HomieCommand {
     # Non-retained, as the convention requires of a controller: "A Homie controller
     # publishes to the set command topic with non-retained messages only."
     $pub = Get-MosquittoTool -Name 'mosquitto_pub.exe'
-    & $pub -h 'localhost' -p $Port -t $Topic -m $Payload | Out-Null
+    # 127.0.0.1 for the same reason as Get-SmartHomeSubscriberArguments: 'localhost'
+    # costs a two-second IPv6 connect timeout against an IPv4-only broker, and
+    # Wait-ForEcho republishes on every poll round.
+    & $pub -h '127.0.0.1' -p $Port -t $Topic -m $Payload | Out-Null
 }
 
 function Wait-ForRetainedValue {

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -563,14 +563,25 @@ function Publish-HomieCommand {
 }
 
 function Wait-ForRetainedValue {
-    # Polls fresh snapshots until $Topic holds $Expected, or the timeout expires.
+    # Polls fresh snapshots until $Topic is *retained* with $Expected, or the timeout
+    # expires.
     #
-    # Returns the winning snapshot alongside the verdict. It already holds the entire
-    # retained store, and callers used to throw it away and immediately spawn another
-    # 3s subscriber to fetch the same data. Reusing it is sound rather than merely
-    # cheaper: HandleDeviceStateChange publishes the full device info while the device
-    # is in Init and only then transitions out of it, so a snapshot containing
-    # $state=ready necessarily contains everything published before it.
+    # The retain flag is part of the condition, not decoration. A snapshot subscriber
+    # that connects while the device is still announcing receives the rest of that
+    # announce live, and a live delivery carries retain=0 -- MQTT only sets the flag when
+    # replaying from the store. Accepting such a snapshot yields one where two thirds of
+    # the topics look unretained, and the caller then reports a conforming device as
+    # broken.
+    #
+    # This went unnoticed for as long as it did because 'localhost' cost a two-second
+    # IPv6 connect timeout, which reliably delayed the subscriber past the end of the
+    # announce. The check was passing on an accident of timing. Removing that delay
+    # produced 31 spurious "not retained" failures, which is how it came to light.
+    #
+    # Requiring the flag is also what makes returning the snapshot safe. The device
+    # publishes its full device info while in Init and only then transitions out of it,
+    # so $state arrives last; a subscriber that saw $state *replayed* necessarily
+    # connected after everything before it was already in the store.
     param(
         [string]$Port,
         [string]$Topic,
@@ -586,7 +597,7 @@ function Wait-ForRetainedValue {
         $snapshot = Get-HomieRetainedSnapshot -Port $Port
         if ($snapshot.Contains($Topic)) {
             $seen = $snapshot[$Topic].Payload
-            if ($seen -eq $Expected) {
+            if ($seen -eq $Expected -and $snapshot[$Topic].Retained) {
                 return @{ Ok = $true; Seen = $seen; Snapshot = $snapshot }
             }
         }

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -489,15 +489,20 @@ function Get-HomieRetainedSnapshot {
     param(
         [string]$Port,
 
-        # Ceiling, not a fixed wait. See the polling note below.
-        [int]$SettleSeconds = 3
+        # Sized for the replay alone. It used to be 3, because two of those seconds were
+        # spent on an IPv6 connect timeout that no longer happens -- see
+        # Get-SmartHomeSubscriberArguments. With the connect at ~0.02s the whole retained
+        # store lands well inside a second.
+        #
+        # A fixed window on purpose. An earlier version of this ended the wait once the
+        # output had been quiet for 250ms, on the assumption that the replay arrives as
+        # one contiguous burst. It does not: the output is buffered and lands in chunks
+        # with gaps, so the snapshot was cut short mid-replay and every topic that had not
+        # arrived yet was reported as "not retained". The conformance check failed with
+        # seven of those. Guessing at when a stream has finished is not worth the
+        # fragility here; a second of wall clock is.
+        [int]$SettleSeconds = 1
     )
-
-    # How long the output has to stay unchanged before the replay is considered finished.
-    # The store arrives as one contiguous burst on localhost, so a quarter of a second of
-    # silence after the last line is a comfortable margin -- the gap between lines within
-    # a burst is sub-millisecond.
-    $quietMilliseconds = 250
 
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
     Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
@@ -514,39 +519,7 @@ function Get-HomieRetainedSnapshot {
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
-    # Wait for the replay to finish, rather than waiting out a fixed window. The broker
-    # sends its whole retained store within milliseconds of SUBACK on localhost, so the
-    # flat Start-Sleep this replaces was almost entirely idle -- and it was paid on every
-    # poll iteration of Wait-ForRetainedValue, which is what made HomieClientCheck the
-    # slowest test in the suite.
-    #
-    # Stop once the file has been quiet for $quietMilliseconds, with $SettleSeconds as the
-    # ceiling. An empty store still costs the full ceiling, unavoidably: "nothing is
-    # retained" and "nothing has arrived yet" look identical from here, and returning
-    # early on the second would report an announcing device as silent.
-    $deadline = (Get-Date).AddSeconds($SettleSeconds)
-    $lastSize = -1
-    $lastChange = Get-Date
-
-    while ((Get-Date) -lt $deadline) {
-        Start-Sleep -Milliseconds 50
-
-        $size = 0
-        if (Test-Path $out) {
-            $size = (Get-Item $out).Length
-        }
-
-        if ($size -ne $lastSize) {
-            $lastSize = $size
-            $lastChange = Get-Date
-            continue
-        }
-
-        if ($size -gt 0 -and ((Get-Date) - $lastChange).TotalMilliseconds -ge $quietMilliseconds) {
-            break
-        }
-    }
-
+    Start-Sleep -Seconds $SettleSeconds
     Stop-SmartHomeProcessTree -ProcessId $process.Id
 
     $snapshot = @{}
@@ -601,7 +574,7 @@ function Wait-ForRetainedValue {
     $snapshot = @{}
 
     while ((Get-Date) -lt $deadline) {
-        $snapshot = Get-HomieRetainedSnapshot -Port $Port -SettleSeconds 2
+        $snapshot = Get-HomieRetainedSnapshot -Port $Port
         if ($snapshot.Contains($Topic)) {
             $seen = $snapshot[$Topic].Payload
             if ($seen -eq $Expected) {
@@ -753,7 +726,7 @@ function Invoke-HomieConformanceCheck {
     $deadline = (Get-Date).AddSeconds($Settings.CommandTimeoutSeconds)
 
     while ($pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
-        $snapshot = Get-HomieRetainedSnapshot -Port $Port -SettleSeconds 2
+        $snapshot = Get-HomieRetainedSnapshot -Port $Port
         $stillPending = @()
 
         foreach ($property in $pending) {

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -489,19 +489,27 @@ function Get-HomieRetainedSnapshot {
     param(
         [string]$Port,
 
-        # Sized for the replay alone. It used to be 3, because two of those seconds were
-        # spent on an IPv6 connect timeout that no longer happens -- see
-        # Get-SmartHomeSubscriberArguments. With the connect at ~0.02s the whole retained
-        # store lands well inside a second.
+        # Three seconds, and it stays three seconds. Two attempts at shortening it both
+        # broke the conformance check, and the measurements are worth keeping so nobody
+        # repeats them:
         #
-        # A fixed window on purpose. An earlier version of this ended the wait once the
-        # output had been quiet for 250ms, on the assumption that the replay arrives as
-        # one contiguous burst. It does not: the output is buffered and lands in chunks
-        # with gaps, so the snapshot was cut short mid-replay and every topic that had not
-        # arrived yet was reported as "not retained". The conformance check failed with
-        # seven of those. Guessing at when a stream has finished is not worth the
-        # fragility here; a second of wall clock is.
-        [int]$SettleSeconds = 1
+        #   - Ending the wait after 250ms of quiet output: 7 failures. The output is
+        #     buffered and lands in chunks, so "quiet" does not mean "finished".
+        #   - A flat 1s: 3 failures, 54 topics where a healthy run sees ~78.
+        #   - mosquitto_sub -W 1, waiting for it to exit rather than killing it:
+        #     complete, but 6.3s -- slower than what it replaced.
+        #
+        # Against a *static* store a 1s kill captures everything (verified: 80/80 seeded
+        # topics), which is what made the short window look safe in isolation. The real
+        # snapshot runs while the device is mid-announce, so live publishes interleave
+        # with the retained replay and there is simply more to receive. That is the
+        # variable, and it is not one this code can observe.
+        #
+        # What did change: with the IPv6 timeout gone from
+        # Get-SmartHomeSubscriberArguments, these three seconds are now three seconds of
+        # *listening* rather than two seconds of connecting and one of listening. Same
+        # cost, three times the margin.
+        [int]$SettleSeconds = 3
     )
 
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
@@ -516,6 +524,7 @@ function Get-HomieRetainedSnapshot {
     # Quoting idiom matches Start-DevEnv.ps1's subscriber launch.
     $subscriberArgs = (Get-SmartHomeSubscriberArguments -Port $Port |
         ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
+
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -476,6 +476,31 @@ function Get-MosquittoTool {
     return $path
 }
 
+# How long a snapshot subscriber listens. Three seconds, and it stays three seconds --
+# a fixed value rather than a parameter, because there is nothing here for a caller to
+# choose. Two attempts at shortening it both broke the conformance check, and the
+# measurements are worth keeping so nobody repeats them:
+#
+#   - Ending the wait after 250ms of quiet output: 7 failures. The output is buffered and
+#     lands in chunks, so "quiet" does not mean "finished".
+#   - A flat 1s: 3 failures, 54 topics where a healthy run sees ~64.
+#   - mosquitto_sub -W 1, waiting for it to exit rather than killing it: complete, but
+#     6.3s -- slower than what it replaced.
+#
+# Against a *static* store a 1s kill captures everything (verified: 80/80 seeded topics),
+# which is what made the short window look safe in isolation. The real snapshot runs while
+# the device is mid-announce, so live publishes interleave with the retained replay and
+# there is simply more to receive.
+#
+# Wait-ForRetainedValue now detects a mid-announce snapshot by its retain flag and retries,
+# so for that path the window is no longer the only defence. It still is for the callers
+# that read a snapshot without a flag guard -- Test-Attribute and the /set verification --
+# which is why it stays at three.
+#
+# With the IPv6 timeout gone from Get-SmartHomeSubscriberArguments these are three seconds
+# of *listening*, where they used to be two of connecting and one of listening.
+$SnapshotSettleSeconds = 3
+
 function Get-HomieRetainedSnapshot {
     # What a controller joining *now* would see: the broker's retained store.
     #
@@ -486,30 +511,15 @@ function Get-HomieRetainedSnapshot {
     #
     # mosquitto_sub is wrapped in cmd.exe for the redirect and then killed as a tree,
     # for the handle-inheritance reason documented in Start-DevEnv.ps1.
+    #
+    # Both retained and live deliveries come back, flag intact. What the flag *means* is
+    # the caller's decision, and the four callers deliberately differ: Wait-ForRetainedValue
+    # requires it when it hands the snapshot on, Test-Attribute reports it as data, the
+    # $retained=false check needs unretained messages to be present at all, and the /set
+    # verification ignores it because a live echo is equally good evidence the command was
+    # applied. Do not filter here.
     param(
-        [string]$Port,
-
-        # Three seconds, and it stays three seconds. Two attempts at shortening it both
-        # broke the conformance check, and the measurements are worth keeping so nobody
-        # repeats them:
-        #
-        #   - Ending the wait after 250ms of quiet output: 7 failures. The output is
-        #     buffered and lands in chunks, so "quiet" does not mean "finished".
-        #   - A flat 1s: 3 failures, 54 topics where a healthy run sees ~78.
-        #   - mosquitto_sub -W 1, waiting for it to exit rather than killing it:
-        #     complete, but 6.3s -- slower than what it replaced.
-        #
-        # Against a *static* store a 1s kill captures everything (verified: 80/80 seeded
-        # topics), which is what made the short window look safe in isolation. The real
-        # snapshot runs while the device is mid-announce, so live publishes interleave
-        # with the retained replay and there is simply more to receive. That is the
-        # variable, and it is not one this code can observe.
-        #
-        # What did change: with the IPv6 timeout gone from
-        # Get-SmartHomeSubscriberArguments, these three seconds are now three seconds of
-        # *listening* rather than two seconds of connecting and one of listening. Same
-        # cost, three times the margin.
-        [int]$SettleSeconds = 3
+        [string]$Port
     )
 
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
@@ -524,11 +534,10 @@ function Get-HomieRetainedSnapshot {
     # Quoting idiom matches Start-DevEnv.ps1's subscriber launch.
     $subscriberArgs = (Get-SmartHomeSubscriberArguments -Port $Port |
         ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
-
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
-    Start-Sleep -Seconds $SettleSeconds
+    Start-Sleep -Seconds $SnapshotSettleSeconds
     Stop-SmartHomeProcessTree -ProcessId $process.Id
 
     $snapshot = @{}
@@ -556,37 +565,45 @@ function Publish-HomieCommand {
     # Non-retained, as the convention requires of a controller: "A Homie controller
     # publishes to the set command topic with non-retained messages only."
     $pub = Get-MosquittoTool -Name 'mosquitto_pub.exe'
-    # 127.0.0.1 for the same reason as Get-SmartHomeSubscriberArguments: 'localhost'
-    # costs a two-second IPv6 connect timeout against an IPv4-only broker, and
-    # Wait-ForEcho republishes on every poll round.
-    & $pub -h '127.0.0.1' -p $Port -t $Topic -m $Payload | Out-Null
+    # Host from Common.ps1, which owns the reasoning. Not a literal here: the broker
+    # address is shared vocabulary, and a second spelling is one a future change to the
+    # listener binding would miss.
+    & $pub -h $SmartHomeLocalBrokerHost -p $Port -t $Topic -m $Payload | Out-Null
 }
 
 function Wait-ForRetainedValue {
     # Polls fresh snapshots until $Topic is *retained* with $Expected, or the timeout
     # expires.
     #
-    # The retain flag is part of the condition, not decoration. A snapshot subscriber
-    # that connects while the device is still announcing receives the rest of that
-    # announce live, and a live delivery carries retain=0 -- MQTT only sets the flag when
-    # replaying from the store. Accepting such a snapshot yields one where two thirds of
-    # the topics look unretained, and the caller then reports a conforming device as
-    # broken.
+    # By default the retain flag is part of the condition, for the retain=0 reason in
+    # Get-HomieRetainedSnapshot: a subscriber that connects mid-announce receives the rest
+    # of that announce live, and accepting such a snapshot hands the caller one where most
+    # topics look unretained.
     #
-    # This went unnoticed for as long as it did because 'localhost' cost a two-second
-    # IPv6 connect timeout, which reliably delayed the subscriber past the end of the
-    # announce. The check was passing on an accident of timing. Removing that delay
-    # produced 31 spurious "not retained" failures, which is how it came to light.
+    # This went unnoticed for as long as it did because 'localhost' cost a two-second IPv6
+    # connect timeout, which reliably delayed the subscriber past the end of the announce.
+    # The check was passing on an accident of timing; removing that delay produced 31
+    # spurious "not retained" failures, which is how it came to light.
     #
-    # Requiring the flag is also what makes returning the snapshot safe. The device
-    # publishes its full device info while in Init and only then transitions out of it,
-    # so $state arrives last; a subscriber that saw $state *replayed* necessarily
-    # connected after everything before it was already in the store.
+    # It is also what makes returning the snapshot sound. The device publishes its full
+    # device info while in Init and only then transitions out, so $state arrives last: a
+    # subscriber that saw $state *replayed* necessarily connected after everything before
+    # it was already in the store. $state arriving retained is, in effect, the "device has
+    # finished announcing" signal, and this turned it from an assumed invariant into an
+    # enforced one.
     param(
         [string]$Port,
         [string]$Topic,
         [string]$Expected,
-        [int]$TimeoutSeconds
+        [int]$TimeoutSeconds,
+
+        # Turn off when only Ok/Seen are read and the snapshot is discarded. Waiting for a
+        # *replayed* value costs a whole extra 3s snapshot whenever the device happens to
+        # publish it just after the subscriber connected -- a coin flip for a value the
+        # device writes within milliseconds of a command. Nothing is lost by accepting the
+        # live delivery there: the payload is the same, and $state's retained-ness is
+        # already asserted once against the announce snapshot.
+        [bool]$RequireRetained = $true
     )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
@@ -597,7 +614,7 @@ function Wait-ForRetainedValue {
         $snapshot = Get-HomieRetainedSnapshot -Port $Port
         if ($snapshot.Contains($Topic)) {
             $seen = $snapshot[$Topic].Payload
-            if ($seen -eq $Expected -and $snapshot[$Topic].Retained) {
+            if ($seen -eq $Expected -and ((-not $RequireRetained) -or $snapshot[$Topic].Retained)) {
                 return @{ Ok = $true; Seen = $seen; Snapshot = $snapshot }
             }
         }
@@ -738,7 +755,7 @@ function Invoke-HomieConformanceCheck {
     }
 
     # One snapshot per round, not one per property. Every reflection is checked
-    # against the same snapshot, so five properties cost one 2s subscriber instead of
+    # against the same snapshot, so five properties cost one snapshot instead of
     # five -- the snapshot has to be a fresh subscriber (retain flags are only set on
     # replay), which is what makes it expensive.
     $pending = @($commands.Keys)
@@ -756,6 +773,11 @@ function Invoke-HomieConformanceCheck {
             $lastSeen[$property] = $seen
 
             # Every datatype, floats included, must match exactly.
+            #
+            # The retain flag is deliberately not part of this. Unlike the waits above,
+            # what is being proven here is that the device applied the command -- a live
+            # echo is equally good evidence of that, and requiring a replayed copy would
+            # cost an extra snapshot round for nothing.
             if ($seen -eq $expected) {
                 continue
             }
@@ -778,7 +800,11 @@ function Invoke-HomieConformanceCheck {
     # device for a transition the convention's own state machine forbids.
     foreach ($state in 'alert', 'ready', 'sleeping', 'ready') {
         Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $state
-        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $state -TimeoutSeconds $Settings.CommandTimeoutSeconds
+        # -RequireRetained $false: this reads Ok/Seen only and discards the snapshot. The
+        # device writes $state within milliseconds of the command, so insisting on a
+        # replayed copy would spend a second full snapshot re-observing the same value,
+        # four times per run.
+        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $state -TimeoutSeconds $Settings.CommandTimeoutSeconds -RequireRetained $false
         if (-not $reached.Ok) {
             $script:conformanceFailures += "device did not reach `$state='$state' on command (saw '$($reached.Seen)')"
         }

--- a/scripts/Start-DevEnv.ps1
+++ b/scripts/Start-DevEnv.ps1
@@ -244,7 +244,7 @@ if ($Detached) {
 
         Write-Error @"
 The homie/# subscriber exited immediately (exit code $($subscriber.ExitCode)); broker stopped again.
-$(if ($reason) { "Subscriber output:`n$reason" } else { 'It produced no output. Check that mosquitto_sub can reach localhost:' + $mqttPort + '.' })
+$(if ($reason) { "Subscriber output:`n$reason" } else { 'It produced no output. Check that mosquitto_sub can reach 127.0.0.1:' + $mqttPort + '.' })
 "@
         exit 1
     }
@@ -269,7 +269,7 @@ if ($Detached) {
 }
 
 Write-Host ""
-Write-Host ("Subscribing to homie/# on localhost:{0}  (Ctrl+C to stop)" -f $mqttPort) -ForegroundColor Cyan
+Write-Host ("Subscribing to homie/# on 127.0.0.1:{0}  (Ctrl+C to stop)" -f $mqttPort) -ForegroundColor Cyan
 Write-Host ('-' * 69)
 
 try {

--- a/scripts/Start-DevEnv.ps1
+++ b/scripts/Start-DevEnv.ps1
@@ -244,7 +244,7 @@ if ($Detached) {
 
         Write-Error @"
 The homie/# subscriber exited immediately (exit code $($subscriber.ExitCode)); broker stopped again.
-$(if ($reason) { "Subscriber output:`n$reason" } else { 'It produced no output. Check that mosquitto_sub can reach 127.0.0.1:' + $mqttPort + '.' })
+$(if ($reason) { "Subscriber output:`n$reason" } else { 'It produced no output. Check that mosquitto_sub can reach ' + $SmartHomeLocalBrokerHost + ':' + $mqttPort + '.' })
 "@
         exit 1
     }
@@ -269,7 +269,7 @@ if ($Detached) {
 }
 
 Write-Host ""
-Write-Host ("Subscribing to homie/# on 127.0.0.1:{0}  (Ctrl+C to stop)" -f $mqttPort) -ForegroundColor Cyan
+Write-Host ("Subscribing to {0} on {1}:{2}  (Ctrl+C to stop)" -f $SmartHomeHomieTopic, $SmartHomeLocalBrokerHost, $mqttPort) -ForegroundColor Cyan
 Write-Host ('-' * 69)
 
 try {

--- a/scripts/local.env.template.ps1
+++ b/scripts/local.env.template.ps1
@@ -9,7 +9,14 @@ $env:SMARTHOME_COM_PORT      = "COM3"
 # Full path to your Mosquitto installation directory (must contain mosquitto.exe)
 $env:SMARTHOME_MOSQUITTO_DIR = "C:\Program Files\mosquitto"
 
-# MQTT broker host/port used by the device and the local subscriber.
-# Only change these if you are not using the default Mosquitto localhost setup.
+# SMARTHOME_MQTT_BROKER is the address the DEVICE dials to reach this machine's broker,
+# so it has to be an address the ESP32 can route to -- your LAN IP, not "localhost".
+# Run-IntegrationTests.ps1 compares it against the BrokerHost constants compiled into the
+# device projects and warns when they have drifted apart.
+#
+# Host-side tooling does NOT use it. The scripts always dial IPv4 loopback directly; see
+# $SmartHomeLocalBrokerHost in Common.ps1 for why that is not configurable.
+#
+# The PORT is shared: both sides must agree on it.
 $env:SMARTHOME_MQTT_BROKER   = "localhost"
 $env:SMARTHOME_MQTT_PORT     = "1883"


### PR DESCRIPTION
## Summary

This started as #16 ("replace the fixed sleeps, save ~20s") and turned into something else. It does **not** make the suite faster — it makes it about 8s slower — and it fixes a latent bug in the conformance check that had been masked by a two-second delay.

Related to #16; deliberately does **not** close it. See the comment there.

## Two real changes

**1. `localhost` cost two seconds on every mosquitto client call.**

| host | time to first message |
|---|---|
| `localhost` | 2.03s, 2.03s, 2.06s |
| `127.0.0.1` | 0.02s, 0.02s, 0.12s |

`localhost` resolves to `::1` first while `Start-DevEnv.ps1` binds `0.0.0.0` — IPv4 only, deliberately, so a real device on the LAN can reach it. Every client attempted IPv6, waited out the connect timeout, then fell back.

This is not primarily a speed fix. A 2s snapshot window used to be consumed almost entirely by the connect, leaving close to **no listening time**; the polling loop only hid that by retrying until something turned up. The same window is now actual listening.

**2. `Wait-ForRetainedValue` ignored the retain flag** — and that is what the whole check exists to verify.

It accepted any snapshot whose topic held the expected payload. A snapshot subscriber connecting while the device is still announcing receives the rest of that announce **live**, and a live delivery carries `retain=0`. Such a snapshot was accepted and handed to the caller, which then reported a conforming device's attributes as not retained.

It never fired before because the 2s IPv6 timeout reliably delayed the subscriber past the end of the announce. **The conformance check was passing on an accident of timing.** Removing the delay produced 31 spurious failures, which is how it surfaced.

Requiring the flag also makes reusing the snapshot sound rather than merely plausible: `$state` is published last, so a subscriber that saw it *replayed* necessarily connected after everything before it was in the store. That was already the stated justification; it is now enforced.

## What I got wrong on the way

Three hardware runs were spent blaming the settle window. The commits are left in history because the measurements are the useful part:

- **Quiet-detection (250ms of no output)** — 7 failures. I asserted the replay is "one contiguous burst". It is not.
- **Flat 1s window** — 3 failures, 54 topics where a healthy run sees ~64.
- **Restoring 3s** — 31 failures. This is what proved the window was never the variable.

An A/B against known ground truth (80 seeded topics) settled it:

```
OLD: flat 3s sleep, then kill    3.31s   80/80   complete
OLD: flat 1s sleep, then kill    1.28s   80/80   complete
NEW: -W 1, wait for exit         6.30s   80/80   complete
```

The kill loses nothing against a static store, so buffering was never the cause, and `mosquitto_sub -W` is twice as slow as what it would replace. My first two explanations were both wrong.

**The earlier harness missed all of this** because it compared the new implementation's topic count against *itself* across four runs. A systematically truncated snapshot passes that perfectly. Ground truth is the whole point.

## Testing Done

**Integration suite 5/5 on the ESP32, 214s.** `HomieClientCheck` passes, including the retained-flag assertions that were failing.

Cost, stated plainly:

| | baseline | this branch |
|---|---|---|
| HomieClientCheck | 62–64s | 74s |
| suite total | 195–206s | 214s |

The extra poll needed to obtain a genuinely-replayed snapshot is the price of the check actually checking. Worth it.

## Checklist

- [x] Code compiles without errors
- [x] Relevant tests pass
- [x] No secrets or credentials committed
- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)