### PR TITLE
feat(scripts): keep the evidence a conformance failure has to be read from

### DIFF
--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -274,35 +274,48 @@ function Start-DeviceDebugCapture {
         $powerShellExe, $watchScript, $TimeoutSeconds, $LogPath
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
-    return @{ ProcessId = $process.Id; Path = $LogPath }
+    # A record, not a bare pid. This launcher can legitimately be dead by the time the
+    # check returns -- a monitor that cannot reach the device gives up after 15s and
+    # takes its cmd.exe with it -- and minutes then pass before anything stops it, which
+    # is long enough for Windows to hand the pid to something else. That is the case
+    # New-SmartHomeProcessRecord carries a name and a start time for. -Tree because the
+    # real work is in the grandchild.
+    return @{
+        Record = New-SmartHomeProcessRecord -Label 'device debug monitor' -Process $process -Tree
+        Path   = $LogPath
+    }
 }
 
 function Stop-DeviceDebugCapture {
-    # Killed as a tree rather than asked to stop: the monitor listens for a fixed
-    # duration and has no way to be told the check is over. The COM port is released
-    # with the process, so the next test's deploy is not affected.
+    # Killed rather than asked to stop: the monitor listens for a fixed duration and has
+    # no way to be told the check is over. The COM port is released with the process, so
+    # the next test's deploy is not affected.
     param([hashtable]$Capture)
 
     if ($null -eq $Capture) {
         return
     }
 
-    # Only if it is still running. A monitor that could not attach exits on its own and
-    # takes its cmd.exe launcher with it, and taskkill then writes "process not found"
-    # to stderr -- which under this script's $ErrorActionPreference = 'Stop' is a
-    # terminating NativeCommandError, thrown out of the finally that calls this and
+    # Through the recorded-process helper, which stops the tree only when pid, name and
+    # start time all still match, and warns instead of killing when the pid has been
+    # recycled. It also covers the already-exited case: taskkill on a dead pid writes to
+    # stderr, and under this script's $ErrorActionPreference = 'Stop' that is a
+    # terminating NativeCommandError -- thrown out of the finally that calls this, and
     # replacing the verdict the check had already reached. Measured, not assumed:
     # Stop-SmartHomeProcessTree on a dead pid throws here.
-    if (Get-Process -Id $Capture.ProcessId -ErrorAction SilentlyContinue) {
-        Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
-    }
+    Stop-SmartHomeRecordedProcess -Record $Capture.Record | Out-Null
 
-    # An attach failure must not change a verdict the broker already decided, so this
-    # warns rather than throwing -- but it says so, because an empty log is otherwise
-    # indistinguishable from a device that said nothing.
+    # A capture that recorded nothing must not change a verdict the broker already
+    # decided, so this warns rather than throwing -- but it says so, because an empty log
+    # is otherwise indistinguishable from a device that said nothing.
+    #
+    # It does not name an attach failure as the cause, because that is the one thing it
+    # cannot be: the child's stderr is redirected into this same file, so a monitor that
+    # found no device leaves its "No nanoFramework device found on ..." in here. Nothing
+    # at all on either stream means the child never got that far.
     $captured = Get-Item -LiteralPath $Capture.Path -ErrorAction SilentlyContinue
     if ($null -eq $captured -or $captured.Length -eq 0) {
-        Write-Warning ("No managed debug output was captured ({0}). The monitor could not attach; the verdict is unaffected, but there is no device-side evidence behind it." -f $Capture.Path)
+        Write-Warning ("No managed debug output was captured, and the monitor reported nothing either ({0}) -- so it never ran. Check that dotnet is on PATH. The verdict is unaffected, but there is no device-side evidence behind it." -f $Capture.Path)
     }
 }
 
@@ -1522,7 +1535,16 @@ finally {
         # here would replace whatever outcome the suite had already reached. Which also
         # means the archiving Stop-SuiteBroker does has to be repeated here, for the
         # generation that covers the end of the last test.
-        Save-BrokerEvidence -Port $mqttPort
+        # Kept apart from the teardown below so the two failures stay distinguishable,
+        # and both inside a catch: this is the finally, and a throw from either would
+        # escape it and take the summary and the exit code with it.
+        try {
+            Save-BrokerEvidence -Port $mqttPort
+        }
+        catch {
+            Write-Warning "Could not preserve the last broker logs: $($_.Exception.Message)"
+        }
+
         try {
             & $stopEnvScript
         }

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -22,7 +22,9 @@
 
     On success this prints a one-line-per-test summary and exits 0 -- nothing else to
     look at. On failure it exits 1 and prints the captured device log path for the
-    failing test, which is where any real investigation starts.
+    failing test, which is where any real investigation starts. Alongside it in the same
+    directory are the broker's own log and the homie/# log for every broker generation
+    the run went through, kept because the dev environment deletes both at teardown.
 
     *** HARDWARE: this flashes and runs code on the physical device on the configured
     COM port, once per test. Treat it exactly like Deploy-ToDevice.ps1. ***
@@ -42,8 +44,9 @@
     tearing down someone else's broker is not theirs to do.
 
 .PARAMETER LogDirectory
-    Where to write the per-test device logs. Defaults to a timestamped folder under
-    the system temp directory; the path is printed at the end of the run.
+    Where to write the per-test device logs, and the preserved broker and homie/# logs
+    that go with them. Defaults to a timestamped folder under the system temp directory;
+    the path is printed at the end of the run.
 
 .EXAMPLE
     .\scripts\Run-IntegrationTests.ps1
@@ -181,6 +184,128 @@ function Get-TestProjectPath {
     return "src\integrationTests\$TestName\$TestName.nfproj"
 }
 
+# ── Evidence ──────────────────────────────────────────────────────────────────
+# What a failed run leaves behind to be read afterwards.
+#
+# Both broker-side logs are transient by design: Start-DevEnv.ps1 truncates them on
+# every start and Stop-DevEnv.ps1 deletes them on every stop, and the host-decided
+# checks cycle the broker mid-test. So by the time a verdict is being investigated the
+# wire evidence behind it is already gone -- which is why the HomieClientCheck run that
+# lost all five /set commands (issue #35) could not be chased any further than the
+# summary line. Each generation is copied into $LogDirectory before it is taken away.
+
+# Which test the next preserved generation belongs to, and how many have been kept.
+# Declared here rather than left to the first assignment because Set-StrictMode
+# -Version Latest makes reading an unset variable a terminating error, and the first
+# read happens in the pre-flight teardown, before any test has run.
+$script:evidenceLabel = 'suite'
+$script:evidenceGeneration = 0
+
+function Save-BrokerEvidence {
+    param([Parameter(Mandatory = $true)][string]$Port)
+
+    $script:evidenceGeneration++
+
+    # Numbered, not timestamped: the number is also the count of broker generations a
+    # run went through, which is the thing a reader wants to line up against the phase
+    # breakdown.
+    foreach ($log in @(
+        @{ Kind = 'BrokerLog';     Name = 'broker' }
+        @{ Kind = 'SubscriberLog'; Name = 'homie' }
+    )) {
+        $source = Get-SmartHomeDevEnvPath -Port $Port -Kind $log.Kind
+        if (-not (Test-Path -LiteralPath $source)) {
+            continue
+        }
+
+        $destination = Join-Path $LogDirectory ("{0}-{1:d2}-{2}.log" -f $script:evidenceLabel, $script:evidenceGeneration, $log.Name)
+        try {
+            # Both files are still open for writing by the processes producing them.
+            # Copy-Item reads them anyway -- measured against a live Mosquitto 2.0.22 log
+            # and the cmd.exe redirect behind the homie/# subscriber.
+            Copy-Item -LiteralPath $source -Destination $destination -ErrorAction Stop
+        }
+        catch {
+            # Preserving evidence must never become the reason a run fails, and this is
+            # called from a finally where a throw would replace the suite's own outcome.
+            Write-Warning ("Could not preserve {0}: {1}" -f $source, $_.Exception.Message)
+        }
+    }
+}
+
+function Start-DeviceDebugCapture {
+    # Managed debug output captured alongside a host-decided check, whose verdict comes
+    # from the broker rather than from the device.
+    #
+    # Only the device's own log can say whether it saw a command at all, and the
+    # conformance path never took one -- so a lost /set left the device side of issue #35
+    # entirely unobserved.
+    #
+    # -NoReboot, unlike the DeviceMarker captures further down. Those reboot because a
+    # missed boot is indistinguishable there from a device that never reported, and their
+    # verdict is read out of the log. Here a few missed lines cost only evidence, while a
+    # reboot would restart the announce the check is about to measure.
+    #
+    # Launched through cmd.exe with ShellExecute for the handle-inheritance reason
+    # documented in Start-DevEnv.ps1: -RedirectStandardOutput forces UseShellExecute=false
+    # and hands this script's own stdout to a child that outlives the call.
+    param(
+        [Parameter(Mandatory = $true)][string]$LogPath,
+
+        # A backstop, not a measurement. The capture is stopped when the check returns;
+        # this only bounds a monitor left behind by a runner that died.
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    Remove-Item -Path $LogPath -Force -ErrorAction SilentlyContinue
+
+    # The host this script is running under, so a pwsh session doesn't spawn a
+    # Windows PowerShell child (or the reverse) with a different view of the module path.
+    $powerShellExe = (Get-Process -Id $PID).Path
+    if (-not $powerShellExe) {
+        $powerShellExe = Join-Path $PSHOME 'powershell.exe'
+    }
+
+    # -ExecutionPolicy Bypass because a fresh process does not inherit the policy the
+    # caller was started under: a machine set to Restricted runs this suite as
+    # `powershell -ExecutionPolicy Bypass -File ...`, and the child would otherwise
+    # refuse to load a script the parent is already executing.
+    $command = '/c ""{0}" -NoProfile -ExecutionPolicy Bypass -File "{1}" -DurationSeconds {2} -NoBuild -NoReboot > "{3}" 2>&1"' -f `
+        $powerShellExe, $watchScript, $TimeoutSeconds, $LogPath
+    $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
+
+    return @{ ProcessId = $process.Id; Path = $LogPath }
+}
+
+function Stop-DeviceDebugCapture {
+    # Killed as a tree rather than asked to stop: the monitor listens for a fixed
+    # duration and has no way to be told the check is over. The COM port is released
+    # with the process, so the next test's deploy is not affected.
+    param([hashtable]$Capture)
+
+    if ($null -eq $Capture) {
+        return
+    }
+
+    # Only if it is still running. A monitor that could not attach exits on its own and
+    # takes its cmd.exe launcher with it, and taskkill then writes "process not found"
+    # to stderr -- which under this script's $ErrorActionPreference = 'Stop' is a
+    # terminating NativeCommandError, thrown out of the finally that calls this and
+    # replacing the verdict the check had already reached. Measured, not assumed:
+    # Stop-SmartHomeProcessTree on a dead pid throws here.
+    if (Get-Process -Id $Capture.ProcessId -ErrorAction SilentlyContinue) {
+        Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
+    }
+
+    # An attach failure must not change a verdict the broker already decided, so this
+    # warns rather than throwing -- but it says so, because an empty log is otherwise
+    # indistinguishable from a device that said nothing.
+    $captured = Get-Item -LiteralPath $Capture.Path -ErrorAction SilentlyContinue
+    if ($null -eq $captured -or $captured.Length -eq 0) {
+        Write-Warning ("No managed debug output was captured ({0}). The monitor could not attach; the verdict is unaffected, but there is no device-side evidence behind it." -f $Capture.Path)
+    }
+}
+
 # ── Broker lifetime ───────────────────────────────────────────────────────────
 # The stop/start recipe the host-decided checks need, in one place instead of six.
 #
@@ -205,6 +330,10 @@ function Start-SuiteBroker {
 
 function Stop-SuiteBroker {
     param([Parameter(Mandatory = $true)][string]$Port)
+
+    # Before the stop, not after: Stop-DevEnv.ps1 deletes the broker and homie/# logs
+    # as part of tearing the environment down, and a restart truncates them again.
+    Save-BrokerEvidence -Port $Port
 
     try {
         & $stopEnvScript | Out-Null
@@ -805,6 +934,25 @@ function Write-ConformancePhaseBreakdown {
     }
 }
 
+function Get-ConformanceCaptureSeconds {
+    # A ceiling for the debug capture that runs alongside the check, derived from the
+    # check's own timeouts rather than guessed: the announce wait, the /set round trip,
+    # one per lifecycle step, and the re-announce wait, plus slack for the snapshot
+    # windows and the broker restart between them.
+    #
+    # Deliberately loose. A capture that ends early takes the device-side evidence with
+    # it exactly when the run was slow enough to be worth reading, and nothing waits out
+    # this window -- Stop-DeviceDebugCapture closes it as soon as the check returns.
+    param([hashtable]$Settings)
+
+    $lifecycleSteps = 5
+
+    return $Settings.SettleSeconds +
+           $Settings.RecoverySeconds +
+           (($lifecycleSteps + 1) * $Settings.CommandTimeoutSeconds) +
+           60
+}
+
 function Invoke-HomieConformanceCheck {
     # Measures a purpose-built device against the Homie v4 convention, from the
     # broker's side. Every assertion is collected rather than thrown, so one run
@@ -1217,6 +1365,7 @@ try {
     foreach ($testName in $Tests) {
         $settings = $testCatalog[$testName]
         $logFile = Join-Path $LogDirectory "$testName.log"
+        $script:evidenceLabel = $testName
 
         Write-Host ('=' * 69)
         Write-Host ("Integration test: {0}" -f $testName) -ForegroundColor Cyan
@@ -1253,7 +1402,15 @@ try {
             # the broker is restarted.
             $verdict = $null
             if ($settings.Kind -eq 'HomieConformance') {
-                $verdict = Invoke-HomieConformanceCheck -Settings $settings -Port $mqttPort
+                $debugCapture = Start-DeviceDebugCapture -LogPath $logFile `
+                                                         -TimeoutSeconds (Get-ConformanceCaptureSeconds -Settings $settings)
+                try {
+                    $verdict = Invoke-HomieConformanceCheck -Settings $settings -Port $mqttPort
+                }
+                finally {
+                    Stop-DeviceDebugCapture -Capture $debugCapture
+                }
+
                 Write-ConformancePhaseBreakdown
             }
             elseif ($settings.Kind -eq 'BrokerOutage') {
@@ -1362,7 +1519,10 @@ finally {
     if ($brokerStarted) {
         Write-Host ""
         # Raw call, deliberately not Stop-SuiteBroker: this is a finally, and a throw
-        # here would replace whatever outcome the suite had already reached.
+        # here would replace whatever outcome the suite had already reached. Which also
+        # means the archiving Stop-SuiteBroker does has to be repeated here, for the
+        # generation that covers the end of the last test.
+        Save-BrokerEvidence -Port $mqttPort
         try {
             & $stopEnvScript
         }
@@ -1394,7 +1554,8 @@ Write-Host ("  {0,-20} {1,-12} {2,-16}" -f 'TOTAL', '', ("{0}s ({1}s deploy)" -f
 $failed = @($results | Where-Object { $_.Outcome -ne 'PASS' })
 
 Write-Host ""
-Write-Host ("Device logs: {0}" -f $LogDirectory) -ForegroundColor DarkGray
+Write-Host ("Logs: {0}" -f $LogDirectory) -ForegroundColor DarkGray
+Write-Host "  <test>.log, plus <test>-NN-broker.log / -homie.log per broker generation" -ForegroundColor DarkGray
 
 if ($failed.Count -gt 0) {
     Write-Host ""


### PR DESCRIPTION
Closes the evidence half of #35. The intermittent lost-command failure itself is **not** touched here and #35 stays open for it.

## The gap

A `HomieConformance` run left nothing behind to investigate:

- Managed debug output was captured only for `DeviceMarker` tests. `$logFile` was written for every other kind and stayed empty for this one, so the conformance path never produced a device log at all.
- Both broker-side logs are transient by design. `Start-DevEnv.ps1` truncates them on every start, `Stop-DevEnv.ps1` deletes them on every stop, and the host-decided checks cycle the broker mid-test — so the wire evidence for a verdict is gone before anyone reads the verdict.

When `HomieClientCheck` lost all five of its `/set` commands in one run of eight, the summary line was all there was.

## The change

All of it in `scripts/Run-IntegrationTests.ps1`.

- **Managed debug output across a conformance run.** `Start-DeviceDebugCapture` / `Stop-DeviceDebugCapture` run `Watch-DeviceDebugOutput.ps1` alongside the check and write `<test>.log`, the same file the `DeviceMarker` path already produced.
- **Broker and `homie/#` logs preserved per generation.** `Save-BrokerEvidence` copies both into the run's `$LogDirectory` before every broker stop, named `<test>-NN-broker.log` / `<test>-NN-homie.log`. It runs from `Stop-SuiteBroker`, which is the single funnel every stop and restart goes through, plus once more in the suite's own teardown.

Three decisions worth stating:

- The capture runs with **`-NoReboot`**, unlike the `DeviceMarker` captures. Those reboot because a missed boot is indistinguishable there from a device that never reported, and their verdict is read out of the log. Here the verdict comes from the broker, so missed lines cost only evidence — while a reboot would restart the announce the check is about to measure, which is the timing #35 is about.
- Its duration is a **backstop, not a wait**, derived from the check's own timeouts (`Get-ConformanceCaptureSeconds`, 420s at the current catalog values). The capture is closed as soon as the check returns.
- **Neither addition can change a verdict.** A monitor that cannot attach warns and leaves an empty log. A log that cannot be copied warns and is skipped. Stopping the capture kills the process tree only when it is still running — `taskkill` on a dead pid writes to stderr, and under this script's `$ErrorActionPreference = 'Stop'` that is a terminating `NativeCommandError` thrown out of the `finally` that stops the capture, which would replace the verdict the check had already reached. That one is measured, not assumed.

#20 and #21 propose restructuring the same verdict-dispatch area. The dispatch itself grows by eight lines; everything else is new functions above it.

## Verified on hardware

Full suite on the real ESP32, all five green, and the summary now names what else is in the log directory:

```
  WifiCheck            PASS         22s (17s deploy) connected to the configured WiFi network
  MqttCheck            PASS         20s (15s deploy) round-trip through 192.168.1.238 on smarthome-test/echo
  Bmp280Check          PASS         19s (14s deploy) 24.262009808258154°C, 942.05946376109111hPa, 54.315140903821391%RH
  HomieClientCheck     PASS         64s (18s deploy) attributes, datatypes, retained flags, /set round-trip, alert/sleeping, a refused transition and re-announce all conform
  MqttReconnectCheck   PASS         50s (15s deploy) republished and stayed subscribed across outages of 3s, 20s
  TOTAL                             175s (79s deploy)
```

What the run left behind — `HomieClientCheck.log` is the file that did not exist before, and `MqttReconnectCheck` contributes a generation per outage:

```
   10474  Bmp280Check.log
  127497  HomieClientCheck-01-broker.log
    5927  HomieClientCheck-01-homie.log
   20634  HomieClientCheck.log
    8657  MqttCheck.log
   47188  MqttReconnectCheck-02-broker.log
    3992  MqttReconnectCheck-02-homie.log
    1537  MqttReconnectCheck-03-broker.log
      51  MqttReconnectCheck-03-homie.log
    1537  MqttReconnectCheck-04-broker.log
      51  MqttReconnectCheck-04-homie.log
    5650  MqttReconnectCheck-05-broker.log
     706  MqttReconnectCheck-05-homie.log
    1510  WifiCheck.log
```

Checked against the three questions #35 says a repeat of the failure would need answered:

**Did the device log a reconnect** — `HomieClientCheck.log`:

```
MQTT connection lost. Reconnect handler called.
Start reconnect...
Trying to reconnect once...
Reconnect attempt finished with result: 0.
```

**Did the command handler ever fire** — one line per `/set`, same file:

```
HomieClientCheck: command on 'string-value' -> 'commanded'
HomieClientCheck: command on 'enum-value' -> 'high'
HomieClientCheck: command on 'boolean-value' -> 'true'
HomieClientCheck: command on 'float-value' -> '21.5'
HomieClientCheck: command on 'integer-value' -> '42'
```

**What the broker did with the five PUBLISH packets** — `HomieClientCheck-01-broker.log`, which holds 702 PUBLISH lines including:

```
Received PUBLISH from auto-22A052D9-... (d0, q0, r0, m0, 'homie/homie-client-check/matrix/string-value/set', ... (9 bytes))
Received PUBLISH from auto-3D2E5C5E-... (d0, q0, r0, m0, 'homie/homie-client-check/matrix/enum-value/set', ... (4 bytes))
Received PUBLISH from auto-CBC8FE36-... (d0, q0, r0, m0, 'homie/homie-client-check/matrix/boolean-value/set', ... (4 bytes))
Received PUBLISH from auto-12815759-... (d0, q0, r0, m0, 'homie/homie-client-check/matrix/float-value/set', ... (4 bytes))
Received PUBLISH from auto-0CA07ECD-... (d0, q0, r0, m0, 'homie/homie-client-check/matrix/integer-value/set', ... (2 bytes))
```

The run was healthy, so this is the shape of the evidence rather than a reproduction of the failure — but it is the evidence that was missing.

Non-hardware checks alongside it: both scripts parse clean; `Save-BrokerEvidence` exercised against a live Mosquitto 2.0.22 broker log and `homie/#` subscriber log (both held open for writing by their producers, both copied); the capture start/stop exercised against a stub standing in for the monitor, confirming the arguments reach it, output streams to the log, and the tree is killed; and the dead-launcher path confirmed to warn rather than throw under `$ErrorActionPreference = 'Stop'`.

RoomSensor was redeployed afterwards, so the device is back on its real job rather than carrying `MqttReconnectCheck`.

Refs #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)