### PR TITLE
docs: make filing verified findings standing behaviour

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,41 @@ Issues are labelled `type:` (bug/feature/task/spike), `area:` (homie/infra/senso
 `status:` (in-progress/blocked/review). Anything `status: blocked` names in its body exactly
 what it is waiting for, so it can be picked up cold.
 
+### File what you find
+
+**Anything found and verified that falls outside the change in hand gets a GitHub issue,
+before the session ends.** Not a note in a pull request body, not a line in a summary the
+user has to act on, not a TODO in the code — an issue, because the issue list is the backlog
+and everything else is a place findings go to be forgotten. This is standing behaviour for
+every session, not something to be asked for.
+
+Three things make it work, and skipping any one of them makes it worse than not doing it:
+
+- **Verified is the bar.** Reproduce it, or read the source that proves it, before filing.
+  A hunch filed as an issue costs the next session a full investigation to disprove and
+  teaches everyone to distrust the list. If investigation refutes the finding, that is a
+  result too — say so plainly and file nothing.
+- **Retract what you already said.** A finding reported somewhere before it was checked — a
+  pull request body, a review comment, a message to the user — has to be corrected in that
+  same place once it turns out to be wrong. A wrong claim left standing in a merged PR is
+  indistinguishable from a real one later.
+- **File it, don't fix it.** Widening the current change to cover what you tripped over is how
+  a reviewable diff becomes an unreviewable one. Write the issue so it can be picked up cold:
+  what is wrong, the evidence, the files, and what closing it would look like.
+
+Check `gh issue list --state open` first — a duplicate is worse than nothing. Label with
+`type:` and `area:` to match the rest of the list, and link the pull request or issue that
+turned the finding up.
+
+Worth filing: a defect confirmed by reproduction or by reading the source; a constant or
+assumption the code asserts without evidence; a residual gap in something just shipped, where
+the mitigation is "remember to do X"; work deliberately cut from a change to keep it
+reviewable.
+
+Not worth filing: style preferences; refactors with no stated payoff; anything already covered
+by an open issue or already documented in this file as intentional; and anything you have not
+actually checked.
+
 ## Development process
 
 [`CONTRIBUTING.md`](CONTRIBUTING.md) is the source of truth for how work moves: trunk-based

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,9 +422,20 @@ Three things make it work, and skipping any one of them makes it worse than not 
   a reviewable diff becomes an unreviewable one. Write the issue so it can be picked up cold:
   what is wrong, the evidence, the files, and what closing it would look like.
 
-Check `gh issue list --state open` first — a duplicate is worse than nothing. Label with
-`type:` and `area:` to match the rest of the list, and link the pull request or issue that
-turned the finding up.
+Check `gh issue list --state all` first — a duplicate is worse than nothing, and a closed issue
+counts as much as an open one: #33 was closed as working-as-intended and #16 as not-planned, so
+searching only the open list re-files decisions this repo has already made. Label to match the
+rest of the list, and link the pull request or issue that turned the finding up. The label names
+contain the space after the colon — `type: bug`, not `type:bug`, which `gh` rejects with
+`'type:bug' not found` and then creates nothing:
+
+```bash
+gh issue create --title "..." --body "..." --label "type: bug" --label "area: infra"
+```
+
+Then say which issues you filed. What must not live in a summary is the *finding* — the issue
+numbers themselves belong in the session's closing message, so the user can see what was opened
+in a public tracker without going to look for it.
 
 Worth filing: a defect confirmed by reproduction or by reading the source; a constant or
 assumption the code asserts without evidence; a residual gap in something just shipped, where
@@ -432,8 +443,11 @@ the mitigation is "remember to do X"; work deliberately cut from a change to kee
 reviewable.
 
 Not worth filing: style preferences; refactors with no stated payoff; anything already covered
-by an open issue or already documented in this file as intentional; and anything you have not
-actually checked.
+by an open issue, settled by a closed one, or already documented in this file as intentional;
+and anything you have not actually checked.
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md) carries the same rule in short form — it is the source of
+truth for process, so change both or neither.
 
 ## Development process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,12 @@ Labels: `type:` (bug, feature, task, spike), `area:` (homie, infra, sensor), `st
 `status: blocked` and says in the body exactly what it is waiting for, so it can be
 picked up cold.
 
+Anything found and *verified* outside the change in hand gets its own issue rather than a
+note in a pull request body — verified because a hunch costs the next reader an
+investigation to disprove, its own issue because widening the current change is how a
+reviewable diff stops being one. Check the closed issues too before filing: a duplicate of
+something already decided is worse than nothing. `CLAUDE.md` has the longer version.
+
 ## Releases
 
 Manual and on demand. Tag when a set of changes is worth calling a version:


### PR DESCRIPTION
Adds a **File what you find** subsection to `CLAUDE.md` under Open work, making it standing
behaviour for every session: anything found and verified that falls outside the change in hand
gets a GitHub issue before the session ends, without being asked for.

## Why

`CLAUDE.md` already says the issue list *is* the backlog and there is no to-do file. What it
did not say is how findings get *into* it. In practice they were landing in pull request
bodies and end-of-session summaries, which leaves the user to transcribe them by hand or lose
them — the exact problem removing `NEXT-STEPS.md` was meant to solve, just relocated.

## What it says

The rule, plus three qualifiers that matter as much as the rule itself:

- **Verified is the bar.** Reproduce it or read the source that proves it before filing. A
  finding that investigation refutes is reported as refuted, and nothing is filed.
- **Retract what you already said.** A claim made somewhere before it was checked — a PR body,
  a review comment — gets corrected in that same place once it turns out to be wrong.
- **File it, don't fix it.** Widening the current change to cover what you tripped over is how
  a reviewable diff stops being one.

Plus explicit lists of what is worth filing (a defect confirmed by reproduction or source; a
constant the code asserts without evidence; a residual gap whose mitigation is "remember to do
X"; work deliberately cut to keep a change reviewable) and what is not (style preferences,
unmotivated refactors, duplicates, anything unchecked), so the list does not fill with noise.

## Where this came from

The session behind #45 produced one of each, which is what prompted writing it down:

- Two findings that survived checking and are now filed as #46 (the padding scheme cannot see
  a Visual Studio F5 deploy, and the manual `-FullPad` mitigation is not enforced) and #47
  (`-DeployPartitionSize`'s default was copied from a prose comment, never measured).
- One that did not. I had reported in #45's description that
  `Watch-DeviceDebugOutput.ps1 -Until` failed to match a line plainly present in its own
  output, and suggested a bug in the tool. `--until` is a documented *substring* match
  (`seen.ToString().Contains(until)` in `tools/DeviceDebugMonitor/Program.cs`); I had passed a
  regex. That claim is retracted in #45 and no issue was filed — which is what the second
  qualifier above exists to make routine.

## Verification

Documentation only. No code, scripts or hardware involved, and **nothing was run on hardware
for this change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
