### PR TITLE
fix(homie): reflect the lifecycle outcome, and make the conformance check measurable

### DIFF
--- a/.claude/skills/smarthome-integration-tests/SKILL.md
+++ b/.claude/skills/smarthome-integration-tests/SKILL.md
@@ -16,8 +16,9 @@ Run `scripts\Run-IntegrationTests.ps1` — one call covers every project under
 - **`HomieConformance`** (HomieClientCheck) — the host measures a purpose-built device against
   the Homie v4 convention: mandatory attributes and their retained flags, one property of every
   datatype with its `$format`/`$unit`/`$settable`/`$retained`, a `/set` command applied and
-  reflected back, the `alert` and `sleeping` states driven through a control property, and a full
-  re-announce after the broker is replaced. It emits no `[ITEST]` marker by design — the evidence
+  reflected back, the `alert` and `sleeping` states driven through a control property, a refused
+  transition that must not be advertised as if it had happened, and a full re-announce after the
+  broker is replaced. It emits no `[ITEST]` marker by design — the evidence
   is what lands on the broker.
 
 Both host-decided kinds (`BrokerOutage`, `HomieConformance`) take the broker away and put a fresh

--- a/.claude/skills/smarthome-integration-tests/SKILL.md
+++ b/.claude/skills/smarthome-integration-tests/SKILL.md
@@ -49,6 +49,14 @@ Reading the result:
 - **exit 1** — the summary names each non-passing test and prints its captured device log path.
   Start there.
 
+Reading the timing: each summary line is `<total>s (<deploy>s deploy)`. The deploy is a full
+`/t:Rebuild` plus a flash and swings by tens of seconds independently of the test, so a run that
+looks slower is usually a build that was — compare the *difference*, not the total.
+`HomieConformance` additionally prints a per-phase breakdown (announce, attributes, `/set`
+round-trip, lifecycle, re-announce) with the number of 3s retained-store snapshots each phase
+took. That count is decided at runtime by how many polls a step needs, so it is the figure that
+explains a conformance run's duration; nothing about it is derivable from reading the script.
+
 Outcomes other than PASS/FAIL:
 
 - `NO-RESULT` — no marker within the capture window. The app crashed before reporting, or wasn't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ device owns a connection rather than being one, and exposing `Publish`/`Subscrib
 let an app publish an attribute non-retained or `$state` out of order. The `Device` model (built
 with `HomieDeviceBuilder`) says what the device *is*; `IHomieClient` is what you *do* with it.
 
-Two things to know when writing an actuator (Irrigation, Oven):
+Three things to know when writing an actuator (Irrigation, Oven):
 
 - Act on `IHomieClient.OnCommand`, not on `property.OnUpdate`. The property event fires both
   when a controller sets a value and when the device updates its own, and cannot tell them
@@ -190,6 +190,13 @@ Two things to know when writing an actuator (Irrigation, Oven):
 - Settable properties are subscribed on `homie/[device]/[node]/[property]/set`, as the spec
   requires. Until 2026-08-21 the code subscribed to the property *value* topic instead, so
   commands were never received and the device re-consumed its own retained publishes.
+- Reflect the outcome, not the command. `HomieClient` publishes a `/set` payload onto the
+  property before `OnCommand` runs, which is right for an ordinary property and wrong for one
+  whose value is a *request* the device can turn down — an illegal `$state` transition, an out
+  of range setpoint, a relay that failed to close. Publish the real value over it once the
+  command has been applied or refused, or the retained store advertises a state the device is
+  not in, to every controller that connects afterwards. `HomieClientCheck` does this for its
+  `lifecycle` property and the conformance suite asserts it.
 
 `HomieClient` owns its MQTT session and must: Homie v4 requires the connection to carry a last
 will setting `homie/[device-id]/$state` to `lost`, and a will can only be declared in CONNECT.
@@ -235,8 +242,9 @@ The suite runs three kinds of test, and the kind is declared per entry in
 - **`HomieConformance`** — the host measures a purpose-built device against the Homie v4
   convention: mandatory attributes and their retained flags, one property of every datatype with
   its `$format`/`$unit`/`$settable`/`$retained`, a `/set` command applied and reflected back, the
-  `alert` and `sleeping` states driven through a control property, and a full re-announce after
-  the broker is replaced. `HomieClientCheck` is this kind. Retained-ness is read from a *fresh*
+  `alert` and `sleeping` states driven through a control property, a refused transition that
+  must not be advertised as if it had happened, and a full re-announce after the broker is
+  replaced. `HomieClientCheck` is this kind. Retained-ness is read from a *fresh*
   subscriber (`mosquitto_sub -F '%t %r %p'`), because MQTT only sets the retain flag when
   replaying from the store — a live retained publish arrives with the flag clear.
 - **`BrokerOutage`** — the host decides. The device publishes a heartbeat and subscribes to an

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -501,6 +501,11 @@ function Get-MosquittoTool {
 # of *listening*, where they used to be two of connecting and one of listening.
 $SnapshotSettleSeconds = 3
 
+# Snapshots taken so far, across the whole run. Declared here rather than left to the
+# first ++ because Set-StrictMode -Version Latest makes incrementing an unset variable a
+# terminating error, which would arrive as an 'ERROR' verdict blamed on the device.
+$script:snapshotsTaken = 0
+
 function Get-HomieRetainedSnapshot {
     # What a controller joining *now* would see: the broker's retained store.
     #
@@ -539,6 +544,12 @@ function Get-HomieRetainedSnapshot {
 
     Start-Sleep -Seconds $SnapshotSettleSeconds
     Stop-SmartHomeProcessTree -ProcessId $process.Id
+
+    # Counted, not estimated. Nearly the whole wall clock of a conformance run is spent
+    # in this function, and the poll loops that call it decide at runtime how many times
+    # they need to -- so the number of snapshots a run actually took is the one figure
+    # that explains its duration, and it cannot be read off the code.
+    $script:snapshotsTaken++
 
     # Last message per topic wins -- except that a repeat of the SAME payload only adds
     # to what is known about it.
@@ -652,6 +663,62 @@ function Wait-ForRetainedValue {
     return @{ Ok = $false; Seen = $seen; Snapshot = $snapshot }
 }
 
+# ── Phase timing ──────────────────────────────────────────────────────────────
+# The summary reports one number per test, and that number covers the deploy as well as
+# the measurement -- so when this check went from 59s to 73s between two runs there was
+# nothing to attribute the difference to, only arithmetic about how many snapshots a new
+# step "ought" to cost. That arithmetic was wrong by 14s and could not be checked.
+#
+# What actually varies is how many times a poll loop has to take a 3s snapshot before the
+# device catches up, and that is a runtime fact. Recording seconds and snapshots per phase
+# turns the next unexplained delta into a line someone can point at.
+#
+# Start/stop rather than a scriptblock wrapper: the phases share $snapshot and the
+# failure list, and & { } would run them in a child scope where those assignments are
+# invisible to the phases that follow.
+$script:conformancePhases = @()
+$script:currentPhase = $null
+
+function Start-ConformancePhase {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    Stop-ConformancePhase
+    $script:currentPhase = @{
+        Name             = $Name
+        Started          = Get-Date
+        SnapshotsAtStart = $script:snapshotsTaken
+    }
+}
+
+function Stop-ConformancePhase {
+    if ($null -eq $script:currentPhase) {
+        return
+    }
+
+    $script:conformancePhases += [pscustomobject]@{
+        Name      = $script:currentPhase.Name
+        Seconds   = [math]::Round(((Get-Date) - $script:currentPhase.Started).TotalSeconds, 1)
+        Snapshots = $script:snapshotsTaken - $script:currentPhase.SnapshotsAtStart
+    }
+    $script:currentPhase = $null
+}
+
+function Write-ConformancePhaseBreakdown {
+    # Called from the test loop, not from the check itself: the check returns from four
+    # places (two of them failure paths), and those are exactly the runs whose timing is
+    # worth seeing. One call after it returns covers all four.
+    Stop-ConformancePhase
+
+    if ($script:conformancePhases.Count -eq 0) {
+        return
+    }
+
+    Write-Host ("  phase breakdown ({0}s per snapshot):" -f $SnapshotSettleSeconds) -ForegroundColor DarkGray
+    foreach ($phase in $script:conformancePhases) {
+        Write-Host ("    {0,-22} {1,6}s  {2,2} snapshot(s)" -f $phase.Name, $phase.Seconds, $phase.Snapshots) -ForegroundColor DarkGray
+    }
+}
+
 function Invoke-HomieConformanceCheck {
     # Measures a purpose-built device against the Homie v4 convention, from the
     # broker's side. Every assertion is collected rather than thrown, so one run
@@ -671,7 +738,10 @@ function Invoke-HomieConformanceCheck {
     # reconcile, and an assertion added against the wrong one would have been collected
     # into a list the verdict never reads: a silently passing conformance test.
     $script:conformanceFailures = @()
+    $script:conformancePhases = @()
+    $script:currentPhase = $null
 
+    Start-ConformancePhase -Name 'announce'
     Write-Host ("Waiting up to {0}s for {1} to announce..." -f $Settings.SettleSeconds, $deviceId) -ForegroundColor Cyan
     $ready = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected 'ready' -TimeoutSeconds $Settings.SettleSeconds
     if (-not $ready.Ok) {
@@ -701,6 +771,8 @@ function Invoke-HomieConformanceCheck {
             $script:conformanceFailures += "$Topic is '$($snapshot[$Topic].Payload)', expected '$Expected'"
         }
     }
+
+    Start-ConformancePhase -Name 'attributes'
 
     # ── mandatory device attributes ──────────────────────────────────────────
     Test-Attribute -Topic "$root/`$homie" -Expected '4'
@@ -762,6 +834,7 @@ function Invoke-HomieConformanceCheck {
     }
 
     # ── a controller command is applied and reflected back ───────────────────
+    Start-ConformancePhase -Name '/set round-trip'
     Write-Host "  driving /set commands..." -ForegroundColor DarkGray
     $commands = @{
         'integer-value' = '42'
@@ -828,6 +901,7 @@ function Invoke-HomieConformanceCheck {
     }
 
     # ── the lifecycle states a device can be driven into ─────────────────────
+    Start-ConformancePhase -Name 'lifecycle'
     Write-Host "  driving `$state through alert, sleeping and a refused transition..." -ForegroundColor DarkGray
     # ready -> alert -> ready -> sleeping -> ready, with the one transition the
     # convention's own state machine forbids asked for in the middle. alert may only
@@ -881,6 +955,7 @@ function Invoke-HomieConformanceCheck {
     }
 
     # ── a replaced broker gets the whole announcement again ──────────────────
+    Start-ConformancePhase -Name 're-announce'
     Write-Host "  replacing the broker to check the re-announce..." -ForegroundColor DarkGray
     try {
         Restart-SuiteBroker -Port $Port -SettleSeconds 5
@@ -988,6 +1063,9 @@ try {
         Write-Host ('=' * 69)
 
         $testStarted = Get-Date
+        # Always defined, so the result object below can read it on every path -- including
+        # the one where the deploy itself is what threw.
+        $deploySeconds = 0
         $outcome = $null
         $detail = $null
 
@@ -1000,6 +1078,12 @@ try {
             # terminating error. One used to sit here and could never run.
             & $deployScript -Project (Get-TestProjectPath -TestName $testName) -Configuration $Configuration
 
+            # Timed apart from the measurement that follows. Deploy-ToDevice.ps1 always
+            # /t:Rebuild's, so this is a full build plus a flash and swings by tens of
+            # seconds with nothing to do with the test -- folded into one number, it is
+            # indistinguishable from the test getting slower.
+            $deploySeconds = [int]((Get-Date) - $testStarted).TotalSeconds
+
             Write-Host ""
 
             # ── Host-decided ──────────────────────────────────────────────────
@@ -1010,6 +1094,7 @@ try {
             $verdict = $null
             if ($settings.Kind -eq 'HomieConformance') {
                 $verdict = Invoke-HomieConformanceCheck -Settings $settings -Port $mqttPort
+                Write-ConformancePhaseBreakdown
             }
             elseif ($settings.Kind -eq 'BrokerOutage') {
                 $verdict = Invoke-BrokerOutageCheck -Settings $settings -Port $mqttPort
@@ -1100,11 +1185,12 @@ try {
         }
 
         $results += [pscustomobject]@{
-            Test    = $testName
-            Outcome = $outcome
-            Detail  = $detail
-            Log     = if (Test-Path $logFile) { $logFile } else { $null }
-            Seconds = [int]((Get-Date) - $testStarted).TotalSeconds
+            Test          = $testName
+            Outcome       = $outcome
+            Detail        = $detail
+            Log           = if (Test-Path $logFile) { $logFile } else { $null }
+            Seconds       = [int]((Get-Date) - $testStarted).TotalSeconds
+            DeploySeconds = $deploySeconds
         }
 
         $color = if ($outcome -eq 'PASS') { 'Green' } else { 'Red' }
@@ -1132,12 +1218,18 @@ Write-Host ('=' * 69)
 Write-Host "Integration test summary" -ForegroundColor Cyan
 Write-Host ('=' * 69)
 
+# Total, then how much of it was the deploy. A test that "got slower" is usually a build
+# that did, and the two used to be one number -- which is how a 14s swing on
+# HomieClientCheck came to be attributed to the check itself.
 foreach ($result in $results) {
     $color = if ($result.Outcome -eq 'PASS') { 'Green' } else { 'Red' }
-    Write-Host ("  {0,-20} {1,-12} {2,5}s  {3}" -f $result.Test, $result.Outcome, $result.Seconds, $result.Detail) -ForegroundColor $color
+    $timing = "{0}s ({1}s deploy)" -f $result.Seconds, $result.DeploySeconds
+    Write-Host ("  {0,-20} {1,-12} {2,-16} {3}" -f $result.Test, $result.Outcome, $timing, $result.Detail) -ForegroundColor $color
 }
 
-Write-Host ("  {0,-20} {1,-12} {2,5}s" -f 'TOTAL', '', (($results | Measure-Object -Property Seconds -Sum).Sum)) -ForegroundColor DarkGray
+$totalSeconds = ($results | Measure-Object -Property Seconds -Sum).Sum
+$totalDeploySeconds = ($results | Measure-Object -Property DeploySeconds -Sum).Sum
+Write-Host ("  {0,-20} {1,-12} {2,-16}" -f 'TOTAL', '', ("{0}s ({1}s deploy)" -f $totalSeconds, $totalDeploySeconds)) -ForegroundColor DarkGray
 
 $failed = @($results | Where-Object { $_.Outcome -ne 'PASS' })
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -527,29 +527,96 @@ function Get-HomieRetainedSnapshot {
         [string]$Port
     )
 
+    $capture = Start-HomieCapture -Port $Port
+    return ConvertTo-HomieSnapshot -Lines (Stop-HomieCapture -Capture $capture)
+}
+
+function Start-HomieCapture {
+    # Opens the fresh-subscriber window that Get-HomieRetainedSnapshot measures through,
+    # without closing it. Split out so a caller can publish *inside* the window: the
+    # refused-transition step has to observe messages the device emits in response to a
+    # command, and a window opened after the command would miss them.
+    #
+    # Callers that only want the settled result should use Get-HomieRetainedSnapshot,
+    # which is this plus Stop-HomieCapture plus ConvertTo-HomieSnapshot.
+    param(
+        [string]$Port,
+
+        # Block until the subscriber has actually connected, for a caller that publishes
+        # inside the window. Start-Process returns as soon as cmd.exe exists, well before
+        # mosquitto_sub has a session, so a publish issued immediately after this returns
+        # can reach the broker first and the response it triggers is then missed entirely
+        # -- which would read as "the command never arrived" and fail the refused step on
+        # a healthy device.
+        #
+        # A subscriber to homie/# gets the whole retained store the moment it subscribes,
+        # so the first byte in the output file is the connection being live. Callers that
+        # only want the settled result do not need this: their 3s sleep starts before the
+        # connection and is a window, not a measurement of anything published inside it.
+        [int]$WaitForConnectSeconds = 0
+    )
+
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
     Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
 
     $sub = Get-MosquittoTool -Name 'mosquitto_sub.exe'
 
     # Arguments come from Common.ps1, not from a second copy of them here. The parser
-    # below depends on the exact '%t %r %p' layout, and that layout is chosen and
-    # explained in Get-SmartHomeSubscriberArguments -- spelling it out again meant a
-    # one-line change in the file that owns it would silently break this reader.
+    # depends on the exact '%t %r %p' layout, and that layout is chosen and explained in
+    # Get-SmartHomeSubscriberArguments -- spelling it out again meant a one-line change in
+    # the file that owns it would silently break this reader.
     # Quoting idiom matches Start-DevEnv.ps1's subscriber launch.
     $subscriberArgs = (Get-SmartHomeSubscriberArguments -Port $Port |
         ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
-    Start-Sleep -Seconds $SnapshotSettleSeconds
-    Stop-SmartHomeProcessTree -ProcessId $process.Id
+    if ($WaitForConnectSeconds -gt 0) {
+        $connectDeadline = (Get-Date).AddSeconds($WaitForConnectSeconds)
+        while ((Get-Date) -lt $connectDeadline) {
+            $captured = Get-Item -Path $out -ErrorAction SilentlyContinue
+            if ($null -ne $captured -and $captured.Length -gt 0) {
+                break
+            }
 
-    # Counted, not estimated. Nearly the whole wall clock of a conformance run is spent
-    # in this function, and the poll loops that call it decide at runtime how many times
-    # they need to -- so the number of snapshots a run actually took is the one figure
-    # that explains its duration, and it cannot be read off the code.
+            Start-Sleep -Milliseconds 100
+        }
+    }
+
+    return @{ ProcessId = $process.Id; Path = $out }
+}
+
+function Stop-HomieCapture {
+    # Closes the window and returns every line it caught, in arrival order.
+    param(
+        [hashtable]$Capture,
+
+        # Time to leave the window open before closing it. Defaults to the same settle
+        # used by a plain snapshot, so a caller that publishes inside the window gets the
+        # same amount of time for the response as one that publishes before it.
+        [int]$SettleSeconds = $SnapshotSettleSeconds
+    )
+
+    # Counted here rather than where the lines are parsed: this is the function that
+    # spends the time, and one closed window is one snapshot however many ways its lines
+    # are later read. Nearly the whole wall clock of a conformance run is these windows,
+    # and the poll loops decide at runtime how many they need -- so the count is the one
+    # figure that explains a run's duration, and it cannot be read off the code.
     $script:snapshotsTaken++
+
+    Start-Sleep -Seconds $SettleSeconds
+    Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
+
+    return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+}
+
+function ConvertTo-HomieSnapshot {
+    # Collapses captured lines to one entry per topic. Kept apart from the capture so the
+    # same lines can be read twice: as a settled per-topic view, and as the ordered
+    # sequence that view deliberately throws away.
+    param(
+        [string[]]$Lines
+    )
 
     # Last message per topic wins -- except that a repeat of the SAME payload only adds
     # to what is known about it.
@@ -570,7 +637,7 @@ function Get-HomieRetainedSnapshot {
     # value it replaced, which is exactly the bug Wait-ForRetainedValue's flag check
     # exists to catch.
     $snapshot = @{}
-    foreach ($line in @(Get-Content -Path $out -ErrorAction SilentlyContinue)) {
+    foreach ($line in $Lines) {
         # "<topic> <0|1> <payload>", and the payload may itself contain spaces.
         $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
         if (-not $match.Success) {
@@ -958,10 +1025,9 @@ function Invoke-HomieConformanceCheck {
 
     foreach ($step in $lifecycleSteps) {
         if ($step.Refused) {
-            Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
             # Nothing to wait for here -- the assertion is that nothing changed -- so one
-            # settled snapshot IS the measurement rather than a poll for it, and it carries
-            # both topics.
+            # capture window IS the measurement rather than a poll for it, and it carries
+            # both topics as well as the sequence on the property.
             #
             # HomieClient reflects a /set payload onto its property before the app ever
             # sees it: right for an ordinary property, wrong for one whose value is a
@@ -970,17 +1036,31 @@ function Invoke-HomieConformanceCheck {
             # controller that connects afterwards reads that contradiction out of the
             # store rather than seeing it go by.
             #
-            # Known limit: this cannot tell a refusal apart from a command that never
-            # arrived. Both leave $state and the property on 'alert', so a dropped /set
-            # passes here rather than failing -- and unlike the polls around it, a single
-            # publish is all this step can do, because the assertion is that nothing
-            # changes and there is no echo to retry until. What keeps it honest for now
-            # is the step before it: reaching 'alert' proves the device was applying /set
-            # on this very topic seconds earlier. Proving arrival outright would mean
-            # asserting the live log shows the library's 'sleeping' reflection being
-            # overwritten by the device's 'alert', which is a different measurement than
-            # this snapshot makes.
-            $refused = Get-HomieRetainedSnapshot -Port $Port
+            # The window is opened BEFORE the command and closed after, rather than
+            # taken afterwards, because this step needs the messages the device emits in
+            # response -- not just where things settled.
+            #
+            # Settling on 'alert' is not by itself evidence of a refusal. A /set is
+            # non-retained, so a command dropped because the device was not subscribed
+            # leaves $state and the property exactly as a refusal does, and this step
+            # cannot retry its way past that the way the polls around it now do: its
+            # whole assertion is that nothing changes, so there is no echo to wait on.
+            # Read only from a settled snapshot, a lost command passes as a refusal.
+            #
+            # What separates them is on the wire. HomieClient reflects the /set payload
+            # onto the property before the app sees it, and HomieClientCheck then
+            # publishes the device's real state over that reflection -- so a command that
+            # arrived and was refused puts 'sleeping' and then 'alert' on the property
+            # topic, in that order. A command that never arrived puts neither.
+            #
+            # That sequence is also the behaviour this test exists to guard: it is the
+            # correction itself, observed rather than inferred from where the store ended
+            # up.
+            $capture = Start-HomieCapture -Port $Port -WaitForConnectSeconds 5
+            Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
+            $lines = Stop-HomieCapture -Capture $capture
+            $refused = ConvertTo-HomieSnapshot -Lines $lines
+
             $stateAfter = if ($refused.Contains("$root/`$state")) { $refused["$root/`$state"].Payload } else { $null }
             $lifecycleAfter = if ($refused.Contains("$node/lifecycle")) { $refused["$node/lifecycle"].Payload } else { $null }
 
@@ -990,6 +1070,30 @@ function Invoke-HomieConformanceCheck {
 
             if ($lifecycleAfter -ne $step.Expect) {
                 $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
+            }
+
+            # Payloads on the property topic, in arrival order, retained replay dropped:
+            # the replayed copy is the value from before this command and says nothing
+            # about whether it arrived.
+            $lifecyclePayloads = @()
+            foreach ($line in $lines) {
+                $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
+                if ($match.Success -and $match.Groups[1].Value -eq "$node/lifecycle" -and $match.Groups[2].Value -eq '0') {
+                    $lifecyclePayloads += $match.Groups[3].Value
+                }
+            }
+
+            $reflected = [array]::IndexOf($lifecyclePayloads, $step.Command)
+            $corrected = [array]::IndexOf($lifecyclePayloads, $step.Expect)
+
+            if ($reflected -lt 0) {
+                $script:conformanceFailures += "refused '$($step.Command)' never reached $nodeId/lifecycle -- the command was lost, so nothing about the refusal was measured (saw: $($lifecyclePayloads -join ', '))"
+            }
+            elseif ($corrected -lt 0) {
+                $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it"
+            }
+            elseif ($corrected -lt $reflected) {
+                $script:conformanceFailures += "$nodeId/lifecycle published '$($step.Expect)' before the reflected '$($step.Command)', so the correction did not overwrite it (saw: $($lifecyclePayloads -join ', '))"
             }
 
             continue

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -540,15 +540,44 @@ function Get-HomieRetainedSnapshot {
     Start-Sleep -Seconds $SnapshotSettleSeconds
     Stop-SmartHomeProcessTree -ProcessId $process.Id
 
+    # Last message per topic wins -- except that a repeat of the SAME payload only adds
+    # to what is known about it.
+    #
+    # A QoS-1 publish whose PUBACK is late gets retransmitted: M2Mqtt resends an in-flight
+    # message with DupFlag set, up to MqttSettings.MaximumAttemptsRetry (3). So a snapshot
+    # can hold a live duplicate of a value the broker also replayed from its store,
+    # arriving after the replayed copy. Overwriting on payload equality threw away the
+    # retain flag that replay had just proved, and Test-Attribute reported "not retained"
+    # for three attributes of 53 that plainly were.
+    #
+    # Measured, not guessed: a 40s capture of one re-announce holds a retransmitted tail
+    # of the last property's attributes, and counter values arriving out of order (146
+    # after 147) -- which nothing but retransmission explains.
+    #
+    # A DIFFERENT payload still replaces both fields. That is what keeps the flag
+    # meaningful: a value delivered only live must not inherit the retained-ness of the
+    # value it replaced, which is exactly the bug Wait-ForRetainedValue's flag check
+    # exists to catch.
     $snapshot = @{}
     foreach ($line in @(Get-Content -Path $out -ErrorAction SilentlyContinue)) {
         # "<topic> <0|1> <payload>", and the payload may itself contain spaces.
         $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
-        if ($match.Success) {
-            $snapshot[$match.Groups[1].Value] = @{
-                Retained = $match.Groups[2].Value -eq '1'
-                Payload  = $match.Groups[3].Value
-            }
+        if (-not $match.Success) {
+            continue
+        }
+
+        $topic = $match.Groups[1].Value
+        $retained = $match.Groups[2].Value -eq '1'
+        $payload = $match.Groups[3].Value
+
+        if ($snapshot.Contains($topic) -and $snapshot[$topic].Payload -eq $payload) {
+            $snapshot[$topic].Retained = $snapshot[$topic].Retained -or $retained
+            continue
+        }
+
+        $snapshot[$topic] = @{
+            Retained = $retained
+            Payload  = $payload
         }
     }
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -643,7 +643,16 @@ function Wait-ForRetainedValue {
         # device writes within milliseconds of a command. Nothing is lost by accepting the
         # live delivery there: the payload is the same, and $state's retained-ness is
         # already asserted once against the announce snapshot.
-        [bool]$RequireRetained = $true
+        [bool]$RequireRetained = $true,
+
+        # A controller command to (re)publish at the top of every poll round, for the
+        # reason set out at the /set round-trip loop: a /set is non-retained, so one that
+        # arrives while the device is not subscribed is dropped and no amount of further
+        # polling can recover it. Callers waiting on something the device produces by
+        # itself -- the announce, the re-announce -- pass neither of these and nothing is
+        # published.
+        [string]$RepublishTopic,
+        [string]$RepublishPayload
     )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
@@ -651,6 +660,10 @@ function Wait-ForRetainedValue {
     $snapshot = @{}
 
     while ((Get-Date) -lt $deadline) {
+        if ($RepublishTopic) {
+            Publish-HomieCommand -Port $Port -Topic $RepublishTopic -Payload $RepublishPayload
+        }
+
         $snapshot = Get-HomieRetainedSnapshot -Port $Port
         if ($snapshot.Contains($Topic)) {
             $seen = $snapshot[$Topic].Payload
@@ -863,10 +876,6 @@ function Invoke-HomieConformanceCheck {
         'float-value' = '21.50'
     }
 
-    foreach ($property in $commands.Keys) {
-        Publish-HomieCommand -Port $Port -Topic "$node/$property/set" -Payload $commands[$property]
-    }
-
     # One snapshot per round, not one per property. Every reflection is checked
     # against the same snapshot, so five properties cost one snapshot instead of
     # five -- the snapshot has to be a fresh subscriber (retain flags are only set on
@@ -875,7 +884,33 @@ function Invoke-HomieConformanceCheck {
     $lastSeen = @{}
     $deadline = (Get-Date).AddSeconds($Settings.CommandTimeoutSeconds)
 
+    # The commands are published at the top of every round, not once before the loop.
+    #
+    # A /set is non-retained, as the convention requires of a controller, so one that
+    # reaches the broker while the device is not yet subscribed is dropped outright --
+    # there is nothing left in the store for the device to pick up when it does
+    # subscribe. Published once, that single lost message becomes the full
+    # CommandTimeoutSeconds of polling for an echo that can never arrive, and five
+    # conformance failures against a device that is working correctly.
+    #
+    # Measured, not hypothetical: 1 run in 8 on 2026-08-26, and it was the only run of
+    # the eight whose announce wait was satisfied by its first snapshot rather than its
+    # third -- i.e. the only one that reached this loop early. The /set phase then spent
+    # 33.4s over 10 snapshots and reported all five properties still holding their boot
+    # values.
+    #
+    # Retrying is the only fix available at this layer. MQTT gives a publisher no signal
+    # about who is subscribed, and $state=ready is the device's claim about itself, not
+    # about the broker's routing table -- so the host cannot wait for the condition it
+    # actually needs. On a healthy run this costs nothing: the first round succeeds and
+    # nothing is ever re-sent. Only still-pending properties are republished, and a
+    # repeated command is idempotent -- the device applies the same value again and
+    # publishes back the same reflection.
     while ($pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
+        foreach ($property in $pending) {
+            Publish-HomieCommand -Port $Port -Topic "$node/$property/set" -Payload $commands[$property]
+        }
+
         $snapshot = Get-HomieRetainedSnapshot -Port $Port
         $stillPending = @()
 
@@ -922,9 +957,8 @@ function Invoke-HomieConformanceCheck {
     )
 
     foreach ($step in $lifecycleSteps) {
-        Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
-
         if ($step.Refused) {
+            Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
             # Nothing to wait for here -- the assertion is that nothing changed -- so one
             # settled snapshot IS the measurement rather than a poll for it, and it carries
             # both topics.
@@ -935,6 +969,17 @@ function Invoke-HomieConformanceCheck {
             # advertising matrix/lifecycle=sleeping beside $state=alert, and every
             # controller that connects afterwards reads that contradiction out of the
             # store rather than seeing it go by.
+            #
+            # Known limit: this cannot tell a refusal apart from a command that never
+            # arrived. Both leave $state and the property on 'alert', so a dropped /set
+            # passes here rather than failing -- and unlike the polls around it, a single
+            # publish is all this step can do, because the assertion is that nothing
+            # changes and there is no echo to retry until. What keeps it honest for now
+            # is the step before it: reaching 'alert' proves the device was applying /set
+            # on this very topic seconds earlier. Proving arrival outright would mean
+            # asserting the live log shows the library's 'sleeping' reflection being
+            # overwritten by the device's 'alert', which is a different measurement than
+            # this snapshot makes.
             $refused = Get-HomieRetainedSnapshot -Port $Port
             $stateAfter = if ($refused.Contains("$root/`$state")) { $refused["$root/`$state"].Payload } else { $null }
             $lifecycleAfter = if ($refused.Contains("$node/lifecycle")) { $refused["$node/lifecycle"].Payload } else { $null }
@@ -950,11 +995,16 @@ function Invoke-HomieConformanceCheck {
             continue
         }
 
+        # No publish here: the wait republishes the command itself at the top of every
+        # round, so a command dropped because the device was not subscribed yet is
+        # retried instead of turning into a timeout. Same reasoning as the /set
+        # round-trip loop above.
+        #
         # -RequireRetained $false: this reads Ok/Seen only and discards the snapshot. The
         # device writes $state within milliseconds of the command, so insisting on a
         # replayed copy would spend a second full snapshot re-observing the same value,
         # four times per run.
-        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $step.Expect -TimeoutSeconds $Settings.CommandTimeoutSeconds -RequireRetained $false
+        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $step.Expect -TimeoutSeconds $Settings.CommandTimeoutSeconds -RequireRetained $false -RepublishTopic "$node/lifecycle/set" -RepublishPayload $step.Command
         if (-not $reached.Ok) {
             $script:conformanceFailures += "device did not reach `$state='$($step.Expect)' on '$($step.Command)' (saw '$($reached.Seen)')"
         }

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -695,9 +695,15 @@ function Stop-ConformancePhase {
         return
     }
 
+    # Rendered here, invariant, rather than left as a double for the -f below to format.
+    # These lines get pasted into pull requests and issues, and -f formats in the host's
+    # culture -- on this machine that produced '16,7s', which reads as a thousands
+    # separator to everyone who wasn't sitting at the machine.
+    $elapsed = ((Get-Date) - $script:currentPhase.Started).TotalSeconds
+
     $script:conformancePhases += [pscustomobject]@{
         Name      = $script:currentPhase.Name
-        Seconds   = [math]::Round(((Get-Date) - $script:currentPhase.Started).TotalSeconds, 1)
+        Seconds   = $elapsed.ToString('0.0', [cultureinfo]::InvariantCulture)
         Snapshots = $script:snapshotsTaken - $script:currentPhase.SnapshotsAtStart
     }
     $script:currentPhase = $null

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -714,6 +714,11 @@ function Invoke-HomieConformanceCheck {
     Test-Attribute -Topic "$node/integer-value/`$format" -Expected '0:100'
     Test-Attribute -Topic "$node/enum-value/`$format" -Expected 'low,medium,high'
     Test-Attribute -Topic "$node/color-value/`$format" -Expected 'rgb'
+    # Built by HomieClientCheck from the State enum rather than spelled out there, so
+    # that the vocabulary a controller is offered cannot drift from the vocabulary
+    # $state is published in. This assertion is what notices if that derivation breaks.
+    Test-Attribute -Topic "$node/lifecycle/`$format" -Expected 'ready,alert,sleeping'
+    Test-Attribute -Topic "$node/lifecycle/`$settable" -Expected 'true'
     Test-Attribute -Topic "$node/integer-value/`$unit" -Expected '#'
     Test-Attribute -Topic "$node/float-value/`$unit" -AnyValue
 
@@ -794,19 +799,55 @@ function Invoke-HomieConformanceCheck {
     }
 
     # ── the lifecycle states a device can be driven into ─────────────────────
-    Write-Host "  driving `$state through alert and sleeping..." -ForegroundColor DarkGray
-    # ready -> alert -> ready -> sleeping -> ready. Not ready -> alert -> sleeping:
-    # alert may only return to ready (or disconnect), so that would be asking the
-    # device for a transition the convention's own state machine forbids.
-    foreach ($state in 'alert', 'ready', 'sleeping', 'ready') {
-        Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $state
+    Write-Host "  driving `$state through alert, sleeping and a refused transition..." -ForegroundColor DarkGray
+    # ready -> alert -> ready -> sleeping -> ready, with the one transition the
+    # convention's own state machine forbids asked for in the middle. alert may only
+    # return to ready (or disconnect), so alert -> sleeping must be refused -- and a
+    # device that advertises it as done anyway is the defect the Refused step measures.
+    $lifecycleSteps = @(
+        @{ Command = 'alert';    Expect = 'alert';    Refused = $false }
+        @{ Command = 'sleeping'; Expect = 'alert';    Refused = $true  }
+        @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
+        @{ Command = 'sleeping'; Expect = 'sleeping'; Refused = $false }
+        @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
+    )
+
+    foreach ($step in $lifecycleSteps) {
+        Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
+
+        if ($step.Refused) {
+            # Nothing to wait for here -- the assertion is that nothing changed -- so one
+            # settled snapshot IS the measurement rather than a poll for it, and it carries
+            # both topics.
+            #
+            # HomieClient reflects a /set payload onto its property before the app ever
+            # sees it: right for an ordinary property, wrong for one whose value is a
+            # request that can be turned down. Uncorrected, the retained store ends up
+            # advertising matrix/lifecycle=sleeping beside $state=alert, and every
+            # controller that connects afterwards reads that contradiction out of the
+            # store rather than seeing it go by.
+            $refused = Get-HomieRetainedSnapshot -Port $Port
+            $stateAfter = if ($refused.Contains("$root/`$state")) { $refused["$root/`$state"].Payload } else { $null }
+            $lifecycleAfter = if ($refused.Contains("$node/lifecycle")) { $refused["$node/lifecycle"].Payload } else { $null }
+
+            if ($stateAfter -ne $step.Expect) {
+                $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state is '$stateAfter')"
+            }
+
+            if ($lifecycleAfter -ne $step.Expect) {
+                $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
+            }
+
+            continue
+        }
+
         # -RequireRetained $false: this reads Ok/Seen only and discards the snapshot. The
         # device writes $state within milliseconds of the command, so insisting on a
         # replayed copy would spend a second full snapshot re-observing the same value,
         # four times per run.
-        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $state -TimeoutSeconds $Settings.CommandTimeoutSeconds -RequireRetained $false
+        $reached = Wait-ForRetainedValue -Port $Port -Topic "$root/`$state" -Expected $step.Expect -TimeoutSeconds $Settings.CommandTimeoutSeconds -RequireRetained $false
         if (-not $reached.Ok) {
-            $script:conformanceFailures += "device did not reach `$state='$state' on command (saw '$($reached.Seen)')"
+            $script:conformanceFailures += "device did not reach `$state='$($step.Expect)' on '$($step.Command)' (saw '$($reached.Seen)')"
         }
     }
 
@@ -841,7 +882,7 @@ function Invoke-HomieConformanceCheck {
 
     return @{
         Outcome = 'PASS'
-        Detail  = "attributes, datatypes, retained flags, /set round-trip, alert/sleeping and re-announce all conform"
+        Detail  = "attributes, datatypes, retained flags, /set round-trip, alert/sleeping, a refused transition and re-announce all conform"
     }
 }
 

--- a/src/integrationTests/HomieClientCheck/Program.cs
+++ b/src/integrationTests/HomieClientCheck/Program.cs
@@ -8,6 +8,7 @@ using SmartHome.Homie.V4;
 using SmartHome.Homie.V4.Builder;
 using SmartHome.Homie.V4.Enums;
 using SmartHome.Homie.V4.EventArgs;
+using SmartHome.Homie.V4.Extensions;
 using SmartHome.Homie.V4.Properties;
 using SmartHome.Mqtt;
 using SmartHome.Networking;
@@ -33,12 +34,17 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
         // The lifecycle property is how the host drives $state: publishing 'alert',
         // 'sleeping' or 'ready' to its /set topic moves the device, which is the only
         // way to exercise those states from outside.
-        private const string LifecycleReady = "ready";
-        private const string LifecycleAlert = "alert";
-        private const string LifecycleSleeping = "sleeping";
+        //
+        // The names are taken from the State enum rather than spelled out here. They are
+        // the convention's own vocabulary and StateExtensions.GetString() already owns
+        // it; a private copy would drift from $state, which is precisely the value the
+        // host compares this property against. This array is the single source for both
+        // the $format string and the set of commands HandleLifecycleCommand accepts.
+        private static readonly State[] LifecycleStates = { State.Ready, State.Alert, State.Sleeping };
 
         private static IHomieClient _homieClient;
         private static IntegerProperty _counter;
+        private static EnumProperty _lifecycle;
 
         public static void Main()
         {
@@ -99,12 +105,33 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
                     .AddIntegerProperty("counter", "Counter", 0)
                         .WithRetained(false)
                     .BuildProperty(out _counter)
-                    .AddEnumProperty("lifecycle", "Lifecycle control", LifecycleReady)
+                    .AddEnumProperty("lifecycle", "Lifecycle control", State.Ready.GetString())
                         .WithSettable(true)
-                        .WithFormat($"{LifecycleReady},{LifecycleAlert},{LifecycleSleeping}")
-                    .BuildProperty()
+                        .WithFormat(BuildLifecycleFormat())
+                    .BuildProperty(out _lifecycle)
                 .BuildNode()
             .BuildDevice();
+        }
+
+        // Not StringUtils.Join: it takes string[], so using it would mean building an
+        // intermediate array of names to join -- two passes and an extra allocation for a
+        // three-element list. SmartHome.Text is on the device either way (SmartHome.Homie
+        // references it), so the trade here is about the second pass, not the assembly.
+        private static string BuildLifecycleFormat()
+        {
+            var format = new StringBuilder();
+
+            for (var i = 0; i < LifecycleStates.Length; i++)
+            {
+                if (i > 0)
+                {
+                    format.Append(',');
+                }
+
+                format.Append(LifecycleStates[i].GetString());
+            }
+
+            return format.ToString();
         }
 
         private static void HandleCommand(HomieCommandEventArgs args)
@@ -119,21 +146,45 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
                 return;
             }
 
-            switch (payload)
+            HandleLifecycleCommand(payload);
+
+            // Publish what the device actually is, over the optimistic reflection the
+            // library already made.
+            //
+            // Reflecting a command onto its own property is right for an ordinary
+            // property, but this one's value is a *request*, and a request can be turned
+            // down: Device.CanChangeState refuses illegal transitions (alert -> sleeping
+            // among them), and an unknown payload is not a state at all. Either way the
+            // reflection would leave the retained store advertising a state the device is
+            // not in, contradicting the $state published right beside it -- and retained,
+            // so every controller connecting later reads the contradiction too.
+            //
+            // Actuators copying this device should do the same: reflect the outcome, not
+            // the command.
+            _lifecycle.Update(_homieClient.State.GetString());
+        }
+
+        private static void HandleLifecycleCommand(string payload)
+        {
+            foreach (var state in LifecycleStates)
             {
-                case LifecycleAlert:
-                    Debug.WriteLine($"HomieClientCheck: alert -> {_homieClient.Alert()}");
-                    return;
-                case LifecycleSleeping:
-                    Debug.WriteLine($"HomieClientCheck: sleep -> {_homieClient.Sleep()}");
-                    return;
-                case LifecycleReady:
-                    Debug.WriteLine($"HomieClientCheck: ready -> {_homieClient.Ready()}");
-                    return;
-                default:
-                    Debug.WriteLine($"HomieClientCheck: unknown lifecycle command '{payload}'.");
-                    return;
+                if (payload != state.GetString())
+                {
+                    continue;
+                }
+
+                var applied = state switch
+                {
+                    State.Alert => _homieClient.Alert(),
+                    State.Sleeping => _homieClient.Sleep(),
+                    _ => _homieClient.Ready(),
+                };
+
+                Debug.WriteLine($"HomieClientCheck: '{payload}' -> {applied}");
+                return;
             }
+
+            Debug.WriteLine($"HomieClientCheck: unknown lifecycle command '{payload}'.");
         }
 
         // The runner cycles the broker while this device runs, so it can boot with no


### PR DESCRIPTION
Closes #13.

Also closes #34.

Started as the `lifecycle` reflection fix. Running it on hardware turned up three further
defects in the conformance check itself, and the timing question the first hardware run
raised is now answered with measurements rather than arithmetic. Six commits, each standing
on its own.

## 1. Reflect the outcome, not the command

`HomieClient.HandleIncomingMessage` calls `property.Set(message)` before raising
`OnCommand`, so a settable property reflects the command optimistically. That is correct
for an ordinary property — a controller writes `21.5`, the device publishes `21.50` back —
but the `lifecycle` property's value is a *request*, and a request can be turned down:

- `Device.CanChangeState` forbids `alert -> sleeping` (alert may only return to `ready`, or disconnect)
- an unknown payload is not a state at all

In both cases the retained store was left advertising `matrix/lifecycle=sleeping` next to
`$state=alert`. Both are retained, so this is not a transient that goes by on the wire —
every controller that connects afterwards reads the contradiction out of the broker's
store. The conformance check only asserted `$state`, so it passed.

`HandleCommand` now publishes the device's actual state over the reflection once the
command has been applied or refused. `CLAUDE.md` carries the rule as the third thing to
know when writing an actuator:

> Reflect the outcome, not the command. […] Publish the real value over it once the
> command has been applied or refused, or the retained store advertises a state the device
> is not in, to every controller that connects afterwards.

`HomieClientCheck` is the reference device the actuators (#11, #12) are meant to copy,
which is what makes this worth fixing before they exist rather than after.

The lifecycle vocabulary now comes from the `State` enum. `StateExtensions.GetString()`
already owns those names; `HomieClientCheck` had its own three consts, spelled them again
into the `$format` string, and the runner spells them a third time. One array is now the
single source for both the `$format` string and the set of commands the dispatch accepts,
and the host asserts `$format` still reads `ready,alert,sleeping` — so if the derivation
breaks, that is what notices. The PowerShell/C# boundary keeps its own copy, deliberately:
the runner cannot call into the device. That is the same unavoidable split #20 notes for
the `[ITEST]` marker grammar.

The suite now asks for `alert -> sleeping` **on purpose** — the one transition the drive
sequence previously went out of its way to avoid — and asserts that neither `$state` nor
the lifecycle property moved. The five drive steps became a table so the refusal sits
between `alert` and `ready` instead of needing its own `alert` / `ready` round trip.

## 2. A retransmitted duplicate must not erase a proved retain flag

The first hardware run failed, and not because of the change above. Three attributes of 53
came back as "not retained": `color-value/$name`, `color-value/$datatype`,
`lifecycle/$format`. A steady-state probe then showed all three retained, six snapshots out
of six, so the store was never the problem.

A 40s capture of one re-announce shows what is: a retransmitted tail of the last property's
attributes, and counter values arriving out of order — 146 after 147. Nothing but
retransmission produces that. Confirmed in the sibling checkout rather than assumed:
`MqttClient.cs:1919` sets `DupFlag = true` when it resends an in-flight message, up to
`MqttSettings.MaximumAttemptsRetry` (3).

`Get-HomieRetainedSnapshot` kept the last message per topic, so a live duplicate arriving
*after* the replayed copy overwrote it with `retain=0`. The attribute was in the store the
whole time; the evidence that it was got thrown away.

The merge rule is now: a repeat of the **same** payload only adds to what is known about a
topic. A **different** payload still replaces both fields — otherwise a value delivered
only live would inherit the retained-ness of the value it replaced, which is precisely the
bug #31's flag check exists to catch. That is why this is not simply an `-or` over the flag.

## 3. Phase timing, and what the "unexplained 14s" actually was

The first hardware run took 73s against a 59s baseline, and the suite reported one number
per test, so there was nothing to attribute the difference to. The check is now timed by
phase, with snapshots counted per phase and the deploy separated from the measurement:

```
  phase breakdown (3s per snapshot):
    announce                 10.1s   3 snapshot(s)
    attributes                0.0s   0 snapshot(s)
    /set round-trip           3.4s   1 snapshot(s)
    lifecycle                16.8s   5 snapshot(s)
    re-announce              12.9s   2 snapshot(s)
```

Almost all of this check's wall clock is 3s snapshot windows, and the poll loops take an
unpredictable number of them, so snapshots-per-phase is the number worth having next to the
seconds.

Eight runs on 2026-08-26 settle the question. A healthy check is **43.1–44.1s, a spread
under one second across seven runs**. Deploy is 16–29s and swings independently. So the 73s
was an ordinary 43s check behind a slow flash — the delta was never in the check, and the
single figure could not show that.

The `+3s` estimate for the refusal step was right, and is now checkable rather than
asserted: lifecycle costs 5 snapshots where it cost 4, and a snapshot is 3.4s.

Phase seconds render in the invariant culture. The first run printed `16,7s` on this
machine, which reads as a thousands separator to everyone who was not sitting at it — and
these lines exist to be quoted into pull requests and issues.

## 4. Retry a controller command instead of timing out on a lost one

One of those eight runs failed, and it exposed a defect in the check that predates this
branch. The check published each `/set` exactly once and then only polled for the echo. A
`/set` is non-retained, as the convention requires of a controller, so a command reaching
the broker while the device is not yet subscribed is dropped outright — nothing remains in
the store for the device to collect when it does subscribe. That single lost message became
the full `CommandTimeoutSeconds` of polling for an echo that could never arrive, and five
conformance failures against a device that was working.

The failing run was the only one of the eight whose announce wait was satisfied by its
first snapshot rather than its third — the only one, in other words, that reached the `/set`
phase early. Its `/set` phase spent 33.4s over 10 snapshots with all five properties still
holding their boot values, while the lifecycle commands thirty seconds later were applied
normally.

Commands are now published at the top of every poll round rather than once before the loop,
and only for properties still pending. `Wait-ForRetainedValue` gains the same option, so the
four lifecycle steps that wait for a state transition retry their command too; the announce
and re-announce waits pass nothing and are unaffected.

Retrying is the only fix available at this layer. MQTT gives a publisher no signal about who
is subscribed, and `$state=ready` is the device's claim about itself rather than about the
broker's routing table, so the host cannot wait for the condition it actually needs. On a
healthy run this costs nothing: the first round succeeds and no command is ever re-sent.

## 5. Prove the refused transition from the wire, not from where it settled

Closes #34, which the retry in section 4 exposed rather than caused. The refused step read
a settled snapshot, and a command that never arrived leaves exactly the snapshot a refused
one does — so a lost `/set` passed it as a refusal. Unlike the polls around it, this step
cannot retry its way out: its whole assertion is that nothing changes, so there is no echo
to wait on.

The difference is on the wire. A refusal that actually happened puts `sleeping` (the
library's optimistic reflection) and then `alert` (the device's correction) on the property
topic, in that order. A command that never arrived puts neither. The step now opens its
capture window before publishing and reads that sequence, with the retained replay excluded
— the replayed copy predates the command and says nothing about whether it arrived.

Three failures now separate what used to be one silent pass: the command never reaching the
property, the reflection being left standing, and the correction arriving before the
reflection rather than over it. The middle one is the defect section 1 fixes.

`Get-HomieRetainedSnapshot` is split into `Start-HomieCapture`, `Stop-HomieCapture` and
`ConvertTo-HomieSnapshot`, composing to what it was for its existing callers. That split is
what lets this step publish *inside* the window. `Start-HomieCapture` also gains
`-WaitForConnectSeconds`, because `Start-Process` returns before `mosquitto_sub` has a
session and a publish issued immediately after could otherwise beat the subscriber onto the
broker — which would read as "the command never arrived" and fail a healthy device.

## Known limits, filed rather than fixed here

- Why the device missed those five commands is not established. The library subscribes
  before it announces, and both travel the same ordered connection, so at the broker the
  SUBSCRIBE precedes the `$state` publish — which argues against the simple "published too
  early" story. The retry removes the symptom without proving the cause. Filed, along with
  the reason it was hard to chase: conformance runs capture no device log.

## Considered and not done

Making the library itself defer the reflection until the app confirms the command. That
would mean `OnCommand` returning an accept/reject result, which is a real API change to
`IHomieClient` and a design decision rather than a bug fix. The device-level correction is
also the more honest layering: only the app knows whether a command succeeded.

## Testing done

- CI green on every commit.
- **16 `HomieClientCheck` runs on real hardware** (ESP32 on COM3, local Mosquitto):
  - 8 before the retry fix — 7 PASS, 1 FAIL (the FAIL is analysed in section 4)
  - 3 after the retry fix — 3 PASS, check at 43.4s, 50.0s and 43.5s
  - 2 after the wire assertion — PASS, check at 44.1s and 43.3s, snapshot counts unchanged
  - 2 negative runs, each reverted afterwards, one per failure mode section 5 adds:

| injected defect | result |
|---|---|
| `_lifecycle.Update()` commented out in `HandleCommand` — the #13 defect itself | FAIL, **2** failures: the settled assertion, plus `device left the reflected 'sleeping' on matrix/lifecycle and never published 'alert' over it` |
| the refused step's `/set` published to a topic nothing subscribes to — a lost command | FAIL, **1** failure: `refused 'sleeping' never reached matrix/lifecycle -- the command was lost, so nothing about the refusal was measured` |

  The second run is the one that matters for #34. Both settled assertions *passed* — `$state`
  was `alert`, the property was `alert` — so before this change that run would have been a
  clean PASS with the command never arriving. That is the vacuous pass #34 describes,
  reproduced on hardware and now caught, with nothing else in the check reacting to it.
- The three passes after the retry fix cannot prove a one-in-eight race fixed, and are not
  offered as that. They show no regression; the retry stands on the mechanism rather than
  on the sample.
- The positive runs also settle a doubt about section 5's mechanism: the assertion depends
  on the tail of a capture reaching disk, where every existing use only needed the bulk
  retained replay, and a buffered tail lost to the process-tree kill would have failed a
  healthy device. It does not.
- Section 5's third failure mode — the correction arriving *before* the reflection rather
  than over it — is not exercised on hardware. Producing it means reordering two publishes
  inside `HandleCommand` against the library's own ordering, which is a contrived device
  rather than a defect anyone would write. The ordering comparison itself was checked in
  isolation.
- The other four integration tests were not re-run. Only `HomieClientCheck` reaches
  `Invoke-HomieConformanceCheck`; the rest are `DeviceMarker` or `BrokerOutage` and read the
  device log or the live `homie/#` log instead.
- RoomSensor has been redeployed, so the device is back to doing its real job.
