### PR TITLE
perf(scripts): size the deploy pad from the previous image, not a flat 400KB

### DIFF
--- a/.claude/agents/device-ops.md
+++ b/.claude/agents/device-ops.md
@@ -20,8 +20,11 @@ Scripts you own (each has a matching `.claude/skills/smarthome-*` skill too):
 - Don't rewrite `Start-DevEnv.ps1`'s child launches to use `-RedirectStandardOutput`: that forces
   handle inheritance and makes piping the script's output hang forever. The ShellExecute +
   `log_dest file` + `cmd.exe` wrapper arrangement is deliberate and commented in the script.
-- `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug|Release] [-DeployAddress <hex>]`
-  — build + flash. `-DeployAddress` defaults to this device's current real `deploy` partition
+- `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug|Release] [-DeployAddress <hex>] [-FullPad]`
+  — build + flash. `-FullPad` pads the flat 400KB worst case instead of sizing the 0xFF pad
+  from the per-COM-port record of the last flash — use it on the first deploy after someone
+  has deployed from Visual Studio, which writes the deployment partition behind this script's
+  back. `-DeployAddress` defaults to this device's current real `deploy` partition
   offset (`0x1E0000`) — `nanoff`'s own hardcoded default (`0x1B0000`) landed inside the
   **factory** partition instead and silently produced a deploy the CLR could never load. If a
   deploy "succeeds" but the device never does anything afterward, verify with

--- a/.claude/skills/smarthome-deploy/SKILL.md
+++ b/.claude/skills/smarthome-deploy/SKILL.md
@@ -13,7 +13,15 @@ hard way), then flashes via `nanoff`.
 .\scripts\Deploy-ToDevice.ps1                                                    # RoomSensor, Debug
 .\scripts\Deploy-ToDevice.ps1 -Project src\devices\IrrigationControl\IrrigationControl.nfproj
 .\scripts\Deploy-ToDevice.ps1 -Configuration Release
+.\scripts\Deploy-ToDevice.ps1 -FullPad                                           # after a VS deploy
 ```
+
+The image is padded with 0xFF far enough to erase whatever the previous deploy left behind —
+sized from a per-COM-port record of the last flash, falling back to a flat 400KB whenever that
+record can't be trusted. **Pass `-FullPad` on the first deploy after anyone has deployed from
+Visual Studio**, since VS writes the deployment partition without going through this script and
+the record then describes an image that is no longer on the device. `Run-Tests.ps1` clears the
+record itself, so no `-FullPad` is needed after a unit-test run.
 
 To deploy an integration test (`src\integrationTests\*`), prefer
 `smarthome-integration-tests` — it deploys, captures, and reads the verdict in one call instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ have a script yet, that's a gap worth closing rather than working around.
 |---|---|---|---|
 | `scripts\Start-DevEnv.ps1 [-NoSync] [-Detached]` | Syncs the sibling repos (unless `-NoSync`), then starts local Mosquitto (explicit `0.0.0.0` listener — a bare `-p` binds localhost-only on Mosquitto 2.x and silently can't be reached from a real device) and subscribes to `homie/#`. `-Detached` backgrounds both and returns | No | `smarthome-dev-env` |
 | `scripts\Stop-DevEnv.ps1 [-KeepLog] [-IncludeOrphans]` | Stops whatever `Start-DevEnv.ps1` recorded for the configured port, verifying pid+name+start-time first so a recycled pid is never killed. No-op + exit 0 if nothing is running, so it's safe to call unconditionally. `-IncludeOrphans` also clears brokers/subscribers this repo started that no state file covers | No | `smarthome-dev-env` |
-| `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug\|Release]` | Always `/t:Rebuild`s (a plain incremental build silently drops the deployment `.bin`) then flashes via `nanoff` | **Yes** | `smarthome-deploy` |
+| `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug\|Release] [-FullPad]` | Always `/t:Rebuild`s (a plain incremental build silently drops the deployment `.bin`) then flashes via `nanoff`, padding the image with 0xFF far enough to erase the previous one (see Deploy padding below). `-FullPad` after a Visual Studio deploy | **Yes** | `smarthome-deploy` |
 | `scripts\Run-Tests.ps1` | Builds `SmartHome.UnitTests` and runs it via `vstest.console` + the nanoFramework test adapter | **Yes** | `smarthome-test` |
 | `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` | The whole `src\integrationTests` suite in one call: broker up, deploy + capture + verdict per test, broker down, summary + exit code | **Yes** | `smarthome-integration-tests` |
 | `scripts\Sync-NanoFrameworkRepos.ps1 [-Force]` | Clones/updates the sibling nanoFramework repos beside `SmartHome` | No | `smarthome-sync-nanoframework` |
@@ -81,6 +81,30 @@ If a new recurring unit of work shows up that isn't covered by an existing scrip
 (follow the conventions above: `Common.ps1` helpers, `Set-StrictMode`, real exit codes, clear
 `Write-Error` remediation) and give it a matching skill — that's the standing expectation for
 this repo, not a one-time cleanup.
+
+### Deploy padding
+
+`nanoff` erases and writes only the image file's own byte length, so a smaller app flashed
+after a larger one leaves the larger one's tail unerased past the new image's end — and the
+CLR finds it. It walks the *whole* deployment partition looking for assembly headers and, on
+a header that doesn't check out, moves to the next candidate rather than stopping
+(`ContiguousBlockAssemblies` in `nf-interpreter`'s `src/CLR/Startup/CLRStartup.cpp`). No
+amount of trailing blank flash terminates that scan; only overwriting the stale bytes does.
+`Deploy-ToDevice.ps1` therefore pads every image with 0xFF, and the invariant it has to hold
+is exactly "cover the footprint of the previous image".
+
+It used to pad every image to a flat 400KB, which held that invariant by brute force. It now
+records the last flashed size per COM port (in `%TEMP%\smarthome-deploy-<port>.json`, written
+pessimistically before the flash and tightened after it) and pads to `max(this image, that
+record)` rounded up to a 4KB sector — same guarantee, roughly half the erase-and-verify
+footprint across a suite run. Anything the record can't vouch for — missing, corrupt, a
+different `-DeployAddress`, `-FullPad` — falls back to the flat 400KB, never to the bare
+image size.
+
+The record only describes what *this script* flashed. Visual Studio's F5 deploy and the
+nanoFramework test adapter both write the deployment partition themselves, and erase only
+their own footprint too. `Run-Tests.ps1` clears the record for that reason; Visual Studio
+can't, so pass `-FullPad` on the first deploy after one.
 
 ## First-time setup
 

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -295,7 +295,10 @@ function Invoke-GitCloneOrUpdate {
 # rename that only touched Start-DevEnv.ps1 would silently turn the scan into a
 # permanent "nothing found" -- which reads as success.
 
-$SmartHomeDevEnvPrefix = 'smarthome'
+# Shared by every temp file this repo leaves behind, dev-environment or not (the
+# deploy-state section at the bottom of this file uses it too), so one glob finds
+# the lot.
+$SmartHomeTempFilePrefix = 'smarthome'
 $SmartHomeHomieTopic = 'homie/#'
 
 # The address host-side mosquitto clients dial. 127.0.0.1, not 'localhost'. Measured, not
@@ -339,7 +342,7 @@ function Get-SmartHomeDevEnvPath {
         'Snapshot'           { "homie-snapshot-$Port.log" }
     }
 
-    return (Join-Path ([System.IO.Path]::GetTempPath()) "$SmartHomeDevEnvPrefix-$suffix")
+    return (Join-Path ([System.IO.Path]::GetTempPath()) "$SmartHomeTempFilePrefix-$suffix")
 }
 
 function Get-SmartHomeSubscriberArguments {
@@ -671,4 +674,149 @@ function Stop-SmartHomeDevEnv {
     }
 
     return $stoppedSomething
+}
+
+# ── Deploy state ──────────────────────────────────────────────────────────────
+# Deploy-ToDevice.ps1 pads every image with 0xFF before flashing it, because nanoff
+# erases and writes only the image file's own byte length -- so a smaller app
+# deployed after a larger one leaves the larger one's tail sitting unerased past
+# the new image's end. That tail is not ignored: the CLR walks the WHOLE deployment
+# partition looking for assembly headers, and on a header that doesn't check out it
+# `continue`s to the next candidate rather than stopping (ContiguousBlockAssemblies
+# in nf-interpreter's src\CLR\Startup\CLRStartup.cpp, whose stream Length is the
+# full block range). So no amount of trailing blank flash terminates the scan --
+# the only thing that keeps stale assemblies out is overwriting them.
+#
+# The invariant is therefore exactly "cover the footprint of the previous image",
+# and the previous image's size is the one fact needed to pad to less than a flat
+# worst case. It is recorded here, keyed by COM port.
+#
+# Deliberately NOT another -Kind on Get-SmartHomeDevEnvPath: that function's -Port
+# is an MQTT port, and one parameter meaning two different kinds of port depending
+# on -Kind is exactly the ambiguity its callers should not have to hold. This
+# shares the temp directory and $SmartHomeTempFilePrefix, not the signature.
+#
+# StaleBytes is the contract: "the number of bytes from the deploy address that the
+# next flash must overwrite for no leftover assembly data to survive it". It is
+# written pessimistically -- the full padded length -- BEFORE a flash, so an
+# interrupted or failed write still leaves a record covering everything nanoff may
+# have put down, and tightened to the image's own length only once nanoff reports
+# success, at which point everything between the image's end and the padded length
+# is known to be 0xFF.
+#
+# Anything that flashes the device WITHOUT going through Deploy-ToDevice.ps1 --
+# Visual Studio's F5 deploy, the nanoFramework test adapter -- invalidates the
+# record, because it writes assemblies this script never saw. Such a path must call
+# Clear-SmartHomeDeployState; the next deploy then falls back to the flat
+# worst-case pad, which is what the script did unconditionally before any of this.
+$SmartHomeDeployStateVersion = 1
+
+function Get-SmartHomeDeployStatePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ComPort
+    )
+
+    # 'COM3' needs no escaping, but the port comes from local.env.ps1 and something
+    # like \\.\COM10 would otherwise build a path pointing somewhere else entirely.
+    # '*' survives the scrub on purpose, so Clear-SmartHomeDeployState can build the
+    # all-ports glob from this one naming rule instead of restating it.
+    $safePort = ($ComPort -replace '[^A-Za-z0-9._*-]', '_')
+    return (Join-Path ([System.IO.Path]::GetTempPath()) "$SmartHomeTempFilePrefix-deploy-$safePort.json")
+}
+
+function Get-SmartHomeDeployState {
+    # Returns the record only when every field is present and sane; $null otherwise.
+    # Every rejection here costs one full-size deploy -- the behaviour this script
+    # had before the record existed -- so the failure direction is the safe one, and
+    # nothing about a bad record should ever reach the flashing decision.
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ComPort
+    )
+
+    $stateFile = Get-SmartHomeDeployStatePath -ComPort $ComPort
+    if (-not (Test-Path $stateFile)) {
+        return $null
+    }
+
+    try {
+        $state = ConvertTo-SmartHomeHashtable -InputObject (Get-Content $stateFile -Raw | ConvertFrom-Json)
+    }
+    catch {
+        Write-Warning "Ignoring unreadable deploy-state file: $stateFile"
+        return $null
+    }
+
+    if ($null -eq $state -or -not ($state -is [System.Collections.IDictionary])) {
+        return $null
+    }
+
+    if ($state['Version'] -ne $SmartHomeDeployStateVersion) {
+        return $null
+    }
+
+    if ($state['ComPort'] -ne $ComPort) {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace([string]$state['DeployAddress'])) {
+        return $null
+    }
+
+    # Parsed rather than type-checked: ConvertFrom-Json hands back Int32, Int64 or
+    # Double depending on the literal, and the caller does arithmetic with this.
+    $staleBytes = 0
+    if (-not [int]::TryParse([string]$state['StaleBytes'], [ref]$staleBytes) -or $staleBytes -lt 0) {
+        return $null
+    }
+    $state['StaleBytes'] = $staleBytes
+
+    return $state
+}
+
+function Save-SmartHomeDeployState {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ComPort,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DeployAddress,
+
+        [Parameter(Mandatory = $true)]
+        [int]$StaleBytes,
+
+        # Purely for humans reading the file while working out what is on a device.
+        [string]$Image = ''
+    )
+
+    # Deliberately returns nothing, same as Save-SmartHomeDevEnvState: callers only
+    # care that the record landed, and a returned path would leak into their output.
+    @{
+        Version       = $SmartHomeDeployStateVersion
+        ComPort       = $ComPort
+        DeployAddress = $DeployAddress
+        StaleBytes    = $StaleBytes
+        Image         = $Image
+        UpdatedUtc    = (Get-Date).ToUniversalTime().ToString('o')
+    } | ConvertTo-Json -Depth 3 |
+        Set-Content -Path (Get-SmartHomeDeployStatePath -ComPort $ComPort) -Encoding utf8
+}
+
+function Clear-SmartHomeDeployState {
+    # Without -ComPort, clears every port's record. That is the right default for the
+    # callers that need it: the nanoFramework test adapter picks its own device when
+    # nano.runsettings leaves RealHardwarePort empty, so which port it flashed is not
+    # knowable here. Clearing one record too many costs one full-size deploy.
+    param(
+        [string]$ComPort
+    )
+
+    if ($ComPort) {
+        Remove-Item -Path (Get-SmartHomeDeployStatePath -ComPort $ComPort) -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    Get-ChildItem -Path (Get-SmartHomeDeployStatePath -ComPort '*') -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -28,6 +28,7 @@
     .\scripts\Deploy-ToDevice.ps1
     .\scripts\Deploy-ToDevice.ps1 -Verbose
     .\scripts\Deploy-ToDevice.ps1 -Project src\devices\IrrigationControl\IrrigationControl.nfproj
+    .\scripts\Deploy-ToDevice.ps1 -FullPad   # after a Visual Studio deploy: pad the worst case
 #>
 
 [CmdletBinding()]
@@ -51,20 +52,35 @@ param(
     # and read the "deploy" line's Offset column from the printed partition table.
     [string]$DeployAddress = '0x1E0000',
 
-    # Every deployed image gets padded with trailing 0xFF (erased-flash value)
-    # bytes up to this size before flashing. nanoff's erase+write only covers
-    # the image file's own byte length, not the full "deploy" partition -- so
-    # deploying a SMALLER app after a LARGER one leaves that previous app's
-    # trailing assembly bytes sitting unerased past the new image's end, and
-    # the CLR loads BOTH on boot (confirmed: saw WifiCheck's own small assembly
-    # list plus leftover Bmp280Check assemblies in the same resolution pass,
-    # failing to link because bytes past WifiCheck's real end were stale
-    # Bmp280Check data, not blank flash). Padding to a fixed size makes every
-    # deploy erase+write the same footprint regardless of app size. 400KB
-    # comfortably covers every project in this repo today; the partition
-    # itself is 0x1C0000 (~1.75MB), so there's plenty of headroom to raise
-    # this if a future project's image ever gets close to it.
-    [int]$PaddedImageSize = 409600
+    # Deployed images get padded with trailing 0xFF (erased-flash value) bytes
+    # before flashing. nanoff's erase+write only covers the image file's own byte
+    # length, not the full "deploy" partition -- so deploying a SMALLER app after a
+    # LARGER one leaves that previous app's trailing assembly bytes sitting unerased
+    # past the new image's end, and the CLR loads BOTH on boot (confirmed: saw
+    # WifiCheck's own small assembly list plus leftover Bmp280Check assemblies in
+    # the same resolution pass, failing to link because bytes past WifiCheck's real
+    # end were stale Bmp280Check data, not blank flash).
+    #
+    # How far to pad is decided per deploy, from the size the previous one recorded
+    # for this COM port -- see the "Deploy state" section of Common.ps1 for the
+    # invariant, and for why trailing blank flash does not terminate the CLR's scan
+    # on its own. THIS value is the fallback used when no trustworthy record exists:
+    # the flat size every deploy used to pay unconditionally. It has to stay large
+    # enough to cover any image that could already be on the device, so lower it only
+    # with the whole of src\devices and src\integrationTests in mind.
+    [int]$FallbackPadSize = 409600,
+
+    # Refuse to pad past the deploy partition; writing beyond it would run into
+    # whatever partition follows. Advisory, from the same boot-log partition table as
+    # -DeployAddress above (.\scripts\Watch-DeviceSerial.ps1, the "deploy" line's
+    # Size column) -- re-derive it there if a firmware update changes the layout.
+    [int]$DeployPartitionSize = 0x1C0000,
+
+    # Ignore any recorded size and pad to -FallbackPadSize. Use this after something
+    # OTHER than this script has flashed the device -- a Visual Studio F5 deploy, most
+    # likely -- since the record then describes an image that is no longer the one on
+    # the device. Run-Tests.ps1 clears the record itself; Visual Studio cannot.
+    [switch]$FullPad
 )
 
 Set-StrictMode -Version Latest
@@ -130,41 +146,110 @@ if (-not (Test-Path $deployImage)) {
 }
 
 $imageBytes = [System.IO.File]::ReadAllBytes($deployImage)
-if ($imageBytes.Length -gt $PaddedImageSize) {
-    Write-Error "Deploy image ($($imageBytes.Length) bytes) is larger than -PaddedImageSize ($PaddedImageSize bytes). Raise -PaddedImageSize."
+
+# ── Decide how far to pad ─────────────────────────────────────────────────────
+# Only the PREVIOUS image's footprint has to be covered, and Common.ps1's deploy
+# state records exactly that, per COM port. Every reason the record cannot be
+# trusted falls back to the flat -FallbackPadSize rather than to the bare image
+# size: this is the flashing path, and over-padding costs seconds where
+# under-padding costs a device booting somebody else's assemblies.
+$sectorSize = 4096   # ESP32 flash erase granularity; keeps the write sector-aligned.
+
+$staleBytes = $null
+$padReason  = $null
+
+if ($FullPad) {
+    $padReason = '-FullPad was passed'
+}
+else {
+    $deployState = Get-SmartHomeDeployState -ComPort $comPort
+    if ($null -eq $deployState) {
+        $padReason = "no usable deploy record for $comPort"
+    }
+    elseif ($deployState['DeployAddress'] -ne $DeployAddress) {
+        # A different address is a different region: what that record describes says
+        # nothing about what is sitting at this one.
+        $padReason = "the deploy record for $comPort covers $($deployState['DeployAddress']), not $DeployAddress"
+    }
+    else {
+        $staleBytes = $deployState['StaleBytes']
+    }
+}
+
+$padFloor  = if ($null -ne $staleBytes) { $staleBytes } else { $FallbackPadSize }
+$padTarget = [Math]::Max($imageBytes.Length, $padFloor)
+$paddedImageSize = [int][Math]::Ceiling($padTarget / [double]$sectorSize) * $sectorSize
+
+if ($paddedImageSize -gt $DeployPartitionSize) {
+    Write-Error @"
+Padded deploy image ($paddedImageSize bytes) does not fit the deploy partition ($DeployPartitionSize bytes).
+The image itself is $($imageBytes.Length) bytes. Either the app has outgrown the partition, or
+-DeployPartitionSize is stale -- re-read the "deploy" line of the partition table printed by
+.\scripts\Watch-DeviceSerial.ps1 and pass the real size.
+"@
     exit 1
 }
 
 $paddedImage = Join-Path $binDir ($projectName + '.padded.bin')
-$padded = New-Object byte[] $PaddedImageSize
+$padded = New-Object byte[] $paddedImageSize
 
 # Fill with 0xFF by doubling an already-filled prefix rather than looping over
-# ~320KB one byte at a time: the scalar loop measured 560ms per deploy, this is
-# ~10ms. ([Array]::Fill would be simpler but is .NET Core only, and this runs on
+# hundreds of KB one byte at a time: the scalar loop measured 560ms per deploy, this
+# is ~10ms. ([Array]::Fill would be simpler but is .NET Core only, and this runs on
 # Windows PowerShell 5.1.)
 $padded[0] = 0xFF
 $filled = 1
-while ($filled -lt $PaddedImageSize) {
-    $chunk = [Math]::Min($filled, $PaddedImageSize - $filled)
+while ($filled -lt $paddedImageSize) {
+    $chunk = [Math]::Min($filled, $paddedImageSize - $filled)
     [Array]::Copy($padded, 0, $padded, $filled, $chunk)
     $filled += $chunk
 }
 
 [Array]::Copy($imageBytes, $padded, $imageBytes.Length)
 [System.IO.File]::WriteAllBytes($paddedImage, $padded)
-Write-Host "  Padded deploy image: $($imageBytes.Length) -> $PaddedImageSize bytes (0xFF fill, clears any stale prior deployment)." -ForegroundColor DarkGray
+
+if ($null -ne $staleBytes) {
+    Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, covering the $staleBytes bytes the last deploy to $comPort left on the device)." -ForegroundColor DarkGray
+}
+else {
+    Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, full-size pad -- $padReason)." -ForegroundColor DarkGray
+}
+
+# Recorded before the flash, and pessimistically: if nanoff dies partway, or the shell
+# is killed, anything up to $paddedImageSize may have landed and the next deploy has to
+# cover all of it. Tightened below once nanoff reports success. Deliberately not
+# wrapped -- $ErrorActionPreference is 'Stop', so a record that cannot be written
+# aborts before flashing rather than flashing against a stale, smaller number.
+Save-SmartHomeDeployState -ComPort $comPort `
+                          -DeployAddress $DeployAddress `
+                          -StaleBytes $paddedImageSize `
+                          -Image $projectName
 
 nanoff --deploy --serialport $comPort --image "$paddedImage" --address $DeployAddress
 $nanoffExit = $LASTEXITCODE
 
-# nanoff has read the image by now, so the padded copy is 400KB of dead weight in
-# bin\Debug. Leaving it also puts a stale .padded.bin next to a freshly built .bin,
-# which is the same shape as the stale-deployment problem the padding exists to fix.
+# nanoff has read the image by now, so the padded copy is dead weight in bin\Debug.
+# Leaving it also puts a stale .padded.bin next to a freshly built .bin, which is the
+# same shape as the stale-deployment problem the padding exists to fix.
 Remove-Item -Path $paddedImage -Force -ErrorAction SilentlyContinue
 
 if ($nanoffExit -ne 0) {
     Write-Error "nanoff deploy failed (exit code $nanoffExit)."
     exit $nanoffExit
+}
+
+# The write completed, so everything from the image's end up to $paddedImageSize is
+# 0xFF now and the next deploy only has to cover the image itself.
+try {
+    Save-SmartHomeDeployState -ComPort $comPort `
+                              -DeployAddress $DeployAddress `
+                              -StaleBytes $imageBytes.Length `
+                              -Image $projectName
+}
+catch {
+    # The pessimistic record written before the flash is still there and still
+    # correct, just bigger than it needs to be. Not worth failing a deploy that worked.
+    Write-Warning "Could not tighten the deploy record for $comPort ($($_.Exception.Message)). The next deploy will pad to $paddedImageSize bytes."
 }
 
 Write-Host ""

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -83,6 +83,30 @@ if (-not (Test-Path $runSettings)) {
     exit 1
 }
 
+# ── Invalidate Deploy-ToDevice.ps1's padding record ───────────────────────────
+# On real hardware the nanoFramework test adapter puts the test assemblies on the
+# device itself, over the debugger's WireProtocol connection rather than through
+# Deploy-ToDevice.ps1 -- and it erases only its own footprint too
+# (DeploymentExecuteFull in nf-debugger's WireProtocol\Engine.cs erases exactly the
+# assemblies' combined length). Deploy-ToDevice.ps1 sizes its 0xFF padding from a
+# record of what IT last flashed, so after a hardware test run that record describes
+# an image that is no longer what is on the device. Drop it, and the next deploy pads
+# the full fallback size -- what the script did unconditionally before the record
+# existed. Costs one full-size deploy; the alternative is a device booting leftover
+# test assemblies.
+#
+# Read via SelectSingleNode rather than $xml.RunSettings.nanoFrameworkAdapter...:
+# Set-StrictMode makes a missing property on an XmlNode a terminating error, and
+# -RunSettings can point at any file.
+[xml]$runSettingsXml = Get-Content -Path $runSettings -Raw
+$isRealHardwareNode = $runSettingsXml.SelectSingleNode('/RunSettings/nanoFrameworkAdapter/IsRealHardware')
+if ($isRealHardwareNode -and $isRealHardwareNode.InnerText.Trim() -eq 'True') {
+    # Every port, not just $env:SMARTHOME_COM_PORT: nano.runsettings leaves
+    # RealHardwarePort empty, so the adapter flashes whichever device it detects first.
+    Clear-SmartHomeDeployState
+    Write-Host "  Cleared the deploy padding record -- the test adapter flashes the device itself." -ForegroundColor DarkGray
+}
+
 # ── Locate vstest.console and the nanoFramework test adapter ─────────────────
 $vstest = Get-VsTestPath
 $vstestCmd = Get-Command $vstest -ErrorAction SilentlyContinue


### PR DESCRIPTION
Closes #17.

## What changed

`Deploy-ToDevice.ps1` padded every deployment image with 0xFF to a flat 409,600 bytes, so
`nanoff` erased and verified 400KB whether the image was RoomSensor's 259,168 bytes or
WifiCheck's 89,512. It now sizes the pad from a record of what it last flashed to that COM
port, and pads to `max(this image, that record)` rounded up to a 4KB sector.

`/t:Rebuild` is untouched.

## Why that is the same guarantee

I checked the firmware before choosing a scheme, because there is an appealing shortcut that
turns out to be wrong. `ContiguousBlockAssemblies` (`nf-interpreter`,
`src/CLR/Startup/CLRStartup.cpp`) walks the deployment region looking for assembly headers,
and on a header that fails its check it `continue`s to the next candidate rather than
breaking — over a stream whose `Length` is the *whole* deployment block range
(`BlockStorageStream_InitializeWithBlockStorageDevice`). So padding an image with one blank
sector, or writing a terminator after it, does not stop the scan: stale assemblies anywhere
in the partition are still found and loaded. That is exactly the failure the existing comment
in the script describes seeing.

Only overwriting the previous image's bytes keeps them out, which makes the invariant exactly
"cover the footprint of the previous image" — precisely what the issue proposed. The flat
409,600 held that invariant by brute force; the record holds it exactly.

The reasoning that it is sufficient: after a completed flash, everything from the image's end
up to the padded length is 0xFF, so the *next* flash only has to cover the previous image's
own length, not the previous padding. Anything beyond that has never been written by this
script.

## Conservative in every failure direction

- The record is written **pessimistically before** the flash, at the full padded length, so an
  interrupted or failed `nanoff` (or a killed shell) still leaves a record covering everything
  it might have put down. It is tightened to the image's own length only after `nanoff`
  reports success.
- Every reason the record cannot be vouched for — missing, unparseable, wrong schema version,
  wrong COM port, a different `-DeployAddress`, or the new `-FullPad` switch — falls back to
  the flat 409,600, **never** to the bare image size.
- A failure to write the pre-flash record aborts before flashing (`$ErrorActionPreference` is
  `Stop`), rather than flashing against a stale, smaller number.
- New `-DeployPartitionSize` bound replaces the old "image is larger than `-PaddedImageSize`"
  error: an image bigger than the fallback is now simply padded to itself instead of being
  rejected, which matters as device images grow (RainwaterCistern is 197,140).

## Out-of-band writers

The record only describes what this script flashed. Two other things write the deployment
partition and erase only their own footprint (`DeploymentExecuteFull` in `nf-debugger`'s
`WireProtocol/Engine.cs` erases exactly the assemblies' combined length):

- The **nanoFramework test adapter**, via `Run-Tests.ps1`. That script now clears the record
  when its run settings target real hardware, so the next deploy pads the full fallback.
- **Visual Studio's F5 deploy**, which cannot be hooked. `-FullPad` is the escape hatch, and
  it is documented in `CLAUDE.md`, the `smarthome-deploy` skill and the `device-ops` agent.

## Why a separate helper rather than a new `Get-SmartHomeDevEnvPath -Kind`

`Get-SmartHomeDevEnvPath`'s `-Port` is an MQTT port, and its `Snapshot` kind is precedent for
non-dev-env files living in that vocabulary. But this file is keyed by **COM** port, and one
parameter meaning two different kinds of port depending on `-Kind` is an ambiguity every
caller would have to hold. The new `Get-SmartHomeDeployStatePath` shares the temp directory
and the prefix (`$SmartHomeDevEnvPrefix` renamed to `$SmartHomeTempFilePrefix` accordingly),
not the signature.

## Verified on hardware

All of the following ran on the real ESP32 on COM3.

| # | Run | Pad | Result |
|---|---|---|---|
| 1 | `Deploy-ToDevice.ps1` (RoomSensor, 259,168) with no record | 409,600 (flat fallback) | Erased `0x1e0000..0x243fff`, hash verified. Record written as `StaleBytes: 259168` |
| 2 | `Deploy-ToDevice.ps1 -Project src\integrationTests\WifiCheck\WifiCheck.nfproj` (89,512) | 262,144 (covers RoomSensor) | Erased `0x1e0000..0x21ffff`. Boot capture: `Total: (10108 RAM - 89512 ROM - 44889 METADATA)` — WifiCheck's own image exactly, no leftover RoomSensor assemblies — and `[ITEST] WifiCheck PASS` |
| 3 | Same deploy again, now against an 89,512 record | 90,112 (the tight case) | Erased `0x1e0000..0x1f5fff` — 4.5x less than the old flat pad. Boot capture identical: ROM 89,512, `[ITEST] WifiCheck PASS` |
| 4 | `Run-IntegrationTests.ps1` (full suite) | 90,112 → 143,360 → 143,360 → 184,320 → 184,320 | **All 5 passed** (WifiCheck, MqttCheck, Bmp280Check, HomieClientCheck, MqttReconnectCheck) |
| 5 | `Deploy-ToDevice.ps1` (RoomSensor) to put the device back to its real job | 262,144 (image-driven) | Erased `0x1e0000..0x21ffff`, hash verified |

Run 2 is the case the padding exists for, and the ROM total is the decisive evidence: 89,512,
not 89,512 plus a tail of RoomSensor. The suite exercised the same smaller-after-larger
direction twice more — Bmp280Check (132,384) padded up to 143,360 to cover MqttCheck's
141,912, and MqttReconnectCheck (150,980) padded up to 184,320 to cover HomieClientCheck's
181,812.

**Footprint across the suite: 745,472 bytes against 2,048,000 flat — 64% less**, and the total
deploy time in the summary was 74s of the 168s run.

## Verified off hardware

A throwaway harness (not committed — this repo's unit suite runs device-side under
nanoFramework, which is the wrong home for host PowerShell helpers) asserted 41 properties of
the new `Common.ps1` functions and the padding arithmetic: round-trip; rejection of corrupt
JSON, wrong version, wrong port, missing address, missing/negative/non-numeric `StaleBytes`, a
JSON array and an empty file; per-port and all-ports clear; that a `\.\COM10`-style port
cannot escape `%TEMP%`; that the pad is always sector-aligned, always covers the image, and
always covers the previous image across a suite-like sequence of sizes. All 41 passed.

Both modified scripts and `Run-IntegrationTests.ps1` parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

