### PR TITLE
docs(homie): keep the command reflection in the app, and pin the rule in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ device owns a connection rather than being one, and exposing `Publish`/`Subscrib
 let an app publish an attribute non-retained or `$state` out of order. The `Device` model (built
 with `HomieDeviceBuilder`) says what the device *is*; `IHomieClient` is what you *do* with it.
 
-Three things to know when writing an actuator (Irrigation, Oven):
+Four things to know when writing an actuator (Irrigation, Oven):
 
 - Act on `IHomieClient.OnCommand`, not on `property.OnUpdate`. The property event fires both
   when a controller sets a value and when the device updates its own, and cannot tell them
@@ -195,8 +195,22 @@ Three things to know when writing an actuator (Irrigation, Oven):
   whose value is a *request* the device can turn down — an illegal `$state` transition, an out
   of range setpoint, a relay that failed to close. Publish the real value over it once the
   command has been applied or refused, or the retained store advertises a state the device is
-  not in, to every controller that connects afterwards. `HomieClientCheck` does this for its
-  `lifecycle` property and the conformance suite asserts it.
+  not in, to every controller that connects afterwards. **After** the reflection, never instead
+  of it: the library's publish is already out by the time the handler runs, so a device that
+  publishes its real value first only has it overwritten. `HomieClientCheck` does this for its
+  `lifecycle` property, the conformance suite asserts the order on the wire, and
+  `HomieClient_Reflects_The_Command_Before_The_Handler_Can_Correct_It` pins the same pattern in
+  the unit suite, where CI can run it. Issue #33 asked whether the library should take this over
+  by having `OnCommand` return accept/reject, and was closed as working-as-intended — the
+  reasoning is in that issue, and worth reading before proposing it again.
+- Don't block `OnCommand`. It runs on M2Mqtt's event-dispatch thread, and that one thread
+  delivers every incoming PUBLISH plus SUBACK, PUBACK, UNSUBACK and the connection-closed
+  signal (`MqttClient.DispatchEventThread` in the sibling `nanoFramework.m2mqtt` checkout). A
+  handler that waits on hardware stalls the client's whole event stream, this device's next
+  `/set` included. An outcome that takes time — a relay confirming, a setpoint validated
+  against a sensor read — belongs on the device's own thread: hand the work off, return, and
+  publish the real value onto the property when it lands. That is the same "reflect the
+  outcome" publish, just later.
 
 `HomieClient` owns its MQTT session and must: Homie v4 requires the connection to carry a last
 will setting `homie/[device-id]/$state` to `lost`, and a will can only be declared in CONNECT.

--- a/src/common/Homie/V4/EventArgs/HomieCommandEventArgs.cs
+++ b/src/common/Homie/V4/EventArgs/HomieCommandEventArgs.cs
@@ -8,8 +8,26 @@ namespace SmartHome.Homie.V4.EventArgs
     /// <remarks>
     /// The property has already been updated by the time this is raised, and the new
     /// value has been reflected back to the property topic -- the spec requires the
-    /// device to publish the processed value "as soon as possible". Handlers act on the
-    /// command (drive a relay, start a pump); they don't have to publish anything.
+    /// device to publish the processed value "as soon as possible".
+    ///
+    /// That reflection is optimistic: it is the *command*, published before anyone knows
+    /// whether it can be honoured. For an ordinary property that is right and a handler
+    /// has nothing to publish. For a property whose value is a *request the device can
+    /// turn down* -- an illegal $state transition, an out of range setpoint, a relay that
+    /// failed to close -- the handler must publish the device's real value over the
+    /// reflection once the command has been applied or refused, or the retained store is
+    /// left advertising a value the device is not in, to every controller that connects
+    /// afterwards. The correction goes *after* the reflection, never instead of it: the
+    /// library's publish is already out by the time this is raised. HomieClientCheck's
+    /// 'lifecycle' property is the worked example, and the conformance suite asserts the
+    /// order on the wire.
+    ///
+    /// This is the app's job rather than the library's on purpose -- see issue #33.
+    ///
+    /// Handlers run on M2Mqtt's event-dispatch thread, the one thread that also carries
+    /// SUBACK, PUBACK, UNSUBACK and the connection-closed signal. Don't block it waiting
+    /// for hardware: hand slow work to another thread, return, and publish the outcome
+    /// onto the property when it arrives.
     /// </remarks>
     public class HomieCommandEventArgs : System.EventArgs
     {

--- a/src/tests/Unit/HomieClientTests.cs
+++ b/src/tests/Unit/HomieClientTests.cs
@@ -3,6 +3,7 @@ using SmartHome.Homie.V4.Enums;
 using SmartHome.Homie.V4.Builder;
 using SmartHome.Homie.V4.Extensions;
 using SmartHome.Homie.V4.Properties;
+using SmartHome.Text;
 using nanoFramework.Logging;
 using nanoFramework.Logging.Debug;
 using nanoFramework.M2Mqtt.Messages;
@@ -296,6 +297,16 @@ namespace SmartHome.UnitTests
 
             homieClient.OnCommand += (args) =>
             {
+                // OnCommand is raised for every settable property, so a handler has to
+                // select the one it owns before correcting anything. Redundant on this
+                // one-property device and kept anyway: this test is cited as the worked
+                // example for #11 and #12, and copied without the guard it would publish
+                // $state onto whichever property a controller happened to write to.
+                if (args.Property.TopicId != _testPropertyLifecycleTopicId)
+                {
+                    return;
+                }
+
                 var payload = Encoding.UTF8.GetString(args.Payload, 0, args.Payload.Length);
                 if (payload == State.Sleeping.GetString())
                 {
@@ -324,7 +335,7 @@ namespace SmartHome.UnitTests
             // correction is what stops the retained store advertising 'sleeping' beside
             // $state='alert'.
             var payloads = mqttClient.PayloadsFor(propertyTopic);
-            Assert.AreEqual(before + 2, payloads.Length, $"expected the reflection and the correction over it, saw: {Describe(payloads)}");
+            Assert.AreEqual(before + 2, payloads.Length, $"expected the reflection and the correction over it, saw: {StringUtils.Join(", ", payloads)}");
             Assert.AreEqual(State.Sleeping.GetString(), payloads[before], "the library did not reflect the command");
             Assert.AreEqual(State.Alert.GetString(), payloads[before + 1], "the device did not publish its real state over the reflection");
 
@@ -735,26 +746,6 @@ namespace SmartHome.UnitTests
 
             Assert.ThrowsException(typeof(ArgumentException),
                 () => new FloatProperty("temperature", "Temperature", decimals: 16));
-        }
-
-        // For HomieClient_Reflects_The_Command_Before_The_Handler_Can_Correct_It: a count
-        // on its own says a publish is missing but not which one, and the order of those
-        // payloads is the whole claim that test makes.
-        private static string Describe(string[] payloads)
-        {
-            var described = new StringBuilder();
-
-            for (var i = 0; i < payloads.Length; i++)
-            {
-                if (i > 0)
-                {
-                    described.Append(", ");
-                }
-
-                described.Append(payloads[i]);
-            }
-
-            return described.ToString();
         }
 
         private Device BuildSinglePropertyDevice()

--- a/src/tests/Unit/HomieClientTests.cs
+++ b/src/tests/Unit/HomieClientTests.cs
@@ -1,6 +1,7 @@
 using SmartHome.Homie.V4;
 using SmartHome.Homie.V4.Enums;
 using SmartHome.Homie.V4.Builder;
+using SmartHome.Homie.V4.Extensions;
 using SmartHome.Homie.V4.Properties;
 using nanoFramework.Logging;
 using nanoFramework.Logging.Debug;
@@ -29,6 +30,9 @@ namespace SmartHome.UnitTests
 
         private const string _testPropertyIntensityTopicId = "intensity";
         private const string _testPropertyIntensityName = "Intensity";
+
+        private const string _testPropertyLifecycleTopicId = "lifecycle";
+        private const string _testPropertyLifecycleName = "Lifecycle control";
 
         [Setup]
         public void Setup()
@@ -254,6 +258,78 @@ namespace SmartHome.UnitTests
             Assert.AreEqual(1, commandCount);
             Assert.IsNotNull(commandedProperty);
             Assert.AreEqual(73.0, property.Value);
+        }
+
+        [TestMethod]
+        public void HomieClient_Reflects_The_Command_Before_The_Handler_Can_Correct_It()
+        {
+            // The rule every actuator has to follow, pinned where CI can run it.
+            //
+            // HomieClient publishes a /set payload onto its property BEFORE OnCommand
+            // runs, so a property whose value is a *request* -- one the device can turn
+            // down -- is reflected optimistically, and retained. Only the app knows
+            // whether the request was honoured, so only the app can correct it, and the
+            // correction has to land AFTER that reflection: the library's publish is
+            // already out by the time the handler is called, so a device that published
+            // its real value first would only have it overwritten.
+            //
+            // Deliberately the same shape as HomieClientCheck's 'lifecycle' property,
+            // which the conformance suite measures on the wire. This is the copy that
+            // needs no hardware, so an actuator has a worked example in CI -- see
+            // "reflect the outcome, not the command" in CLAUDE.md, and issue #33 for why
+            // the library does not take this over.
+
+            // Arrange -- a lifecycle property whose value mirrors $state
+            var mqttClient = new MockMqttClient();
+
+            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
+            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
+                        .AddEnumProperty(_testPropertyLifecycleTopicId, _testPropertyLifecycleName, State.Ready.GetString())
+                            .WithSettable(true)
+                            .WithFormat("ready,alert,sleeping")
+                        .BuildProperty(out EnumProperty lifecycle)
+                    .BuildNode()
+                .BuildDevice();
+
+            var homieClient = new HomieClient(device, mqttClient);
+            homieClient.Connect();
+
+            homieClient.OnCommand += (args) =>
+            {
+                var payload = Encoding.UTF8.GetString(args.Payload, 0, args.Payload.Length);
+                if (payload == State.Sleeping.GetString())
+                {
+                    homieClient.Sleep();
+                }
+
+                // Applied or refused, this is what the device actually is.
+                lifecycle.Update(homieClient.State.GetString());
+            };
+
+            // alert may only return to ready or disconnect, so the command below is refused
+            Assert.IsTrue(homieClient.Alert());
+
+            var propertyTopic = lifecycle.GetTopic();
+            var before = mqttClient.PayloadsFor(propertyTopic).Length;
+
+            // Act -- a controller asks for the one transition the convention forbids
+            var commandTopic = $"{propertyTopic}{Constants.TopicSeparator}{Constants.SetPropertyTopicId}";
+            mqttClient.RaisePublishReceived(new MqttMsgPublishEventArgs(commandTopic, Encoding.UTF8.GetBytes(State.Sleeping.GetString()), false, MqttQoSLevel.AtLeastOnce, false));
+
+            // Assert -- the transition did not happen ...
+            Assert.AreEqual((int)State.Alert, (int)homieClient.State);
+
+            // ... and the property carries the reflection first, the correction over it.
+            // Both, in that order: the reflection proves the command was seen, the
+            // correction is what stops the retained store advertising 'sleeping' beside
+            // $state='alert'.
+            var payloads = mqttClient.PayloadsFor(propertyTopic);
+            Assert.AreEqual(before + 2, payloads.Length, $"expected the reflection and the correction over it, saw: {Describe(payloads)}");
+            Assert.AreEqual(State.Sleeping.GetString(), payloads[before], "the library did not reflect the command");
+            Assert.AreEqual(State.Alert.GetString(), payloads[before + 1], "the device did not publish its real state over the reflection");
+
+            // The last payload on a retained topic is what every later controller reads.
+            Assert.AreEqual(State.Alert.GetString(), lifecycle.Value);
         }
 
         [TestMethod]
@@ -659,6 +735,26 @@ namespace SmartHome.UnitTests
 
             Assert.ThrowsException(typeof(ArgumentException),
                 () => new FloatProperty("temperature", "Temperature", decimals: 16));
+        }
+
+        // For HomieClient_Reflects_The_Command_Before_The_Handler_Can_Correct_It: a count
+        // on its own says a publish is missing but not which one, and the order of those
+        // payloads is the whole claim that test makes.
+        private static string Describe(string[] payloads)
+        {
+            var described = new StringBuilder();
+
+            for (var i = 0; i < payloads.Length; i++)
+            {
+                if (i > 0)
+                {
+                    described.Append(", ");
+                }
+
+                described.Append(payloads[i]);
+            }
+
+            return described.ToString();
         }
 
         private Device BuildSinglePropertyDevice()

--- a/src/tests/Unit/MockMqttClient.cs
+++ b/src/tests/Unit/MockMqttClient.cs
@@ -4,11 +4,19 @@ using nanoFramework.M2Mqtt;
 using nanoFramework.M2Mqtt.Messages;
 using System;
 using System.Collections;
+using System.Text;
 
 namespace SmartHome.UnitTests
 {
     internal class MockMqttClient : IReconnectingMqttClient
     {
+        // Every publish, in order, topic and payload. PublishCount cannot express an
+        // ordering claim, and "reflect the outcome, not the command" is entirely about
+        // order -- a device's correction has to land AFTER the library's optimistic
+        // reflection, not instead of it, because the library's publish is already out by
+        // the time the OnCommand handler runs.
+        private readonly ArrayList _publishes = new ArrayList();
+
         public int PublishCount { get; private set; } = 0;
         public int SubscriptionCount { get; private set; } = 0;
 
@@ -129,19 +137,19 @@ namespace SmartHome.UnitTests
 
         public ushort Publish(string topic, byte[] message, string contentType, ArrayList userProperties, MqttQoSLevel qosLevel, bool retain)
         {
-            PublishCount++;
+            Record(topic, message);
             return 0;
         }
 
         public ushort Publish(string topic, byte[] message, string contentType)
         {
-            PublishCount++;
+            Record(topic, message);
             return 0;
         }
 
         public ushort Publish(string topic, byte[] message)
         {
-            PublishCount++;
+            Record(topic, message);
             return 0;
         }
 
@@ -158,6 +166,51 @@ namespace SmartHome.UnitTests
                 SubscriptionCount++;
             }
             return 0;
+        }
+
+        /// <summary>
+        /// The payloads published to one topic, in the order they were published.
+        /// </summary>
+        public string[] PayloadsFor(string topic)
+        {
+            var matches = new ArrayList();
+
+            foreach (PublishedMessage published in _publishes)
+            {
+                if (published.Topic == topic)
+                {
+                    matches.Add(published.Payload);
+                }
+            }
+
+            var payloads = new string[matches.Count];
+            for (int i = 0; i < matches.Count; i++)
+            {
+                payloads[i] = (string)matches[i];
+            }
+
+            return payloads;
+        }
+
+        // Recorded from all three Publish overloads, so a test cannot miss a publish by
+        // which overload the code under test happened to take.
+        private void Record(string topic, byte[] message)
+        {
+            PublishCount++;
+            _publishes.Add(new PublishedMessage(topic, message));
+        }
+
+        private class PublishedMessage
+        {
+            internal PublishedMessage(string topic, byte[] message)
+            {
+                Topic = topic;
+                Payload = message == null ? string.Empty : Encoding.UTF8.GetString(message, 0, message.Length);
+            }
+
+            public string Topic { get; }
+
+            public string Payload { get; }
         }
 
         public ushort Unsubscribe(string[] topics)

--- a/src/tests/Unit/Unit.nfproj
+++ b/src/tests/Unit/Unit.nfproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\common\Homie\Homie.nfproj" />
     <ProjectReference Include="..\..\common\Mqtt\Mqtt.nfproj" />
+    <ProjectReference Include="..\..\common\Text\Text.nfproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib">


### PR DESCRIPTION
﻿Resolves #33 — a spike, answered **no**. The full reasoning is
[recorded on the issue](https://github.com/JojoEffect/SmartHome/issues/33#issuecomment-5462459391),
where the next person will look for it; this PR carries the consequences.

`OnCommand` keeps its shape, `HomieClient` keeps reflecting the command before raising it, and
the device keeps publishing its real value over that reflection. No library behaviour changes.

## Why the API change was rejected

Five reasons, of which the first two are decisive.

**Neither default works.** Accept-unless-rejected leaves the failure mode exactly as it is today
— an author who does not know the rule omits the `Reject()` call instead of omitting the
correcting publish, and the retained store ends up in the same contradictory state. It charges an
API break and keeps correctness opt-in, which was the entire complaint.
Reject-unless-accepted does make correctness the default, but a settable property with no
`OnCommand` handler at all — legal Homie, and six of `HomieClientCheck`'s seven settable
properties — would stop reflecting anything, which the spec forbids more plainly than the bug
being fixed. Across the devices that exist there is one refusable property against seven settable
ones; the change taxes the common case to protect the rare one.

**The realistic cases are asynchronous.** `OnCommand` runs on M2Mqtt's event-dispatch thread, and
`MqttClient.DispatchEventThread` (sibling `nanoFramework.m2mqtt` checkout) drains one queue
carrying SUBACK, PUBACK, PUBCOMP, UNSUBACK and the connection-closed signal alongside incoming
PUBLISH. A handler that waits 200 ms for a relay to confirm stalls all of it. So the two cases
this issue was raised for — a relay that failed to close, a setpoint validated against a sensor
read — cannot answer inside the handler at all, and would still need the device to publish the
outcome later.

The remaining three are on the issue: `property.Set()` publishes *through* `OnUpdate`, so
deferring the reflection cannot be separated from deferring the model update without either
withholding the value from the handler or a snapshot/rollback dance on the dispatch thread;
multicast `OnCommand` has no property-ownership model, so any "who decides" rule is arbitrary;
and Homie has no refusal channel, so the library could do nothing with a rejection that the app
cannot already do — while knowing strictly less about whether the command worked.

## What this PR does instead

The counter-argument in the issue is real: a rule that is easy to forget produces a contradiction
rather than an error. It was easy to forget because the only thing checking it was the conformance
suite, which needs an ESP32, a network and a broker, and which only ever measures
`HomieClientCheck`.

**`HomieClient_Reflects_The_Command_Before_The_Handler_Can_Correct_It`** builds a `lifecycle`
property shaped like `HomieClientCheck`'s, drives the device to `alert`, asks for the forbidden
`alert -> sleeping` transition, and asserts the two publishes on the property topic in order: the
library's optimistic `sleeping`, then the device's `alert` over it. #11 and #12 now have a worked
example of the pattern that runs in CI without hardware.

**`MockMqttClient`** records topic and payload for every publish instead of only counting them —
the claim being made is entirely about order — from all three `Publish` overloads, so a test
cannot miss a publish by which overload the code happened to take.

**`HomieCommandEventArgs`'** own documentation said handlers "don't have to publish anything".
That stopped being true when #32 landed, and it is the doc a device author reads at the point of
use. It now states what a handler owes a property whose value is a request, that the correction
goes *after* the reflection rather than instead of it, and that the handler must not block the
dispatch thread.

**`CLAUDE.md`** gains the same two points. "Three things to know when writing an actuator" becomes
four: the ordering constraint is now explicit in the reflect-the-outcome rule, and the
dispatch-thread constraint is new — it was documented nowhere, and it decides how #11 and #12 have
to be written.

## Split out

#39. A payload that violates a property's own declared `$datatype` or `$format` is not a valid
command and the library could refuse it before publishing anything, with no API change. Today it
does not, and the five property types disagree about what to do with one: `EnumProperty` accepts
any string including one absent from its `$format`, `IntegerProperty` ignores a declared range,
and `BooleanProperty` turns any unrecognised payload into `false` rather than rejecting it. That
last one fabricates a value rather than merely failing to reject, which is why it is worth a
separate issue rather than a footnote.

## Testing done

- Solution builds clean, Debug, no errors.
- **Unit suite 40/40 on the nanoclr virtual device** (`.\scripts\Run-Tests.ps1 -RunSettings
  nano.ci.runsettings`) — the same entry point CI uses.
- **One negative run**, reverted afterwards: the correction commented out of the new test's
  handler, which is the #13 defect reproduced inside the test's own device. It fails that test and
  only that test, reporting one publish on the property topic where two were expected.
- **No hardware run.** Nothing here reaches a device: the only non-test change is an XML doc
  comment, and the conformance suite's assertions are untouched. The device is still running
  whatever the last session left on it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
