### PR TITLE
docs: require an authenticated gh CLI and fix three CLAUDE.md inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,10 @@ Required local tools:
 - `nanoff` CLI: `dotnet tool install -g nanoff`
 - [Mosquitto](https://mosquitto.org/download/)
 - Git on PATH
+- [GitHub CLI](https://cli.github.com/) (`gh`), **authenticated** — `gh auth login`, then
+  confirm with `gh auth status`. Not optional and not only for opening pull requests: the
+  backlog *is* GitHub issues (see Open work below), so `gh issue list` is how you find out
+  what there is to do. Without it, that section of this file cannot be acted on at all.
 
 ## Repository layout
 
@@ -418,8 +422,8 @@ needs your own GitHub admin action (I can't do this for you):
 3. Add it as repo secret `CLAUDE_CODE_OAUTH_TOKEN`
 
 Locally, `/code-review` works today with no setup — reviews your branch's diff in-session,
-`--fix` applies findings, `--comment` posts them to a PR (needs `gh` CLI authenticated, which
-isn't installed on this machine yet).
+`--fix` applies findings, `--comment` posts them to a PR (that last one goes through `gh`,
+which First-time setup requires anyway).
 
 ## Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
 | `scripts\Watch-DeviceDebugOutput.ps1 [-DurationSeconds <n>] [-NoReboot] [-NoBuild] [-BuildOnly] [-Until <regex>] [-DumpConfig]` | Real managed-code debug output (`Debug.WriteLine`, exceptions) via `tools\DeviceDebugMonitor` — no VS needed, same library VS's debugger extension uses | Resets only | `smarthome-watch-debug-output` |
-| `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into every `Properties\AssemblyInfo.cs` under `src` — found by glob, so adding a device needs no edit here. `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
+| `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into every `AssemblyInfo.cs` under `src` — a plain recursive glob, not a fixed list and not restricted to `Properties\`, so adding a device needs no edit here and a stray one anywhere under `src` will also be picked up (and fails the run if it carries no version attribute). `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
 | `scripts\Common.ps1` | Shared helpers (env loading, MSBuild/vstest/adapter discovery, repo-sync, dev-env state) — dot-source, don't duplicate its logic | No | — |
 
 `Start-DevEnv.ps1` is the session bootstrap: it absorbed the old `Start-AgentWorkspace.ps1`,
@@ -106,7 +106,9 @@ Required local tools:
 - [GitHub CLI](https://cli.github.com/) (`gh`), **authenticated** — `gh auth login`, then
   confirm with `gh auth status`. Not optional and not only for opening pull requests: the
   backlog *is* GitHub issues (see Open work below), so `gh issue list` is how you find out
-  what there is to do. Without it, that section of this file cannot be acted on at all.
+  what there is to do. A human can fall back to the issues page in a browser; an agent
+  session has no such fallback, and every workflow in this file that reaches GitHub goes
+  through `gh`.
 
 ## Repository layout
 
@@ -169,10 +171,11 @@ Two naming traps this layout exists to avoid, both hit for real:
 shared Homie client, layered on `ReconnectingMqttClient` (in `SmartHome.Mqtt`).
 
 `ReconnectingMqttClient`'s auto-reconnect handling was long marked WIP, "blocked on an ESP32
-nanoFramework target bug" — as of 2026-08-20 that is out of date at the MQTT level:
-`MqttReconnectCheck` proves on real hardware that a client keeps its heartbeat going across
-broker outages of 3s and 20s, reconnecting rather than restarting. That test exercises
-`SmartHome.Mqtt` alone -- it does not reference `SmartHome.Homie` at all.
+nanoFramework target bug" — as of 2026-08-20 that is out of date: `MqttReconnectCheck` proves on
+real hardware that a client keeps its heartbeat going across broker outages of 3s and 20s,
+reconnecting rather than restarting. That test exercises `SmartHome.Mqtt` alone -- it does not
+reference `SmartHome.Homie` at all, so it settles the transport and nothing above it. The Homie
+layer is the next paragraph.
 
 The Homie layer on top now re-announces too: `HandleConnectionOpen` takes the device back through
 `init` -> `ready`, republishing every attribute, because Homie state lives in the broker's
@@ -240,9 +243,9 @@ for the interface instead of racing it.
 - **`src/devices`** — real applications. Nothing here should exist only to prove a dependency
   works; that's what `integrationTests` is for.
 
-Within `src/integrationTests`, what differs between tests is how the verdict is reached. That
-is declared per entry by the `Kind` field in `$testCatalog` in `Run-IntegrationTests.ps1`, and
-there are three of them (not to be confused with the three *locations* above):
+Those tests differ in which dependency they exercise, as above, and separately in *who decides
+the verdict*. The latter is declared per entry by the `Kind` field in `$testCatalog` in
+`Run-IntegrationTests.ps1`, and there are three (not the same three as the locations above):
 
 - **`DeviceMarker`** — the device decides. The runner captures managed debug output and reads
   the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
 | `scripts\Watch-DeviceDebugOutput.ps1 [-DurationSeconds <n>] [-NoReboot] [-NoBuild] [-BuildOnly] [-Until <regex>] [-DumpConfig]` | Real managed-code debug output (`Debug.WriteLine`, exceptions) via `tools\DeviceDebugMonitor` — no VS needed, same library VS's debugger extension uses | Resets only | `smarthome-watch-debug-output` |
-| `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into all 14 `Properties\AssemblyInfo.cs`. `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
+| `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into every `Properties\AssemblyInfo.cs` under `src` — found by glob, so adding a device needs no edit here. `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
 | `scripts\Common.ps1` | Shared helpers (env loading, MSBuild/vstest/adapter discovery, repo-sync, dev-env state) — dot-source, don't duplicate its logic | No | — |
 
 `Start-DevEnv.ps1` is the session bootstrap: it absorbed the old `Start-AgentWorkspace.ps1`,
@@ -166,7 +166,9 @@ Two naming traps this layout exists to avoid, both hit for real:
   `GetFileNameWithoutExtension($projectPath)` for that purpose.
 
 `RoomSensor/Program.cs` is the main device logic; `HomieClient` (in `SmartHome.Homie`) is the
-shared Homie client, layered on `ReconnectingMqttClient` (in `SmartHome.Mqtt`). Its auto-reconnect handling was long marked WIP, "blocked on an ESP32
+shared Homie client, layered on `ReconnectingMqttClient` (in `SmartHome.Mqtt`).
+
+`ReconnectingMqttClient`'s auto-reconnect handling was long marked WIP, "blocked on an ESP32
 nanoFramework target bug" — as of 2026-08-20 that is out of date at the MQTT level:
 `MqttReconnectCheck` proves on real hardware that a client keeps its heartbeat going across
 broker outages of 3s and 20s, reconnecting rather than restarting. That test exercises
@@ -238,8 +240,9 @@ for the interface instead of racing it.
 - **`src/devices`** — real applications. Nothing here should exist only to prove a dependency
   works; that's what `integrationTests` is for.
 
-The suite runs three kinds of test, and the kind is declared per entry in
-`$testCatalog` in `Run-IntegrationTests.ps1`:
+Within `src/integrationTests`, what differs between tests is how the verdict is reached. That
+is declared per entry by the `Kind` field in `$testCatalog` in `Run-IntegrationTests.ps1`, and
+there are three of them (not to be confused with the three *locations* above):
 
 - **`DeviceMarker`** — the device decides. The runner captures managed debug output and reads
   the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way.


### PR DESCRIPTION
## Summary

Makes an authenticated `gh` CLI a documented requirement in `CLAUDE.md` rather than an aside about one machine not having it, and fixes three inconsistencies found while re-reading the file against the repo.

## Changes

**`gh` as a requirement (6e05870)**

- `CLAUDE.md` carried *"needs `gh` CLI authenticated, which isn't installed on this machine yet"* as a parenthetical on `/code-review --comment`. That was stale — `gh` is installed and authenticated — and a note about one machine's state does not belong in a file that tells everyone how to work in this repo.
- It also understated the dependency. `CLAUDE.md` declares GitHub issues to be the backlog, says there is deliberately no to-do file, and gives `gh issue list --state open` as the way to check it. Without `gh` that section cannot be acted on at all, so it is not an optional extra for opening PRs.
- Now listed under **First-time setup → Required local tools** alongside `nanoff`, Mosquitto and git, with `gh auth login` / `gh auth status` spelled out — an installed-but-unauthenticated `gh` fails the same way a missing one does.

**Coherence fixes (2cecda4)**

- **A count that decays.** `Set-AssemblyVersion.ps1` was described as stamping *"all 14 `Properties\AssemblyInfo.cs`"*. The script globs `AssemblyInfo.cs` under `src` rather than working from a fixed list, so the number is something this file has to be told about every time a device is added — and there are 14 today only by coincidence of nothing having been added since. Replaced with what the script actually does.
- **An ambiguous antecedent.** *"Its auto-reconnect handling was long marked WIP"* followed a sentence naming three things (`RoomSensor/Program.cs`, `HomieClient`, `ReconnectingMqttClient`), leaving the reader to guess which one was blocked on the ESP32 bug. Named outright, and the run-on line rewrapped to the width the rest of the file uses.
- **Two different triples called "kinds of test".** The heading *"Three kinds of test, deliberately kept apart"* is about three **locations** (`src/tests`, `src/integrationTests`, `src/devices`). Four lines later, *"The suite runs three kinds of test"* is about three ways a **verdict** is reached (`DeviceMarker`, `HomieConformance`, `BrokerOutage`). Close enough together to read as one list. The second now says it is about how the verdict is reached, keeps the `Kind` field name the runner actually uses, and points at the distinction.

## What was validated and found correct

Re-read against the repo rather than taken on trust — everything below already matched:

- All 11 scripts in the entry-point table exist; all 10 `smarthome-*` skills they name exist.
- Both subagents (`device-ops`, `nanoframework-sync`) exist in `.claude/agents/`.
- The repository-layout tree matches `git ls-files` exactly — no tracked directory missing from it, none listed that does not exist.
- All 14 companion repos match what `Sync-NanoFrameworkRepos.ps1` actually clones, in the same order.
- All four package baselines (`CoreLibrary` 1.17.11, `Hardware.Esp32` 1.6.42, `Logging` 1.1.161, `M2Mqtt` 5.1.221) still match `packages.config` verbatim, as does the `TestFramework` 3.0.80 claim behind the `NFUnitTest` naming rule.
- `CONTRIBUTING.md`, `.github/workflows/claude.yml` and `TestSupport/IntegrationTest.cs` all exist at the paths given.

## Type of Change

- [x] Refactor / chore

## Testing Done

Documentation only — no code changed, so there is nothing to run on hardware and **nothing was run on hardware for this PR**.

For completeness, on the same working tree earlier in this session the full integration suite passed 5/5 on real hardware (ESP32 on COM3, local Mosquitto), but that exercised the branch in #32's follow-up, not this change.

## Checklist

- [x] Code compiles without errors — N/A, no code changed
- [x] Relevant tests pass (or N/A for non-code changes) — N/A
- [x] No secrets or credentials committed
- [x] PR title follows Conventional Commits (it becomes the merge commit message)
