### PR TITLE
refactor(tests): reuse the single-property device helper in the older HomieClient tests

### DIFF
--- a/src/tests/Unit/HomieClientTests.cs
+++ b/src/tests/Unit/HomieClientTests.cs
@@ -56,13 +56,7 @@ namespace SmartHome.UnitTests
 
             var mqttClient = new MockMqttClient();
 
-            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
-            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
-                        .AddFloatProperty(_testPropertyTemperatureTopicId, _testPropertyTemperatureName, 0.0)
-                        .BuildProperty(out FloatProperty property)
-                    .BuildNode()
-                .BuildDevice();
-
+            var device = BuildSinglePropertyDevice(out FloatProperty property, settable: false);
 
             // Act
             var homieClient = new HomieClient(device, mqttClient);
@@ -87,13 +81,7 @@ namespace SmartHome.UnitTests
 
             var mqttClient = new MockMqttClient();
 
-            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
-            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
-                        .AddFloatProperty(_testPropertyTemperatureTopicId, _testPropertyTemperatureName, initialValue)
-                            .WithSettable(true)
-                        .BuildProperty(out FloatProperty property)
-                    .BuildNode()
-                .BuildDevice();
+            var device = BuildSinglePropertyDevice(out FloatProperty property, settable: true);
 
             // Assert
             Assert.AreEqual(initialValue, property.Value);
@@ -123,12 +111,7 @@ namespace SmartHome.UnitTests
             // Arrange
             var mqttClient = new MockMqttClient();
 
-            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
-            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
-                        .AddFloatProperty(_testPropertyTemperatureTopicId, _testPropertyTemperatureName, 0.0)
-                        .BuildProperty()
-                    .BuildNode()
-                .BuildDevice();
+            var device = BuildSinglePropertyDevice();
 
             var homieClient = new HomieClient(device, mqttClient);
 
@@ -153,12 +136,7 @@ namespace SmartHome.UnitTests
             var mqttClient = new MockMqttClient();
             mqttClient.Connect("someone-else");
 
-            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
-            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
-                        .AddFloatProperty(_testPropertyTemperatureTopicId, _testPropertyTemperatureName, 0.0)
-                        .BuildProperty()
-                    .BuildNode()
-                .BuildDevice();
+            var device = BuildSinglePropertyDevice();
 
             var homieClient = new HomieClient(device, mqttClient);
 
@@ -377,12 +355,7 @@ namespace SmartHome.UnitTests
             // Arrange
             var mqttClient = new MockMqttClient();
 
-            var builder = new HomieDeviceBuilder(_testDeviceTopicId, _testDeviceName);
-            var device = builder.AddNode(_testNodeEngineTopicId, _testNodeEngineName, _testNodeEngineType)
-                        .AddFloatProperty(_testPropertyTemperatureTopicId, _testPropertyTemperatureName, 0.0)
-                        .BuildProperty(out FloatProperty property)
-                    .BuildNode()
-                .BuildDevice();
+            var device = BuildSinglePropertyDevice(out FloatProperty property, settable: false);
 
             var homieClient = new HomieClient(device, mqttClient);
             homieClient.Connect();


### PR DESCRIPTION
Closes #15.

Five tests in `HomieClientTests.cs` restated the same `HomieDeviceBuilder` chain — one
`engine` node, one float `temperature` property at `0.0` — differing only in whether the
property was settable and whether it was captured. That is exactly the shape
`BuildSinglePropertyDevice(out FloatProperty, bool)` already covers; those tests simply
predate the helper.

Arrange step only: 5 insertions, 32 deletions, one file. No test renamed, no assertion
touched, no expected count adjusted.

## Why the counts cannot have moved

The counts are the whole risk here, so the substitution is exact at the source level
rather than only by observation:

- `HomiePropertyBuilderBase` initialises `_settable` to `false`
  ([`HomiePropertyBuilderBase.cs:12`](src/common/Homie/V4/Builder/HomiePropertyBuilderBase.cs#L12)),
  so omitting `WithSettable(...)` constructs the identical `FloatProperty` as
  `WithSettable(false)`.
- `HomieFloatPropertyBuilder.BuildProperty()` is defined as `BuildProperty(out _)`
  ([`HomieFloatPropertyBuilder.cs:18`](src/common/Homie/V4/Builder/HomieFloatPropertyBuilder.cs#L18)),
  so dropping the capture changes nothing about the device being built.
- `PublishHomiePropertyInfo` publishes `$settable` unconditionally
  ([`HomiePublishExtensions.cs:40`](src/common/Homie/V4/HomiePublishExtensions.cs#L40)),
  so the announce count cannot move with the flag's value in either direction.

The three converted tests that assert exact counts — `HomieClient_Publish_On_Property_Update`
(17 publishes / 0 subscriptions), `HomieClient_Property_Is_Set_On_Property_Set_Message`
(17 / 1) and `HomieClient_Publishes_Once_Per_Update_After_A_Reconnect` (`before + 1`) — all
pass unchanged on hardware.

## Left alone deliberately

Per the issue's constraint, tests where moving onto the helper would change *what they
measure* rather than just how they read were not touched:

- `HomieClient_Raises_OnCommand_For_A_Controller_Set` and
  `HomieClient_Retried_Connect_Handles_A_Command_Once` build the `intensity` property, not
  `temperature`. The helper is hardcoded to `temperature`, so converting them would change
  the fixture rather than collapse a duplicate — outside the issue's stated shape ("differing
  only in whether the property is settable and whether it is captured").
- `HomieClient_Connect_Disconnect` builds **two** properties, which is precisely what its
  23/24 publishes and 2 subscriptions measure. A single-property helper cannot express it.
- The lifecycle (enum with `$format`), boolean, and two-property precision tests are not this
  shape at all.

## Verification

Ran on the real ESP32 with the user's explicit confirmation:

```
.\scripts\Run-Tests.ps1
```

**40 passed, 0 failed, 40 of 40 executed.** The "of 40 executed" matters — a silently-skipped
suite is the known failure mode when the test assembly cannot be resolved, and it still exits
0. The assembly name is untouched and the output is still `NFUnitTest.dll`.

No integration tests were run; nothing in this change touches device behaviour, only test
arrange code.

Branched from `origin/main` at 115005e. Neither `claude/rainwater-cistern` nor #39 had landed
changes to `HomieClientTests.cs`, and the duplication the issue describes was confirmed
present before starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
