### PR TITLE
fix(homie): refuse a /set payload the property's own $datatype forbids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,8 +191,18 @@ device owns a connection rather than being one, and exposing `Publish`/`Subscrib
 let an app publish an attribute non-retained or `$state` out of order. The `Device` model (built
 with `HomieDeviceBuilder`) says what the device *is*; `IHomieClient` is what you *do* with it.
 
-Four things to know when writing an actuator (Irrigation, Oven):
+Five things to know when writing an actuator (Irrigation, Oven):
 
+- Don't re-check the payload against `$datatype` or `$format` -- the property already did.
+  Since 2026-08-29 `PropertyBase.Set` validates a `/set` before anything is applied: an enum
+  payload must be one of the `$format` values, an integer or float inside a declared
+  `min:max` range, a boolean exactly `true` or `false`, a colour a real `<r>,<g>,<b>` triple.
+  A rejected payload is logged and dropped -- the value does not move, nothing is published,
+  nothing lands in the retained store -- and `HomieClient` does **not** raise `OnCommand` for
+  it, so a handler only ever sees payloads its property can hold. That is narrower than it
+  sounds and does not replace the rule below: the library refuses what the *declaration*
+  forbids, and only the app can refuse what its *state* forbids (a legal enum value that is
+  an illegal transition, a valid setpoint a relay then fails to reach). Issue #39.
 - Act on `IHomieClient.OnCommand`, not on `property.OnUpdate`. The property event fires both
   when a controller sets a value and when the device updates its own, and cannot tell them
   apart; `OnCommand` fires only for a controller's `/set`.
@@ -265,7 +275,8 @@ the verdict*. The latter is declared per entry by the `Kind` field in `$testCata
   the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way.
 - **`HomieConformance`** — the host measures a purpose-built device against the Homie v4
   convention: mandatory attributes and their retained flags, one property of every datatype with
-  its `$format`/`$unit`/`$settable`/`$retained`, a `/set` command applied and reflected back, the
+  its `$format`/`$unit`/`$settable`/`$retained`, a `/set` command applied and reflected back, a
+  payload each datatype's own `$format` forbids that must be refused rather than applied, the
   `alert` and `sleeping` states driven through a control property, a refused transition that
   must not be advertised as if it had happened, and a full re-announce after the broker is
   replaced. `HomieClientCheck` is this kind. Retained-ness is read from a *fresh*

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1222,12 +1222,20 @@ function Invoke-HomieConformanceCheck {
     # was dropped, and a boolean that was neither 'true' nor 'false' was turned into
     # 'false' -- fabricated, not refused.
     #
+    # That last one is why the boolean's valid payload is 'true' rather than the more
+    # obvious 'false'. A fabricating boolean never publishes 'on' back, it publishes
+    # 'false', so a case whose valid payload is also 'false' cannot tell the fabrication
+    # from the refusal -- both leave a single 'false' on the topic and the "was the
+    # forbidden payload applied" check below looks for 'on', which never appears. With
+    # 'true' as the valid payload the fabricated 'false' lands *before* the reflection,
+    # which is what the ordering check below measures.
+    #
     # string-value has no case here: every payload is a valid Homie string and $format
     # carries no meaning for that datatype, so there is nothing for a payload to violate.
     $outOfFormatCases = @(
         @{ Property = 'integer-value'; Bad = '101';    Good = '43';        Echo = '43'        }
         @{ Property = 'float-value';   Bad = 'warm';   Good = '22.5';      Echo = '22.50'     }
-        @{ Property = 'boolean-value'; Bad = 'on';     Good = 'false';     Echo = 'false'     }
+        @{ Property = 'boolean-value'; Bad = 'on';     Good = 'true';      Echo = 'true'      }
         @{ Property = 'enum-value';    Bad = 'purple'; Good = 'medium';    Echo = 'medium'    }
         @{ Property = 'color-value';   Bad = 'FF8000'; Good = '255,128,0'; Echo = '255,128,0' }
     )
@@ -1270,8 +1278,23 @@ function Invoke-HomieConformanceCheck {
             continue
         }
 
-        if ([array]::IndexOf($payloads, $case.Echo) -lt 0) {
+        $echoIndex = [array]::IndexOf($payloads, $case.Echo)
+
+        if ($echoIndex -lt 0) {
             $script:conformanceFailures += "neither the out-of-format '$($case.Bad)' nor the valid '$($case.Good)' reached $($case.Property), so the refusal was never measured (saw: $($payloads -join ', '))"
+            continue
+        }
+
+        # A forbidden payload does not have to come back verbatim to have been applied.
+        # BooleanProperty's old behaviour turned anything unrecognised into 'false' and
+        # published *that*, which the verbatim check above cannot see at all -- so the
+        # measurement is the stronger one: a refusal publishes nothing, therefore the
+        # valid payload's reflection must be the FIRST thing on the property topic inside
+        # the window. Anything ahead of it is the forbidden payload having moved the
+        # value, whatever it was rendered as.
+        if ($echoIndex -gt 0) {
+            $before = $payloads[0..($echoIndex - 1)] -join ', '
+            $script:conformanceFailures += "$($case.Property) published '$before' before the valid '$($case.Good)', so the out-of-format '$($case.Bad)' was applied rather than refused (saw: $($payloads -join ', '))"
         }
     }
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -804,6 +804,34 @@ function ConvertTo-HomieSnapshot {
     return $snapshot
 }
 
+function Get-HomieLivePayloads {
+    # The payloads published to one topic inside a capture window, in arrival order,
+    # with the retained replay dropped: the replayed copy is the value from before the
+    # window opened and says nothing about what happened inside it.
+    #
+    # ConvertTo-HomieSnapshot answers "where did this settle". This answers "what went
+    # past, in what order", which is the only thing that tells a command that was refused
+    # apart from one that was never delivered -- both leave the store exactly as it was.
+    param(
+        [string[]]$Lines,
+        [string]$Topic
+    )
+
+    $payloads = @()
+    foreach ($line in $Lines) {
+        # Same "<topic> <0|1> <payload>" layout ConvertTo-HomieSnapshot parses, and for
+        # the same reason it is not spelled out in two places: the layout is chosen in
+        # Get-SmartHomeSubscriberArguments.
+        $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
+        if ($match.Success -and $match.Groups[1].Value -eq $Topic -and $match.Groups[2].Value -eq '0') {
+            $payloads += $match.Groups[3].Value
+        }
+    }
+
+    # Comma so a zero- or one-element result still arrives as an array.
+    return ,$payloads
+}
+
 function Publish-HomieCommand {
     param(
         [string]$Port,
@@ -950,8 +978,8 @@ function Write-ConformancePhaseBreakdown {
 function Get-ConformanceCaptureSeconds {
     # A ceiling for the debug capture that runs alongside the check, derived from the
     # check's own timeouts rather than guessed: the announce wait, the /set round trip,
-    # one per lifecycle step, and the re-announce wait, plus slack for the snapshot
-    # windows and the broker restart between them.
+    # the out-of-format round, one per lifecycle step, and the re-announce wait, plus
+    # slack for the snapshot windows and the broker restart between them.
     #
     # Deliberately loose. A capture that ends early takes the device-side evidence with
     # it exactly when the run was slow enough to be worth reading, and nothing waits out
@@ -960,9 +988,11 @@ function Get-ConformanceCaptureSeconds {
 
     $lifecycleSteps = 5
 
+    # +2 rather than +1: the /set round trip and the out-of-format phase each poll for up
+    # to CommandTimeoutSeconds on top of the lifecycle steps.
     return $Settings.SettleSeconds +
            $Settings.RecoverySeconds +
-           (($lifecycleSteps + 1) * $Settings.CommandTimeoutSeconds) +
+           (($lifecycleSteps + 2) * $Settings.CommandTimeoutSeconds) +
            60
 }
 
@@ -1169,6 +1199,82 @@ function Invoke-HomieConformanceCheck {
         $script:conformanceFailures += "/set on $property did not come back on the property topic (saw '$($lastSeen[$property])', expected '$wanted')"
     }
 
+    # ── payloads the properties' own $datatype/$format forbid ────────────────
+    Start-ConformancePhase -Name 'out-of-format /set'
+    Write-Host "  driving /set commands the datatypes forbid..." -ForegroundColor DarkGray
+    # The library refuses these before anything is applied: the value does not move and
+    # nothing is published, so nothing lands in the retained store and the controller's
+    # only feedback is a property that did not change (issue #39).
+    #
+    # Which is also precisely what a command that never arrived looks like. A /set is
+    # non-retained, so a lost one leaves no trace whatsoever -- the same reasoning the
+    # refused-transition step below sets out at length.
+    #
+    # So each forbidden payload is followed by a valid one on the same property, inside
+    # one capture window. The valid payload's reflection is the proof that the device was
+    # subscribed and receiving while the forbidden one went past: seeing it, and NOT
+    # seeing the forbidden payload before it, is a refusal. Seeing neither is a lost
+    # command, and is reported as exactly that rather than passing.
+    #
+    # One case per datatype, each the behaviour that type used to have: an integer
+    # outside a declared range and a float that does not parse were applied or dropped
+    # silently, an enum value $format does not list was accepted, an unparseable colour
+    # was dropped, and a boolean that was neither 'true' nor 'false' was turned into
+    # 'false' -- fabricated, not refused.
+    #
+    # string-value has no case here: every payload is a valid Homie string and $format
+    # carries no meaning for that datatype, so there is nothing for a payload to violate.
+    $outOfFormatCases = @(
+        @{ Property = 'integer-value'; Bad = '101';    Good = '43';        Echo = '43'        }
+        @{ Property = 'float-value';   Bad = 'warm';   Good = '22.5';      Echo = '22.50'     }
+        @{ Property = 'boolean-value'; Bad = 'on';     Good = 'false';     Echo = 'false'     }
+        @{ Property = 'enum-value';    Bad = 'purple'; Good = 'medium';    Echo = 'medium'    }
+        @{ Property = 'color-value';   Bad = 'FF8000'; Good = '255,128,0'; Echo = '255,128,0' }
+    )
+
+    $pending = @($outOfFormatCases)
+    $seenPayloads = @{}
+    $deadline = (Get-Date).AddSeconds($Settings.CommandTimeoutSeconds)
+
+    while ($pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
+        $capture = Start-HomieCapture -Port $Port -WaitForConnectSeconds 5
+
+        foreach ($case in $pending) {
+            Publish-HomieCommand -Port $Port -Topic "$node/$($case.Property)/set" -Payload $case.Bad
+            Publish-HomieCommand -Port $Port -Topic "$node/$($case.Property)/set" -Payload $case.Good
+        }
+
+        $lines = Stop-HomieCapture -Capture $capture
+        $stillPending = @()
+
+        foreach ($case in $pending) {
+            $payloads = Get-HomieLivePayloads -Lines $lines -Topic "$node/$($case.Property)"
+            $seenPayloads[$case.Property] = $payloads
+
+            # Retried only while NEITHER payload was seen, i.e. while nothing has been
+            # measured. A forbidden payload that did land is a real failure and must not
+            # be retried away.
+            if ([array]::IndexOf($payloads, $case.Echo) -lt 0 -and [array]::IndexOf($payloads, $case.Bad) -lt 0) {
+                $stillPending += $case
+            }
+        }
+
+        $pending = $stillPending
+    }
+
+    foreach ($case in $outOfFormatCases) {
+        $payloads = if ($seenPayloads.Contains($case.Property)) { $seenPayloads[$case.Property] } else { @() }
+
+        if ([array]::IndexOf($payloads, $case.Bad) -ge 0) {
+            $script:conformanceFailures += "out-of-format '$($case.Bad)' was applied to $($case.Property) and published back (saw: $($payloads -join ', '))"
+            continue
+        }
+
+        if ([array]::IndexOf($payloads, $case.Echo) -lt 0) {
+            $script:conformanceFailures += "neither the out-of-format '$($case.Bad)' nor the valid '$($case.Good)' reached $($case.Property), so the refusal was never measured (saw: $($payloads -join ', '))"
+        }
+    }
+
     # ── the lifecycle states a device can be driven into ─────────────────────
     Start-ConformancePhase -Name 'lifecycle'
     Write-Host "  driving `$state through alert, sleeping and a refused transition..." -ForegroundColor DarkGray
@@ -1233,16 +1339,7 @@ function Invoke-HomieConformanceCheck {
                 $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
             }
 
-            # Payloads on the property topic, in arrival order, retained replay dropped:
-            # the replayed copy is the value from before this command and says nothing
-            # about whether it arrived.
-            $lifecyclePayloads = @()
-            foreach ($line in $lines) {
-                $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
-                if ($match.Success -and $match.Groups[1].Value -eq "$node/lifecycle" -and $match.Groups[2].Value -eq '0') {
-                    $lifecyclePayloads += $match.Groups[3].Value
-                }
-            }
+            $lifecyclePayloads = Get-HomieLivePayloads -Lines $lines -Topic "$node/lifecycle"
 
             $reflected = [array]::IndexOf($lifecyclePayloads, $step.Command)
             $corrected = [array]::IndexOf($lifecyclePayloads, $step.Expect)
@@ -1307,7 +1404,7 @@ function Invoke-HomieConformanceCheck {
 
     return @{
         Outcome = 'PASS'
-        Detail  = "attributes, datatypes, retained flags, /set round-trip, alert/sleeping, a refused transition and re-announce all conform"
+        Detail  = "attributes, datatypes, retained flags, /set round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce all conform"
     }
 }
 

--- a/src/common/Homie/V4/HomieClient.cs
+++ b/src/common/Homie/V4/HomieClient.cs
@@ -371,17 +371,34 @@ namespace SmartHome.Homie.V4
             // Guarded separately: a command that failed to apply is still a command the
             // app should hear about, since handlers act on the payload rather than on the
             // property's resulting value.
+            //
+            // A payload the property *rejected* is the one exception, and it is a
+            // different thing from one that threw. Set() only throws once it is applying
+            // a payload it already accepted -- typically from the reflection publish on a
+            // flaky link -- so that command did reach the device and the app should hear
+            // about it. A rejected payload never reached anything: it violates the
+            // property's own declared $datatype or $format, the value did not move and
+            // nothing was published. Raising OnCommand for it would hand every actuator a
+            // payload the library has already refused, which is how each of them ends up
+            // re-checking the $format its property already declares (issue #39).
+            var accepted = true;
             try
             {
                 // Set() reflects the value back to the property topic via OnUpdate, which
                 // is what the spec asks for. OnCommand is raised separately so an app can
                 // tell a controller's command from its own update -- property.OnUpdate
                 // fires for both and cannot distinguish them.
-                property.Set(message);
+                accepted = property.Set(message);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Failed to apply the command on '{topic}'.");
+            }
+
+            if (!accepted)
+            {
+                // Set() has already logged what was wrong with the payload.
+                return;
             }
 
             try

--- a/src/common/Homie/V4/Properties/BooleanProperty.cs
+++ b/src/common/Homie/V4/Properties/BooleanProperty.cs
@@ -39,10 +39,25 @@ namespace SmartHome.Homie.V4.Properties
         // Update() always had it right, which is what made the mismatch easy to miss.
         private static string Format(bool value) => value ? "true" : "false";
 
+        internal override string? Validate(string value)
+        {
+            // Exactly "true" or "false", which is all Homie v4 permits. This used to
+            // accept "1" and "True" as well and -- worse -- treat everything else as
+            // false, so a controller sending "on" or a typo got a device that published
+            // 'false' and acted on it. At the broker that is indistinguishable from a
+            // controller having deliberately asked for false.
+            if (value == "true" || value == "false")
+            {
+                return null;
+            }
+
+            return "not 'true' or 'false'";
+        }
+
         internal override void SetInternal(string value)
         {
-            bool parsed = value == "true" || value == "1" || value == "True";
-            Update(parsed);
+            // Validate() has already ruled out everything else.
+            Update(value == "true");
         }
     }
 }

--- a/src/common/Homie/V4/Properties/ColorProperty.cs
+++ b/src/common/Homie/V4/Properties/ColorProperty.cs
@@ -90,8 +90,23 @@ namespace SmartHome.Homie.V4.Properties
             OnUpdate?.Invoke(args);
         }
 
+        internal override string? Validate(string value)
+        {
+            // Only rgb is implemented, whatever $format declares -- an hsv property would
+            // be measured against the wrong grammar here, which is a pre-existing gap in
+            // HomieColor rather than something this check introduces.
+            if (!HomieColor.TryParse(value, out _))
+            {
+                return "not an '<r>,<g>,<b>' triple with components in 0..255";
+            }
+
+            return null;
+        }
+
         internal override void SetInternal(string value)
         {
+            // Validate() has already proven this parses; the guard is what keeps that
+            // structural rather than a comment.
             if (HomieColor.TryParse(value, out var parsed))
             {
                 Update(parsed);

--- a/src/common/Homie/V4/Properties/EnumProperty.cs
+++ b/src/common/Homie/V4/Properties/EnumProperty.cs
@@ -32,6 +32,33 @@ namespace SmartHome.Homie.V4.Properties
             OnUpdate?.Invoke(args);
         }
 
+        internal override string? Validate(string value)
+        {
+            var format = FormatAttribute.Value;
+
+            // Homie v4 requires $format on an enum, but a property that declares none has
+            // declared nothing to violate. Rejecting every payload here would turn a
+            // device author's omission into a property no controller can ever set, which
+            // is a worse failure than the one this validation exists to stop.
+            if (format == null || format.Length == 0)
+            {
+                return null;
+            }
+
+            // The format entries are trimmed, the payload is not. A device author writing
+            // "ready, alert" means the same three names; a controller sending " ready"
+            // is sending a different value.
+            foreach (var candidate in format.Split(','))
+            {
+                if (candidate.Trim() == value)
+                {
+                    return null;
+                }
+            }
+
+            return $"not one of the values '{format}' declared by $format";
+        }
+
         internal override void SetInternal(string value)
         {
             Update(value);

--- a/src/common/Homie/V4/Properties/FloatProperty.cs
+++ b/src/common/Homie/V4/Properties/FloatProperty.cs
@@ -89,8 +89,30 @@ namespace SmartHome.Homie.V4.Properties
             return value;
         }
 
+        internal override string? Validate(string value)
+        {
+            if (!double.TryParse(value, out var parsed))
+            {
+                return "not a number";
+            }
+
+            // A Homie float payload is the literal representation of a number, and NaN
+            // and the infinities are not one -- see EnsurePublishable, which throws on
+            // them. Caught here rather than there: SetInternal runs on M2Mqtt's dispatch
+            // thread, so a controller must not be able to reach that throw with a
+            // payload.
+            if (double.IsNaN(parsed) || double.IsPositiveInfinity(parsed) || double.IsNegativeInfinity(parsed))
+            {
+                return "not a finite number";
+            }
+
+            return ValidateRange(parsed);
+        }
+
         internal override void SetInternal(string value)
         {
+            // Validate() has already proven this parses; the guard is what keeps that
+            // structural rather than a comment.
             if (double.TryParse(value, out var parsed))
             {
                 Update(parsed);

--- a/src/common/Homie/V4/Properties/IntegerProperty.cs
+++ b/src/common/Homie/V4/Properties/IntegerProperty.cs
@@ -32,8 +32,20 @@ namespace SmartHome.Homie.V4.Properties
             OnUpdate?.Invoke(args);
         }
 
+        internal override string? Validate(string value)
+        {
+            if (!int.TryParse(value, out var parsed))
+            {
+                return "not an integer";
+            }
+
+            return ValidateRange(parsed);
+        }
+
         internal override void SetInternal(string value)
         {
+            // Validate() has already proven this parses; the guard is what keeps that
+            // structural rather than a comment.
             if (int.TryParse(value, out var parsed))
             {
                 Update(parsed);

--- a/src/common/Homie/V4/Properties/PropertyBase.cs
+++ b/src/common/Homie/V4/Properties/PropertyBase.cs
@@ -54,20 +54,113 @@ namespace SmartHome.Homie.V4.Properties
         
         public UnitAttribute UnitAttribute => _unitAttribute;
 
-        public void Set(byte[] value)
+        /// <summary>
+        /// Applies a controller's payload, if the property's own declared
+        /// <c>$datatype</c> and <c>$format</c> permit it.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> when the payload was applied, <c>false</c> when it was rejected.
+        /// </returns>
+        /// <remarks>
+        /// A rejected payload is logged and dropped: the value does not move, so nothing
+        /// is published and nothing lands in the broker's retained store. Homie has no
+        /// "command refused" channel, so a property that did not change is the only
+        /// feedback a controller gets -- and it is the same signal the convention gives
+        /// for any other refusal.
+        /// </remarks>
+        public bool Set(byte[] value)
         {
-            if (SettableAttribute.Value)
-            {
-                var str = Encoding.UTF8.GetString(value, 0, value.Length);
-                _logger.LogDebug($"Setting property '{TopicId}' to value '{str}'.");
-                SetInternal(str);
-            }
-            else
+            if (!SettableAttribute.Value)
             {
                 throw new InvalidOperationException($"Property '{TopicId}' is not settable.");
             }
+
+            var str = Encoding.UTF8.GetString(value, 0, value.Length);
+
+            // Before SetInternal, deliberately. Validating afterwards would mean the
+            // value had already moved and OnUpdate had already published it.
+            var rejection = Validate(str);
+            if (rejection != null)
+            {
+                _logger.LogWarning($"Property '{TopicId}' rejected the payload '{str}': {rejection}.");
+                return false;
+            }
+
+            _logger.LogDebug($"Setting property '{TopicId}' to value '{str}'.");
+            SetInternal(str);
+            return true;
         }
 
+        /// <summary>
+        /// Why this payload is not a value the property may hold, or <c>null</c> if it is.
+        /// </summary>
+        /// <remarks>
+        /// Every datatype answers this the same way -- reject -- which is the point: the
+        /// five implementations used to give three different answers to the same
+        /// question. <see cref="EnumProperty"/> accepted anything, the numeric types
+        /// ignored a declared range, <see cref="FloatProperty"/> and
+        /// <see cref="ColorProperty"/> dropped an unparseable payload silently, and
+        /// <see cref="BooleanProperty"/> turned anything unrecognised into <c>false</c> --
+        /// which at the broker is indistinguishable from a controller having deliberately
+        /// asked for <c>false</c>.
+        ///
+        /// The returned text is the log line's reason, so it reads as a continuation of
+        /// "rejected the payload 'x': ".
+        /// </remarks>
+        internal abstract string? Validate(string value);
+
         internal abstract void SetInternal(string value);
+
+        /// <summary>
+        /// Checks a numeric value against the <c>min:max</c> range <c>$format</c> may
+        /// declare. Returns <c>null</c> when the value is in range, or when no range was
+        /// declared.
+        /// </summary>
+        protected string? ValidateRange(double value)
+        {
+            if (!TryGetDeclaredRange(out var minimum, out var maximum))
+            {
+                return null;
+            }
+
+            if (value < minimum || value > maximum)
+            {
+                return $"outside the range '{FormatAttribute.Value}' declared by $format";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Reads the <c>min:max</c> range a numeric <c>$format</c> may declare.
+        /// </summary>
+        /// <remarks>
+        /// Both ends are required, which is all Homie v4 defines ("from:to", e.g.
+        /// "10:15"). A <c>$format</c> that is empty or does not parse as a range declares
+        /// no range, so no range is enforced -- a device author's malformed format is not
+        /// a reason to start refusing a controller's otherwise valid payloads.
+        ///
+        /// Both ends are read as doubles, integer properties included. An int is exact as
+        /// a double well beyond the range the type covers, so one helper serves both
+        /// numeric types rather than two that could drift apart.
+        /// </remarks>
+        private bool TryGetDeclaredRange(out double minimum, out double maximum)
+        {
+            minimum = 0;
+            maximum = 0;
+
+            var format = FormatAttribute.Value;
+            if (format == null || format.Length == 0)
+            {
+                return false;
+            }
+
+            var bounds = format.Split(':');
+
+            return bounds.Length == 2
+                && double.TryParse(bounds[0].Trim(), out minimum)
+                && double.TryParse(bounds[1].Trim(), out maximum)
+                && minimum <= maximum;
+        }
     }
 }

--- a/src/common/Homie/V4/Properties/StringProperty.cs
+++ b/src/common/Homie/V4/Properties/StringProperty.cs
@@ -33,6 +33,10 @@ namespace SmartHome.Homie.V4.Properties
             OnUpdate?.Invoke(args);
         }
 
+        // Any payload is a valid Homie string, and $format carries no meaning for this
+        // datatype in Homie v4 -- so there is nothing declared for a payload to violate.
+        internal override string? Validate(string value) => null;
+
         internal override void SetInternal(string value) => Update(value);
     }
 }

--- a/src/integrationTests/HomieClientCheck/Program.cs
+++ b/src/integrationTests/HomieClientCheck/Program.cs
@@ -38,8 +38,15 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
         // The names are taken from the State enum rather than spelled out here. They are
         // the convention's own vocabulary and StateExtensions.GetString() already owns
         // it; a private copy would drift from $state, which is precisely the value the
-        // host compares this property against. This array is the single source for both
-        // the $format string and the set of commands HandleLifecycleCommand accepts.
+        // host compares this property against.
+        //
+        // It is the single source for the $format string, and since issue #39 that is
+        // the only place the membership rule is stated: EnumProperty measures a /set
+        // against its own $format and HomieClient does not raise OnCommand for a payload
+        // it refused, so a name outside this array can no longer reach the handler below.
+        // The array is still needed -- something has to build $format, and the handler
+        // still has to map a name to the client call that applies it -- but that mapping
+        // is dispatch now, not a second copy of the check.
         private static readonly State[] LifecycleStates = { State.Ready, State.Alert, State.Sleeping };
 
         private static IHomieClient _homieClient;
@@ -184,6 +191,9 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
                 return;
             }
 
+            // Unreachable since #39 -- the property refuses a payload its $format does not
+            // list, and a refused payload never reaches OnCommand. Kept as the thing that
+            // would say so if that ever stopped being true.
             Debug.WriteLine($"HomieClientCheck: unknown lifecycle command '{payload}'.");
         }
 

--- a/src/tests/Unit/PropertyValidationTests.cs
+++ b/src/tests/Unit/PropertyValidationTests.cs
@@ -1,0 +1,397 @@
+using SmartHome.Homie.V4;
+using SmartHome.Homie.V4.Builder;
+using SmartHome.Homie.V4.Extensions;
+using SmartHome.Homie.V4.Properties;
+using nanoFramework.Logging;
+using nanoFramework.Logging.Debug;
+using nanoFramework.M2Mqtt.Messages;
+using nanoFramework.TestFramework;
+using System.Text;
+
+namespace SmartHome.UnitTests
+{
+    // A settable property used to accept payloads its own $datatype and $format forbid,
+    // and the types disagreed about what to do with one: EnumProperty accepted anything,
+    // the numeric types ignored a declared range, FloatProperty and ColorProperty dropped
+    // an unparseable payload silently, and BooleanProperty turned everything unrecognised
+    // into false -- fabricating a value, not merely failing to refuse one.
+    //
+    // Every case below asserts the same thing: the property did not move. That is the
+    // whole contract. Homie has no "command refused" channel, so a value that did not
+    // change is all a controller gets, and it is the same signal the convention gives for
+    // any other refusal (issue #39, and #33 for why the *app*-level refusal is separate).
+    [TestClass]
+    public class PropertyValidationTests
+    {
+        private const string _deviceTopicId = "super-car";
+        private const string _deviceName = "Super car";
+        private const string _nodeTopicId = "matrix";
+        private const string _nodeName = "Datatype matrix";
+        private const string _nodeType = "conformance";
+
+        [Setup]
+        public void Setup()
+        {
+            LogDispatcher.LoggerFactory = new DebugLoggerFactory();
+        }
+
+        [Cleanup]
+        public void Cleanup()
+        {
+            LogDispatcher.LoggerFactory = null;
+        }
+
+        [TestMethod]
+        public void IntegerProperty_Rejects_A_Payload_Outside_Its_Declared_Range()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddIntegerProperty("integer-value", "Integer", 7)
+                            .WithSettable(true)
+                            .WithFormat("0:100")
+                        .BuildProperty(out IntegerProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            // Both ends are inclusive, so the bounds themselves are commands, not
+            // violations -- a range check that is off by one at the edge is the usual way
+            // this kind of validation goes wrong.
+            SendCommand(mqttClient, property, "0");
+            Assert.AreEqual(0, property.Value);
+
+            SendCommand(mqttClient, property, "100");
+            Assert.AreEqual(100, property.Value);
+
+            SendCommand(mqttClient, property, "101");
+            Assert.AreEqual(100, property.Value, "a value above the declared maximum moved the property");
+
+            SendCommand(mqttClient, property, "-1");
+            Assert.AreEqual(100, property.Value, "a value below the declared minimum moved the property");
+        }
+
+        [TestMethod]
+        public void IntegerProperty_Rejects_A_Payload_That_Is_Not_An_Integer()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddIntegerProperty("integer-value", "Integer", 7)
+                            .WithSettable(true)
+                        .BuildProperty(out IntegerProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "twelve");
+
+            Assert.AreEqual(7, property.Value);
+        }
+
+        [TestMethod]
+        public void FloatProperty_Rejects_A_Payload_Outside_Its_Declared_Range()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddFloatProperty("float-value", "Float", 5.0)
+                            .WithSettable(true)
+                            .WithFormat("-10:10.5")
+                        .BuildProperty(out FloatProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "10.5");
+            Assert.AreEqual(10.5, property.Value);
+
+            SendCommand(mqttClient, property, "10.6");
+            Assert.AreEqual(10.5, property.Value, "a value above the declared maximum moved the property");
+
+            SendCommand(mqttClient, property, "-10.1");
+            Assert.AreEqual(10.5, property.Value, "a value below the declared minimum moved the property");
+        }
+
+        [TestMethod]
+        public void FloatProperty_Rejects_A_Payload_That_Is_Not_A_Number()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddFloatProperty("float-value", "Float", 5.0)
+                            .WithSettable(true)
+                        .BuildProperty(out FloatProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "warm");
+
+            Assert.AreEqual(5.0, property.Value);
+        }
+
+        [TestMethod]
+        public void FloatProperty_Rejects_A_Payload_With_No_Homie_Representation()
+        {
+            // NaN and the infinities have no Homie float payload -- EnsurePublishable
+            // throws on them, and SetInternal runs on M2Mqtt's dispatch thread, whose
+            // catch-all treats an escaping exception as a dead connection. So a
+            // controller must not be able to reach that throw with a payload, whether or
+            // not this runtime's double.TryParse happens to accept the spelling.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddFloatProperty("float-value", "Float", 5.0)
+                            .WithSettable(true)
+                        .BuildProperty(out FloatProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "NaN");
+            SendCommand(mqttClient, property, "Infinity");
+            SendCommand(mqttClient, property, "-Infinity");
+
+            Assert.AreEqual(5.0, property.Value);
+        }
+
+        [TestMethod]
+        public void BooleanProperty_Rejects_A_Payload_That_Is_Not_True_Or_False()
+        {
+            // The worst of the old behaviours, and the reason this is worth doing before
+            // an actuator exists: an unrecognised payload did not fail to apply, it
+            // applied 'false'. A relay would have opened, and the broker would have
+            // carried a retained 'false' no controller ever asked for.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddBooleanProperty("boolean-value", "Boolean", true)
+                            .WithSettable(true)
+                        .BuildProperty(out BooleanProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "on");
+            Assert.IsTrue(property.Value, "'on' was fabricated into false");
+
+            SendCommand(mqttClient, property, "1");
+            Assert.IsTrue(property.Value, "'1' was fabricated into false");
+
+            SendCommand(mqttClient, property, "True");
+            Assert.IsTrue(property.Value, "'True' was fabricated into false");
+
+            // ... and the two payloads the convention does define still work.
+            SendCommand(mqttClient, property, "false");
+            Assert.IsFalse(property.Value);
+
+            SendCommand(mqttClient, property, "true");
+            Assert.IsTrue(property.Value);
+        }
+
+        [TestMethod]
+        public void EnumProperty_Rejects_A_Payload_Its_Format_Does_Not_List()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddEnumProperty("enum-value", "Enum", "low")
+                            .WithSettable(true)
+                            .WithFormat("low,medium,high")
+                        .BuildProperty(out EnumProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "high");
+            Assert.AreEqual("high", property.Value);
+
+            SendCommand(mqttClient, property, "purple");
+            Assert.AreEqual("high", property.Value, "a value $format does not list moved the property");
+
+            // A prefix of a listed value is not a listed value.
+            SendCommand(mqttClient, property, "med");
+            Assert.AreEqual("high", property.Value);
+        }
+
+        [TestMethod]
+        public void EnumProperty_Accepts_Anything_When_It_Declares_No_Format()
+        {
+            // Homie requires $format on an enum, but a property that declares none has
+            // declared nothing to violate. Refusing everything here would turn a device
+            // author's omission into a property no controller can ever set.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddEnumProperty("enum-value", "Enum", "low")
+                            .WithSettable(true)
+                        .BuildProperty(out EnumProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "purple");
+
+            Assert.AreEqual("purple", property.Value);
+        }
+
+        [TestMethod]
+        public void ColorProperty_Rejects_A_Payload_That_Is_Not_An_Rgb_Triple()
+        {
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddColorProperty("color-value", "Colour", new HomieColor { R = 1, G = 2, B = 3 })
+                            .WithSettable(true)
+                            .WithFormat("rgb")
+                        .BuildProperty(out ColorProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "FF8000");
+            SendCommand(mqttClient, property, "255,128");
+            SendCommand(mqttClient, property, "255,128,256");
+
+            Assert.AreEqual(1, (int)property.Value.R);
+            Assert.AreEqual(2, (int)property.Value.G);
+            Assert.AreEqual(3, (int)property.Value.B);
+
+            SendCommand(mqttClient, property, "255,128,0");
+
+            Assert.AreEqual(255, (int)property.Value.R);
+            Assert.AreEqual(128, (int)property.Value.G);
+            Assert.AreEqual(0, (int)property.Value.B);
+        }
+
+        [TestMethod]
+        public void StringProperty_Accepts_Any_Payload()
+        {
+            // Nothing to violate: every payload is a valid Homie string, and $format
+            // carries no meaning for this datatype.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddStringProperty("string-value", "String", "initial")
+                            .WithSettable(true)
+                        .BuildProperty(out StringProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            SendCommand(mqttClient, property, "anything at all, 255,128 included");
+
+            Assert.AreEqual("anything at all, 255,128 included", property.Value);
+        }
+
+        [TestMethod]
+        public void HomieClient_Publishes_Nothing_For_A_Rejected_Payload()
+        {
+            // The refusal has to leave no trace at the broker. A rejected payload that
+            // was still reflected would be worse than accepting it: the retained store
+            // would advertise a value the device does not hold, to every controller that
+            // connects afterwards.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddIntegerProperty("integer-value", "Integer", 7)
+                            .WithSettable(true)
+                            .WithFormat("0:100")
+                        .BuildProperty(out IntegerProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Connect(device, mqttClient);
+
+            var publishesBefore = mqttClient.PublishCount;
+            var payloadsBefore = mqttClient.PayloadsFor(property.GetTopic()).Length;
+
+            SendCommand(mqttClient, property, "9000");
+
+            Assert.AreEqual(publishesBefore, mqttClient.PublishCount, "a rejected payload published something");
+            Assert.AreEqual(payloadsBefore, mqttClient.PayloadsFor(property.GetTopic()).Length);
+        }
+
+        [TestMethod]
+        public void HomieClient_Does_Not_Raise_OnCommand_For_A_Rejected_Payload()
+        {
+            // The decision recorded here: a payload the library refused is not handed to
+            // the app. HandleIncomingMessage's standing rule -- "a command that failed to
+            // apply is still a command the app should hear about" -- is about a command
+            // that threw while being applied, typically from the reflection publish on a
+            // flaky link. That command did reach the device. A payload that violates the
+            // property's own $datatype or $format never did, and raising it would leave
+            // every actuator re-checking the format its property already declares.
+            var mqttClient = BuildClient();
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            var device = builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddEnumProperty("enum-value", "Enum", "low")
+                            .WithSettable(true)
+                            .WithFormat("low,medium,high")
+                        .BuildProperty(out EnumProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            var homieClient = new HomieClient(device, mqttClient);
+            homieClient.Connect();
+
+            var commandCount = 0;
+            homieClient.OnCommand += (args) => commandCount++;
+
+            SendCommand(mqttClient, property, "purple");
+            Assert.AreEqual(0, commandCount, "the app was handed a payload the library refused");
+
+            SendCommand(mqttClient, property, "medium");
+            Assert.AreEqual(1, commandCount, "a valid command no longer reaches the app");
+        }
+
+        [TestMethod]
+        public void Property_Set_Reports_Whether_The_Payload_Was_Applied()
+        {
+            // Set() is public, so a caller outside HomieClient can tell a refusal from a
+            // success without inspecting the value it was trying to write.
+            var builder = new HomieDeviceBuilder(_deviceTopicId, _deviceName);
+            builder.AddNode(_nodeTopicId, _nodeName, _nodeType)
+                        .AddIntegerProperty("integer-value", "Integer", 7)
+                            .WithSettable(true)
+                            .WithFormat("0:100")
+                        .BuildProperty(out IntegerProperty property)
+                    .BuildNode()
+                .BuildDevice();
+
+            Assert.IsTrue(property.Set(Encoding.UTF8.GetBytes("42")));
+            Assert.AreEqual(42, property.Value);
+
+            Assert.IsFalse(property.Set(Encoding.UTF8.GetBytes("9000")));
+            Assert.AreEqual(42, property.Value);
+        }
+
+        private static MockMqttClient BuildClient() => new MockMqttClient();
+
+        // Announce the device, so a command travels the same path it does in production:
+        // the /set subscription, HandleIncomingMessage, then the property.
+        private static void Connect(Device device, MockMqttClient mqttClient)
+        {
+            var homieClient = new HomieClient(device, mqttClient);
+            homieClient.Connect();
+        }
+
+        private static void SendCommand(MockMqttClient mqttClient, PropertyBase property, string payload)
+        {
+            var topic = $"{property.GetTopic()}{Constants.TopicSeparator}{Constants.SetPropertyTopicId}";
+            mqttClient.RaisePublishReceived(
+                new MqttMsgPublishEventArgs(topic, Encoding.UTF8.GetBytes(payload), false, MqttQoSLevel.AtLeastOnce, false));
+        }
+    }
+}

--- a/src/tests/Unit/Unit.nfproj
+++ b/src/tests/Unit/Unit.nfproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="HomieClientTests.cs" />
     <Compile Include="DeviceBuilderTests.cs" />
+    <Compile Include="PropertyValidationTests.cs" />
     <Compile Include="MockMqttClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/tests/Unit/nano.ci.runsettings
+++ b/src/tests/Unit/nano.ci.runsettings
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  CI run settings: the same 34 unit tests, executed on the nanoclr *virtual device*
-  instead of a physical board.
+  CI run settings: the same unit tests, executed on the nanoclr *virtual device*
+  instead of a physical board. (No count here: it was stale within three commits of
+  being written, and the run reports its own.)
 
   This is a second file rather than a switch inside nano.runsettings because the settings
   are declarative and a reviewer should be able to see, in one place, exactly what CI


### PR DESCRIPTION
Closes #39.

A settable property accepted payloads its own `$datatype`/`$format` forbids, and the five types gave three different answers to the same question: accept it, drop it, or invent a value for it.

`PropertyBase.Set` now validates before `SetInternal` mutates anything, through a `Validate` hook each type implements. A rejected payload is logged and dropped — the value does not move, so nothing is published and nothing lands in the retained store, and the controller's only feedback is a property that did not change. That is the same signal Homie gives for any refusal.

| Type | Before | Now |
|---|---|---|
| `EnumProperty` | accepted anything | payload must be one of the `$format` values |
| `IntegerProperty` | parsed, then ignored `min:max` | must parse **and** sit inside a declared `min:max` |
| `FloatProperty` | unparseable dropped silently, range ignored | must parse, be finite, and sit inside a declared `min:max` |
| `ColorProperty` | unparseable dropped silently | must be a real `<r>,<g>,<b>` triple, rejection explicit |
| `BooleanProperty` | anything unrecognised became `false` | exactly `true` or `false` |
| `StringProperty` | accepted anything | unchanged — nothing declared to violate |

`BooleanProperty` was the one worth doing first: it did not merely fail to reject, it fabricated. A controller sending `on` or a typo got a device that published `false` and acted on it, which at the broker is indistinguishable from a controller having deliberately asked for `false`.

Two deliberate non-changes. A string property has nothing to violate — every payload is a valid Homie string and `$format` carries no meaning for the datatype. An enum that declares **no** `$format` also has nothing to violate: Homie requires `$format` on an enum, but refusing everything there would turn a device author's omission into a property no controller can ever set, which is a worse failure than the one being fixed.

One case is new rather than merely stricter: a float payload that parses to `NaN` or an infinity is refused. `EnsurePublishable` throws on those, and `SetInternal` runs on M2Mqtt's dispatch thread, whose catch-all treats an escaping exception as a dead connection — so a controller must not be able to reach that throw with a payload.

Numeric ranges require both ends (`0:100`), which is all Homie v4 defines. A `$format` that is empty or does not parse as a range declares no range and none is enforced: a device author's malformed format is not a reason to start refusing a controller's otherwise valid payloads.

## The `OnCommand` decision

**`OnCommand` no longer fires for a payload the library rejected.**

`HandleIncomingMessage` guarded `property.Set()` and `OnCommand` separately, commenting that "a command that failed to apply is still a command the app should hear about". That reasoning holds, and it is about a *different* failure: `Set()` only throws once it is applying a payload it already accepted — typically from the reflection publish on a flaky link — and that command did reach the device. A payload violating the property's own declaration never reached anything: the value did not move and nothing was published.

The deciding argument is the duplication this issue exists to remove. If a refused payload still reaches `OnCommand`, every actuator must keep re-checking the `$format` its property already declares, which is exactly what `HomieClientCheck.HandleLifecycleCommand` does today. Both cases stay distinguishable because `Set()` now returns `bool`; an exception out of `Set()` still raises `OnCommand`.

This is the library's half of the #33 spike, which asked whether the *app* should be able to refuse a command and was closed as working-as-intended. The split: the library refuses what the *declaration* forbids, the app refuses what its *state* forbids (a legal enum value that is an illegal transition, a valid setpoint a relay then fails to reach) and still corrects the reflection afterwards. No API change to `IHomieClient`.

## Can `HomieClientCheck`'s copy of the enum list go away?

**Partly, and the array itself has to stay.** `LifecycleStates` is what builds the `$format` string, so it cannot be deleted. What changes is its second role: `HandleLifecycleCommand`'s loop is now dispatch (name → `Alert()`/`Sleep()`/`Ready()`) rather than a second membership check, because a name outside `$format` can no longer reach the handler. Its "unknown lifecycle command" branch is unreachable and is kept, commented as such, as the thing that would say so if that stopped being true. Comment-only change to that file.

## Verification

**Run on hardware: the full integration suite passes, all 5 tests.** `.\scripts\Run-IntegrationTests.ps1` against a real ESP32 on COM3 and a real Mosquitto broker, 186s total (81s of it deploys):

| Test | | Detail |
|---|---|---|
| `WifiCheck` | PASS | connected to the configured WiFi network |
| `MqttCheck` | PASS | round-trip through `192.168.1.238` on `smarthome-test/echo` |
| `Bmp280Check` | PASS | 23.19 °C, 941.85 hPa, 59.87 %RH |
| `HomieClientCheck` | PASS | attributes, datatypes, retained flags, `/set` round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce all conform |
| `MqttReconnectCheck` | PASS | republished and stayed subscribed across outages of 3s, 20s |

The unit suite was also run on the nanoclr virtual device — `.\scripts\Run-Tests.ps1 -RunSettings nano.ci.runsettings`, the same path CI takes — where **55 of 55 tests pass**, and the full solution rebuilds clean. `Run-Tests.ps1` against `nano.runsettings` (the unit suite on the physical board) was not run; the virtual device covers the same 55 tests.

The suite leaves `MqttReconnectCheck` flashed, so the board needs a `Deploy-ToDevice.ps1` to go back to being a RoomSensor.

Twelve new tests in `src/tests/Unit/PropertyValidationTests.cs`, one or more per datatype, each asserting the property does not move. They drive commands through `HomieClient` and the mock broker rather than calling `Set` directly, so they cover the whole path: range bounds are checked inclusive at both ends, `HomieClient_Publishes_Nothing_For_A_Rejected_Payload` pins that a refusal leaves no trace at the broker, and `HomieClient_Does_Not_Raise_OnCommand_For_A_Rejected_Payload` pins the decision above in CI.

The conformance suite gained an `out-of-format /set` phase (one forbidden payload per datatype, `string-value` excepted). Proving a negative on the wire needs care: a `/set` is non-retained, so a *lost* command leaves exactly the trace a *refused* one does. Each forbidden payload is therefore followed by a valid one on the same property inside a single capture window — the valid payload's reflection proves the device was subscribed and receiving while the forbidden one went past. Seeing neither is reported as a lost command rather than passing. The ordered-payload reader the refused-transition step had inline is now `Get-HomieLivePayloads`, shared by both.

**This phase ran on hardware and measured what it claims to.** It took 3.9s over a single capture window with no retries — every case resolved on the first round — and the captured `homie/#` traffic shows exactly one publish per case inside it, each the valid payload's reflection with nothing ahead of it:

```
homie/homie-client-check/matrix/integer-value 0 43          # not 101
homie/homie-client-check/matrix/float-value   0 22.50       # not warm
homie/homie-client-check/matrix/boolean-value 0 true        # no fabricated false
homie/homie-client-check/matrix/enum-value    0 medium      # not purple
homie/homie-client-check/matrix/color-value   0 255,128,0   # not FF8000
```

### A follow-up commit on the boolean case

Review of this branch found the boolean case could not detect the behaviour it exists to measure. It asserted only that the forbidden payload never came back on the property topic — but the old `BooleanProperty` did not echo `on`, it turned it into false and published *that*. With the case's valid payload also being `false`, a fabricating device put `['false', 'false']` on the topic: forbidden payload absent, echo present, phase green on exactly the regression it was written to catch.

Fixed in `fix(tests): make the boolean out-of-format case able to see a fabrication`. The boolean's valid payload is now `true`, so a fabricated `false` is distinguishable from the reflection, and the assertion is generalised from "the forbidden payload must not come back" to "the valid payload's reflection must be the first thing on the topic". A refusal publishes nothing, so anything ahead of the reflection is the forbidden payload having moved the value, whatever it was rendered as — which covers every datatype rather than only the ones whose forbidden payload happens to round-trip verbatim. The hardware run above used the fixed script.

`CLAUDE.md` gains the rule for actuator authors: don't re-check the payload against `$datatype`/`$format`, the property already did.

## Note for the reviewer

`src/tests/Unit/Unit.nfproj` gains one `<Compile Include>` line. `claude/rainwater-cistern` is adding entries to the same `ItemGroup` and had not landed when this branched, so expect a trivial conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

