### PR TITLE
feat(scripts): add a setup preflight, and document the machine prerequisites

### DIFF
--- a/.claude/skills/smarthome-check-setup/SKILL.md
+++ b/.claude/skills/smarthome-check-setup/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: smarthome-check-setup
+description: Check that everything the SmartHome scripts assume exists on this machine — the two local.env files, restored packages, an authenticated gh, MSBuild/vstest, Mosquitto, the COM port. Use at the start of a session, in a fresh worktree, or when a script fails in a way that might be a missing prerequisite rather than a code problem.
+---
+
+# Check the SmartHome machine setup
+
+```powershell
+.\scripts\Test-Setup.ps1
+```
+
+Read-only. Nothing is installed, nothing is written, no COM port is opened and no device is
+touched — so unlike the hardware scripts this needs no confirmation and is safe to run at any
+point, including while someone else has the device.
+
+Exit code is 0 when nothing FAILed (WARNings still pass), 1 otherwise.
+
+## Why this exists
+
+Everything the scripts in `scripts\` depend on beyond the source tree lives **outside the
+repository**: two git-ignored `local.env` files, a restored `packages\` folder, an authenticated
+`gh`, Visual Studio's MSBuild and vstest, Mosquitto, the ESP32's COM port. None of it is
+version-controlled, none of it can be inferred from a clone, and a session cannot install any
+of it for itself.
+
+The problem is not that these go missing — it is *how* they fail. Each surfaces as something
+that reads like broken code:
+
+| What is missing | What you actually see |
+|---|---|
+| `packages\` not restored | A wall of `error CS0518` — predefined type `System.Object` is not defined — in every project, which looks like the source tree is broken |
+| `scripts\local.env.ps1` | Any script aborting at its first line with `Missing: ...\scripts\local.env.ps1` |
+| A value inside it | `Missing environment variable: SMARTHOME_...` |
+| `gh` not authenticated | The backlog is simply unreadable; `gh issue list` fails |
+
+This script reports all of them at once instead of letting a workflow discover one, stop, and
+hide the next. It deliberately does not use `Import-SmartHomeLocalEnv`, which exits on the first
+missing file — the opposite of what a preflight is for.
+
+## When to run it
+
+- **At the start of a session**, before the first script call, rather than discovering a gap
+  midway through a workflow.
+- **In a fresh worktree**, always. `Get-SmartHomeScriptsDir` returns the calling script's own
+  `$PSScriptRoot`, so a worktree under `.claude\worktrees\<name>` reads *its own*
+  `scripts\local.env.ps1`, never the main checkout's. Both `local.env` files and `packages\`
+  are git-ignored, so a new worktree has neither and the first script call fails even though
+  the main checkout is fully configured. The script detects the worktree and prints the exact
+  `Copy-Item` from the main checkout.
+- **When a script fails and it might not be your code** — especially a compile that broke
+  everywhere at once, or a `gh` call that failed for no obvious reason.
+
+## Reading the output
+
+Each row is `OK`, `WARN` or `FAIL`, followed by a `How to fix` block naming the remediation for
+anything that is not `OK`.
+
+`WARN` is for things that do not block building: a COM port that is not currently present (the
+device is unplugged — only the hardware-touching scripts care), companion nanoFramework repos
+that have not been synced (needed before firmware/library debugging, not before a build), or a
+check that could not run because the config it depends on is missing. A check that could not run
+still gets a row, on purpose — a check that silently disappears reads as a check that passed.
+
+Related: `smarthome-restore-packages` for the `packages\` fix, `smarthome-sync-nanoframework`
+for the companion repos. The full prerequisite list, with the same failure table, is the
+"First-time setup" section of `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` | The whole `src\integrationTests` suite in one call: broker up, deploy + capture + verdict per test, broker down, summary + exit code | **Yes** | `smarthome-integration-tests` |
 | `scripts\Sync-NanoFrameworkRepos.ps1 [-Force]` | Clones/updates the sibling nanoFramework repos beside `SmartHome` | No | `smarthome-sync-nanoframework` |
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
+| `scripts\Test-Setup.ps1` | Reports everything the other scripts assume exists on this machine — both `local.env` files and their values, restored `packages\`, the test adapter, `gh` auth, MSBuild/vstest, Mosquitto, the COM port, the companion repos — all at once, rather than one abort at a time. Read-only; opens no port and touches no device | No | `smarthome-check-setup` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
 | `scripts\Watch-DeviceDebugOutput.ps1 [-DurationSeconds <n>] [-NoReboot] [-NoBuild] [-BuildOnly] [-Until <regex>] [-DumpConfig]` | Real managed-code debug output (`Debug.WriteLine`, exceptions) via `tools\DeviceDebugMonitor` — no VS needed, same library VS's debugger extension uses | Resets only | `smarthome-watch-debug-output` |
 | `scripts\Set-AssemblyVersion.ps1 -Version <v> [-Check]` | Stamps a version into every `AssemblyInfo.cs` under `src` — a plain recursive glob, not a fixed list and not restricted to `Properties\`, so adding a device needs no edit here and a stray one anywhere under `src` will also be picked up (and fails the run if it carries no version attribute). `.nfproj` has no generated assembly info, so this is the only thing that makes a release build carry its version. Normally invoked by the release workflow, not by hand | No | `smarthome-release` |
@@ -122,22 +123,27 @@ stops the run at its first line, ahead of any build, flash or broker start.
 
 ### Check it before relying on it
 
-Read-only, touches no hardware, and worth doing before the first script call of a session
-rather than discovering the gap midway through a workflow:
-
 ```powershell
-Test-Path scripts\local.env.ps1, scripts\nanoFramework.local.env.ps1
-gh auth status
-nanoff --version
+.\scripts\Test-Setup.ps1
 ```
 
-One trap while running those: in Windows PowerShell 5.1, do **not** pipe a native tool through
-`2>&1`. The redirect wraps the exe's ordinary stderr in a `NativeCommandError` and sets `$?` to
-false, so a perfectly healthy `nanoff --version` reports as a failure.
+Checks every item in this section in one pass and reports them together — read-only, opens no
+COM port, touches no device, exit 0 unless something FAILs. Worth running before the first
+script call of a session rather than discovering the gap midway through a workflow, and always
+in a fresh worktree. Skill: `smarthome-check-setup`.
+
+It reports rather than aborts, on purpose: `Import-SmartHomeLocalEnv` exits on the first missing
+file, so a workflow that relies on it discovers one gap, stops, and hides the next.
+
+One trap if you check something by hand instead: in Windows PowerShell 5.1, do **not** pipe a
+native tool through `2>&1`. The redirect wraps the exe's ordinary stderr in a
+`NativeCommandError` and sets `$?` to false, so a perfectly healthy `nanoff --version` reports
+as a failure.
 
 ### What a missing prerequisite looks like
 
-None of these are code problems, and each has been read as one:
+None of these are code problems, and each has been read as one. `Test-Setup.ps1` reports all of
+them by name; the table is for when you meet one without having run it:
 
 | Symptom | Cause | Fix |
 |---|---|---|
@@ -162,6 +168,9 @@ Copy-Item ..\..\..\scripts\local.env.ps1 scripts\
 Copy-Item ..\..\..\scripts\nanoFramework.local.env.ps1 scripts\
 .\scripts\Restore-Packages.ps1
 ```
+
+`Test-Setup.ps1` detects the worktree and prints that first `Copy-Item` with both paths already
+filled in, so running it first is quicker than reading this.
 
 ## Repository layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 convention (topic prefix `homie/`). Primary device today: **RoomSensor**.
 
 This file is the single source of truth for how to work in this repo — layout, scripts,
-companion repos, version policy. (It replaced `.github/copilot-instructions.md` and the root
+machine prerequisites, companion repos, version policy. (It replaced `.github/copilot-instructions.md` and the root
 `AGENTS.md`, which were near-duplicates of it; if you find a stale reference to either, fix the
 reference rather than recreating the file.)
 
@@ -84,6 +84,14 @@ this repo, not a one-time cleanup.
 
 ## First-time setup
 
+Everything in this section lives **outside the repository** — on the machine the session is
+running on. None of it is version-controlled, none of it can be inferred from the source tree,
+and a session cannot install any of it for itself. So it is an assumption to check rather than
+a given, and checking is cheap: each item goes missing as something that reads like broken code
+or a broken build, which is what the failure table below exists to translate.
+
+### Machine-local config
+
 ```powershell
 Copy-Item scripts\local.env.template.ps1 scripts\local.env.ps1
 Copy-Item scripts\nanoFramework.local.env.template.ps1 scripts\nanoFramework.local.env.ps1
@@ -95,9 +103,11 @@ Then fill in:
   `SMARTHOME_MQTT_BROKER` / `SMARTHOME_MQTT_PORT`
 - `scripts\nanoFramework.local.env.ps1` — `SMARTHOME_NANOFW_BRANCH`
 
-Both `local.env.ps1` files are git-ignored — never commit them.
+Both `local.env.ps1` files are git-ignored — never commit them. Every script dot-sources them
+through `Import-SmartHomeLocalEnv` before doing anything else, so a missing or half-filled file
+stops the run at its first line, ahead of any build, flash or broker start.
 
-Required local tools:
+### Required local tools
 
 - [nanoFramework VS extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension)
 - `nanoff` CLI: `dotnet tool install -g nanoff`
@@ -109,6 +119,49 @@ Required local tools:
   what there is to do. A human can fall back to the issues page in a browser; an agent
   session has no such fallback, and every workflow in this file that reaches GitHub goes
   through `gh`.
+
+### Check it before relying on it
+
+Read-only, touches no hardware, and worth doing before the first script call of a session
+rather than discovering the gap midway through a workflow:
+
+```powershell
+Test-Path scripts\local.env.ps1, scripts\nanoFramework.local.env.ps1
+gh auth status
+nanoff --version
+```
+
+One trap while running those: in Windows PowerShell 5.1, do **not** pipe a native tool through
+`2>&1`. The redirect wraps the exe's ordinary stderr in a `NativeCommandError` and sets `$?` to
+false, so a perfectly healthy `nanoff --version` reports as a failure.
+
+### What a missing prerequisite looks like
+
+None of these are code problems, and each has been read as one:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| A script exits at once with `Missing: ...\scripts\local.env.ps1` | config file absent | copy the templates above, or the filled-in files from another checkout |
+| `Missing environment variable: SMARTHOME_...` | config file present but incomplete | fill the value in, comparing against the template |
+| A wall of `error CS0518` — predefined type `System.Object`/`System.Void` not defined — in every project | NuGet packages not restored: `packages\` is git-ignored (`.gitignore:200`) and comes with no clone | `scripts\Restore-Packages.ps1`. A plain `msbuild /t:Restore` is a no-op for this project style |
+| `gh` fails with an authentication error | `gh auth login` never run, or the token expired | `gh auth login`. The backlog is unreadable until then |
+
+MSBuild on this machine emits **German** diagnostics, so match on the error *code* (`CS0518`)
+rather than on English message text.
+
+### A fresh worktree starts with none of it
+
+`Get-SmartHomeScriptsDir` returns the calling script's own `$PSScriptRoot`, so a worktree under
+`.claude\worktrees\<name>` reads *its own* `scripts\local.env.ps1`, never the main checkout's.
+Both config files and `packages\` are git-ignored, so a new worktree has neither, and the first
+script call fails there even though the main checkout is fully set up. Seed it once, from the
+worktree root (`..\..\..` being `<name>` → `worktrees` → `.claude` → the repo root):
+
+```powershell
+Copy-Item ..\..\..\scripts\local.env.ps1 scripts\
+Copy-Item ..\..\..\scripts\nanoFramework.local.env.ps1 scripts\
+.\scripts\Restore-Packages.ps1
+```
 
 ## Repository layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,11 @@ interesting part is why.
 
 ## Local setup
 
-See `CLAUDE.md`. In short: copy the two `local.env` templates, fill in your COM port and
-Mosquitto directory, and use the scripts in `scripts/` rather than raw `msbuild` /
-`nanoff` / `mosquitto_sub`. Both `local.env.ps1` files are git-ignored and must stay that
-way.
+See the "First-time setup" section of `CLAUDE.md`. In short: copy the two `local.env`
+templates, fill in your COM port and Mosquitto directory, and use the scripts in `scripts/`
+rather than raw `msbuild` / `nanoff` / `mosquitto_sub`. Both `local.env.ps1` files are
+git-ignored and must stay that way.
+
+That section also carries the parts that are easy to misdiagnose: how to check the setup
+before relying on it, what each missing prerequisite looks like when a script fails because
+of it, and why a fresh worktree starts with none of it.

--- a/scripts/Test-Setup.ps1
+++ b/scripts/Test-Setup.ps1
@@ -1,0 +1,331 @@
+<#
+.SYNOPSIS
+    Check everything the other scripts assume already exists on this machine.
+
+.DESCRIPTION
+    The rest of scripts\ depends on things that live outside the repository: two
+    git-ignored local.env files, a set of installed tools, an authenticated gh, a
+    restored packages\ folder. None of that is version-controlled and none of it
+    can be inferred from a clone, so every one of them is an assumption -- and
+    each fails in a way that reads like broken code rather than a missing
+    prerequisite. An unrestored packages\ folder, for instance, emits a wall of
+    CS0518 "predefined type 'System.Object' is not defined" across every project.
+
+    This script reports all of them at once, rather than letting a workflow
+    discover one, stop, and hide the next. It is read-only: nothing is installed,
+    nothing is written, no COM port is opened and no device is touched.
+
+    Deliberately does NOT use Import-SmartHomeLocalEnv -- that helper exits on the
+    first missing file, which is the opposite of what a preflight is for.
+
+    Exit code is 0 when nothing FAILed (WARNings still pass), 1 otherwise.
+
+.EXAMPLE
+    .\scripts\Test-Setup.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+$repoRoot = Get-SmartHomeRepoRoot
+$scriptsDir = Get-SmartHomeScriptsDir
+
+$results = New-Object System.Collections.Generic.List[psobject]
+
+function Add-Result {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][ValidateSet('OK', 'WARN', 'FAIL')][string]$Status,
+        [Parameter(Mandatory = $true)][string]$Detail,
+        [string]$Fix = ''
+    )
+
+    $results.Add([pscustomobject]@{
+        Name   = $Name
+        Status = $Status
+        Detail = $Detail
+        Fix    = $Fix
+    })
+}
+
+function Test-OnPath {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    return $null
+}
+
+# The main working tree, when this is running inside a linked worktree. Used only to
+# make the remediation for a missing local.env concrete: the file is git-ignored, so
+# a fresh worktree never has one even though the main checkout is fully configured.
+function Get-MainCheckoutRoot {
+    try {
+        $commonDir = & git -C $repoRoot rev-parse --path-format=absolute --git-common-dir 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commonDir)) {
+            return $null
+        }
+
+        $mainRoot = Split-Path $commonDir -Parent
+        if ($mainRoot -and ($mainRoot.TrimEnd('\') -ne $repoRoot.TrimEnd('\'))) {
+            return $mainRoot
+        }
+    }
+    catch {
+        # git absent, or not a repository. The template hint still applies.
+    }
+
+    return $null
+}
+
+$mainCheckout = Get-MainCheckoutRoot
+
+# ---------------------------------------------------------------- config files --
+
+$configFiles = @(
+    @{ Name = 'local.env.ps1'; Values = @('SMARTHOME_COM_PORT', 'SMARTHOME_MOSQUITTO_DIR') },
+    @{ Name = 'nanoFramework.local.env.ps1'; Values = @('SMARTHOME_NANOFW_BRANCH') }
+)
+
+foreach ($config in $configFiles) {
+    $path = Join-Path $scriptsDir $config.Name
+    $template = Join-Path $scriptsDir ($config.Name -replace '\.ps1$', '.template.ps1')
+
+    if (-not (Test-Path $path)) {
+        $fix = "Copy-Item `"$template`" `"$path`"  (then fill it in)"
+        if ($mainCheckout) {
+            $fix = "Copy-Item `"$(Join-Path $mainCheckout "scripts\$($config.Name)")`" `"$scriptsDir`"  " +
+                   "-- this is a worktree; the file is git-ignored, so it did not come along"
+        }
+
+        Add-Result -Name "scripts\$($config.Name)" -Status 'FAIL' -Detail 'missing' -Fix $fix
+        continue
+    }
+
+    Add-Result -Name "scripts\$($config.Name)" -Status 'OK' -Detail 'present'
+
+    # Dot-source into this scope so the values below are readable. Safe: both files
+    # are assignments to $env: only.
+    . $path
+
+    foreach ($name in $config.Values) {
+        $value = [Environment]::GetEnvironmentVariable($name)
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            Add-Result -Name $name -Status 'FAIL' -Detail 'not set' `
+                       -Fix "Set it in $path -- compare against $template"
+        }
+        else {
+            Add-Result -Name $name -Status 'OK' -Detail $value
+        }
+    }
+}
+
+# ------------------------------------------------------------------- mosquitto --
+
+$mosquittoDir = [Environment]::GetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR')
+if (-not [string]::IsNullOrWhiteSpace($mosquittoDir)) {
+    $mosquitto = Join-Path $mosquittoDir 'mosquitto.exe'
+    if (Test-Path $mosquitto) {
+        Add-Result -Name 'mosquitto.exe' -Status 'OK' -Detail $mosquitto
+    }
+    else {
+        Add-Result -Name 'mosquitto.exe' -Status 'FAIL' -Detail "not at $mosquittoDir" `
+                   -Fix 'Install Mosquitto (https://mosquitto.org/download/), or point SMARTHOME_MOSQUITTO_DIR at the directory holding mosquitto.exe'
+    }
+}
+else {
+    # Say so rather than dropping the row: a check that silently disappears reads as
+    # a check that passed.
+    Add-Result -Name 'mosquitto.exe' -Status 'WARN' -Detail 'not checked -- SMARTHOME_MOSQUITTO_DIR unset'
+}
+
+# -------------------------------------------------------------------- COM port --
+
+$comPort = [Environment]::GetEnvironmentVariable('SMARTHOME_COM_PORT')
+if (-not [string]::IsNullOrWhiteSpace($comPort)) {
+    # Enumerates names only -- the port is never opened, so this cannot disturb a
+    # device or collide with a session that has it open.
+    $ports = @([System.IO.Ports.SerialPort]::GetPortNames())
+    if ($ports -contains $comPort) {
+        Add-Result -Name "COM port $comPort" -Status 'OK' -Detail 'present'
+    }
+    else {
+        $seen = if ($ports.Count -gt 0) { $ports -join ', ' } else { 'none' }
+        Add-Result -Name "COM port $comPort" -Status 'WARN' -Detail "not present (this machine has: $seen)" `
+                   -Fix 'Plug the ESP32 in, or correct SMARTHOME_COM_PORT. Only the hardware-touching scripts need it'
+    }
+}
+else {
+    Add-Result -Name 'COM port' -Status 'WARN' -Detail 'not checked -- SMARTHOME_COM_PORT unset'
+}
+
+# ----------------------------------------------------------------------- tools --
+
+foreach ($tool in @('git', 'nanoff', 'gh')) {
+    $source = Test-OnPath $tool
+    if ($source) {
+        Add-Result -Name $tool -Status 'OK' -Detail $source
+    }
+    else {
+        $fix = switch ($tool) {
+            'git'    { 'Install Git and put it on PATH' }
+            'nanoff' { 'dotnet tool install -g nanoff' }
+            'gh'     { 'Install the GitHub CLI (https://cli.github.com/)' }
+        }
+        Add-Result -Name $tool -Status 'FAIL' -Detail 'not on PATH' -Fix $fix
+    }
+}
+
+if (Test-OnPath 'gh') {
+    # Not piped through 2>&1 on purpose: in Windows PowerShell 5.1 that wraps a native
+    # command's ordinary stderr in a NativeCommandError and flips $?, so a healthy gh
+    # would be reported as broken.
+    $authOk = $false
+    try {
+        & gh auth status 2>$null | Out-Null
+        $authOk = ($LASTEXITCODE -eq 0)
+    }
+    catch {
+        $authOk = $false
+    }
+
+    if ($authOk) {
+        Add-Result -Name 'gh auth' -Status 'OK' -Detail 'authenticated'
+    }
+    else {
+        Add-Result -Name 'gh auth' -Status 'FAIL' -Detail 'not authenticated' `
+                   -Fix 'gh auth login -- the backlog is GitHub issues, so it is unreadable until then'
+    }
+}
+
+# ----------------------------------------------------- Visual Studio-side tools --
+
+# Both resolvers fall back to a bare name off PATH when vswhere finds nothing, so a
+# returned value is not by itself proof the tool exists.
+foreach ($vsTool in @(
+    @{ Name = 'MSBuild'; Path = (Get-MSBuildPath) },
+    @{ Name = 'vstest.console'; Path = (Get-VsTestPath) }
+)) {
+    $path = $vsTool.Path
+    if ((Test-Path $path -ErrorAction SilentlyContinue) -or (Test-OnPath $path)) {
+        Add-Result -Name $vsTool.Name -Status 'OK' -Detail $path
+    }
+    else {
+        Add-Result -Name $vsTool.Name -Status 'FAIL' -Detail "not found (resolved to '$path')" `
+                   -Fix 'Install Visual Studio with the MSBuild and Managed Desktop components'
+    }
+}
+
+# ------------------------------------------------------------------- packages\ --
+
+$packagesDir = Join-Path $repoRoot 'packages'
+$missingPackages = New-Object System.Collections.Generic.List[string]
+
+$configs = @(Get-ChildItem -Path $repoRoot -Filter 'packages.config' -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '\\(bin|obj)\\' })
+
+foreach ($configFile in $configs) {
+    [xml]$xml = Get-Content $configFile.FullName
+    foreach ($package in $xml.packages.package) {
+        $name = "$($package.id).$($package.version)"
+        if (-not (Test-Path (Join-Path $packagesDir $name)) -and -not $missingPackages.Contains($name)) {
+            $missingPackages.Add($name)
+        }
+    }
+}
+
+if ($configs.Count -eq 0) {
+    Add-Result -Name 'packages\' -Status 'WARN' -Detail 'no packages.config found' `
+               -Fix 'Unexpected -- check this is a full checkout'
+}
+elseif ($missingPackages.Count -eq 0) {
+    Add-Result -Name 'packages\' -Status 'OK' -Detail "all packages restored ($($configs.Count) packages.config)"
+}
+else {
+    Add-Result -Name 'packages\' -Status 'FAIL' -Detail "$($missingPackages.Count) package(s) not restored, e.g. $($missingPackages[0])" `
+               -Fix '.\scripts\Restore-Packages.ps1 -- otherwise every project fails to compile with CS0518, which looks like broken source'
+}
+
+# The unit-test adapter lives inside packages\, so this only means anything once the
+# restore above is clean -- but naming it separately saves guessing when Run-Tests.ps1
+# is the thing that failed.
+$adapterDir = Get-NanoFrameworkTestAdapterDir -RepoRoot $repoRoot
+if ($adapterDir) {
+    Add-Result -Name 'nanoFramework test adapter' -Status 'OK' -Detail $adapterDir
+}
+else {
+    Add-Result -Name 'nanoFramework test adapter' -Status 'FAIL' -Detail 'nanoFramework.TestAdapter.dll not in packages\' `
+               -Fix '.\scripts\Restore-Packages.ps1 -- Run-Tests.ps1 cannot run without it'
+}
+
+# -------------------------------------------------------------- sibling repos --
+
+$siblingRoot = Get-SiblingRoot
+$siblingProbe = @('nf-interpreter', 'nanoFramework.m2mqtt', 'Samples')
+$missingSiblings = @($siblingProbe | Where-Object { -not (Test-Path (Join-Path $siblingRoot $_)) })
+
+if ($missingSiblings.Count -eq 0) {
+    Add-Result -Name 'companion nanoFramework repos' -Status 'OK' -Detail $siblingRoot
+}
+else {
+    Add-Result -Name 'companion nanoFramework repos' -Status 'WARN' -Detail "missing under $siblingRoot`: $($missingSiblings -join ', ')" `
+               -Fix '.\scripts\Sync-NanoFrameworkRepos.ps1 -- needed before any firmware/library debugging, not for building'
+}
+
+# ---------------------------------------------------------------------- report --
+
+Write-Host ""
+Write-Host "SmartHome setup check" -ForegroundColor Cyan
+Write-Host "  repo:    $repoRoot"
+if ($mainCheckout) {
+    Write-Host "  worktree of: $mainCheckout" -ForegroundColor DarkGray
+}
+Write-Host ""
+
+$width = ($results | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum
+
+foreach ($result in $results) {
+    $colour = switch ($result.Status) {
+        'OK'   { 'Green' }
+        'WARN' { 'Yellow' }
+        'FAIL' { 'Red' }
+    }
+
+    Write-Host ("  [{0,-4}] {1}  {2}" -f $result.Status, $result.Name.PadRight($width), $result.Detail) -ForegroundColor $colour
+}
+
+$failed = @($results | Where-Object { $_.Status -eq 'FAIL' })
+$warned = @($results | Where-Object { $_.Status -eq 'WARN' })
+
+$needsAction = @($results | Where-Object { $_.Status -ne 'OK' -and $_.Fix })
+if ($needsAction.Count -gt 0) {
+    Write-Host ""
+    Write-Host "How to fix:" -ForegroundColor Cyan
+    foreach ($result in $needsAction) {
+        Write-Host "  $($result.Name)" -ForegroundColor Yellow
+        Write-Host "    $($result.Fix)"
+    }
+}
+
+Write-Host ""
+Write-Host "$($results.Count) checked, $($failed.Count) failed, $($warned.Count) warned." -ForegroundColor Cyan
+
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Error "Setup is incomplete: $($failed.Count) check(s) failed. See 'How to fix' above."
+    exit 1
+}
+
+Write-Host "Setup looks complete." -ForegroundColor Green
+
+# Explicit success code, same reason as Restore-Packages.ps1: callers read
+# $LASTEXITCODE, which would otherwise carry whatever the last native command left.
+exit 0

--- a/scripts/Test-Setup.ps1
+++ b/scripts/Test-Setup.ps1
@@ -95,6 +95,14 @@ $configFiles = @(
     @{ Name = 'nanoFramework.local.env.ps1'; Values = @('SMARTHOME_NANOFW_BRANCH') }
 )
 
+# What the config files actually provided, as opposed to what happens to be in the
+# process environment. The checks below read this and never $env: directly: these
+# scripts dot-source local.env.ps1 into the caller's own process, so after any other
+# SmartHome script has run in the same shell the variables are still set even once the
+# file is gone -- and a preflight would then pass a mosquitto/COM-port check on behalf
+# of a config file it just reported as missing.
+$configValues = @{}
+
 foreach ($config in $configFiles) {
     $path = Join-Path $scriptsDir $config.Name
     $template = Join-Path $scriptsDir ($config.Name -replace '\.ps1$', '.template.ps1')
@@ -118,6 +126,8 @@ foreach ($config in $configFiles) {
 
     foreach ($name in $config.Values) {
         $value = [Environment]::GetEnvironmentVariable($name)
+        $configValues[$name] = $value
+
         if ([string]::IsNullOrWhiteSpace($value)) {
             Add-Result -Name $name -Status 'FAIL' -Detail 'not set' `
                        -Fix "Set it in $path -- compare against $template"
@@ -130,7 +140,7 @@ foreach ($config in $configFiles) {
 
 # ------------------------------------------------------------------- mosquitto --
 
-$mosquittoDir = [Environment]::GetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR')
+$mosquittoDir = $configValues['SMARTHOME_MOSQUITTO_DIR']
 if (-not [string]::IsNullOrWhiteSpace($mosquittoDir)) {
     $mosquitto = Join-Path $mosquittoDir 'mosquitto.exe'
     if (Test-Path $mosquitto) {
@@ -149,7 +159,7 @@ else {
 
 # -------------------------------------------------------------------- COM port --
 
-$comPort = [Environment]::GetEnvironmentVariable('SMARTHOME_COM_PORT')
+$comPort = $configValues['SMARTHOME_COM_PORT']
 if (-not [string]::IsNullOrWhiteSpace($comPort)) {
     # Enumerates names only -- the port is never opened, so this cannot disturb a
     # device or collide with a session that has it open.
@@ -229,12 +239,31 @@ foreach ($vsTool in @(
 $packagesDir = Join-Path $repoRoot 'packages'
 $missingPackages = New-Object System.Collections.Generic.List[string]
 
+# Worktrees live *inside* the main checkout (.claude\worktrees\<name>), each a full
+# copy with its own packages.config set and its own packages\ folder. Recursing into
+# them would report on other checkouts than the one being checked: from the main
+# checkout that is 155 packages.config instead of 14, and a worktree that has pinned a
+# different package version to chase a regression would produce a "not restored"
+# failure here for a package this checkout does not need.
+#
+# Anchored to $repoRoot rather than matched as a substring anywhere in the path: this
+# script usually runs *from* a worktree, whose own paths all contain
+# '\.claude\worktrees\', and a bare substring test would exclude every file it is
+# supposed to check.
+$worktreesDir = Join-Path $repoRoot '.claude\worktrees'
 $configs = @(Get-ChildItem -Path $repoRoot -Filter 'packages.config' -Recurse -File -ErrorAction SilentlyContinue |
-    Where-Object { $_.FullName -notmatch '\\(bin|obj)\\' })
+    Where-Object {
+        $_.FullName -notmatch '\\(bin|obj)\\' -and
+        -not $_.FullName.StartsWith($worktreesDir, [StringComparison]::OrdinalIgnoreCase)
+    })
 
 foreach ($configFile in $configs) {
     [xml]$xml = Get-Content $configFile.FullName
-    foreach ($package in $xml.packages.package) {
+
+    # XPath rather than $xml.packages.package: under Set-StrictMode -Version Latest the
+    # property access throws on a packages.config with no <package> children, which
+    # would abort the whole preflight. SelectNodes just returns an empty list.
+    foreach ($package in $xml.SelectNodes('/packages/package')) {
         $name = "$($package.id).$($package.version)"
         if (-not (Test-Path (Join-Path $packagesDir $name)) -and -not $missingPackages.Contains($name)) {
             $missingPackages.Add($name)
@@ -320,6 +349,14 @@ Write-Host "$($results.Count) checked, $($failed.Count) failed, $($warned.Count)
 
 if ($failed.Count -gt 0) {
     Write-Host ""
+
+    # Non-terminating on purpose. $ErrorActionPreference is 'Stop' for the body of this
+    # script, which would make Write-Error throw -- the `exit 1` below would never run,
+    # and the exception would propagate into whatever called this script, so a caller
+    # could never reach its own next line to read $LASTEXITCODE. The contract of a
+    # preflight is its exit code, so the message goes to the error stream without
+    # terminating.
+    $ErrorActionPreference = 'Continue'
     Write-Error "Setup is incomplete: $($failed.Count) check(s) failed. See 'How to fix' above."
     exit 1
 }


### PR DESCRIPTION
The scripts table in `CLAUDE.md` says what each script does. Nothing said what has to already
exist **on the machine** before any of them will run — and that class of prerequisite fails in
ways that read like broken code rather than a missing setup step, so it gets debugged as the
wrong problem.

`gh` was the example that prompted this: required, documented, but nothing said what its absence
looks like or how to check it before depending on it.

Two commits: the documentation, then the script and skill that make it checkable.

## `scripts\Test-Setup.ps1` (new)

Reports 16 checks in one pass instead of one abort at a time — both `local.env` files and the
values inside them, `mosquitto.exe` at the configured directory, the COM port, `git`/`nanoff`/`gh`
on PATH, `gh` authentication, MSBuild and `vstest.console`, `packages\` restored, the
nanoFramework test adapter, and the companion repos.

**Read-only throughout.** Nothing installed or written, the COM port is enumerated but never
opened, no device touched — so it needs no confirmation and is safe to run while another session
holds the hardware. Exit 0 unless something FAILs; WARN covers what does not block a build (an
unplugged COM port, unsynced companion repos).

Three deliberate choices:

- **It does not use `Import-SmartHomeLocalEnv`.** That helper exits on the first missing file,
  which is the opposite of what a preflight is for — you would fix one gap, re-run, and meet the
  next.
- **A check that cannot run still emits a row** (`not checked -- SMARTHOME_COM_PORT unset`)
  rather than vanishing. A check that silently disappears reads as a check that passed.
- **It resolves the main working tree via git's common dir**, so in a worktree the remediation
  for a missing `local.env.ps1` is the exact `Copy-Item` from the main checkout with both paths
  filled in, not the generic copy-the-template hint.

## `smarthome-check-setup` (new skill)

Matches the script, per the standing expectation in `CLAUDE.md` that every script has one.

## `CLAUDE.md`

"First-time setup" expanded into four subsections. The heading is unchanged, so the existing
cross-reference from the GitHub integration section still resolves.

- **Machine-local config** / **Required local tools** — as before, plus the note that every
  script dot-sources `local.env.ps1` through `Import-SmartHomeLocalEnv` before doing anything
  else, so a missing or half-filled file stops the run at its first line.
- **Check it before relying on it** — now points at `Test-Setup.ps1` rather than listing
  commands. Keeps the Windows PowerShell 5.1 trap for anyone checking by hand: piping a native
  tool through `2>&1` wraps its ordinary stderr in a `NativeCommandError`, so a healthy
  `nanoff --version` reports as a failure.
- **What a missing prerequisite looks like** — a symptom→cause→fix table, for meeting one
  without having run the preflight. The row most worth having: an unrestored `packages\` emits a
  wall of `error CS0518` — predefined type `System.Object` not defined — across every project,
  which looks like the source tree is broken and is just `Restore-Packages.ps1`. Also notes that
  MSBuild on this machine emits German diagnostics, so match on the error *code*.
- **A fresh worktree starts with none of it** — `Get-SmartHomeScriptsDir` returns the calling
  script's own `$PSScriptRoot`, so a worktree reads *its own* `scripts\local.env.ps1`, never the
  main checkout's. Both config files and `packages\` are git-ignored, so a new worktree has
  neither.

Plus the scripts-table row. `CONTRIBUTING.md` still points at `CLAUDE.md` rather than restating
any of it, now naming the section.

## Verification

The script was run both ways on this machine:

- **Healthy:** 16 checked, 0 failed, 0 warned, exit 0. Worktree correctly detected.
- **Broken:** with `scripts\local.env.ps1` temporarily renamed away — `FAIL` on the config file,
  the two dependent checks reported as `not checked` rather than disappearing, the worktree-aware
  `Copy-Item` remediation with both absolute paths, and exit 1. File restored, no `.bak` left.

Every documented claim was hit for real while working #15 in a fresh worktree, not written from
memory: the `Import-SmartHomeLocalEnv` abort, the `CS0518` wall cleared by `Restore-Packages.ps1`,
and the `2>&1` trap (tripped while writing the check block itself).
[`Common.ps1:18`](scripts/Common.ps1#L18) for `$PSScriptRoot`; [`.gitignore:200`](.gitignore#L200)
for `packages/`; `.gitignore:401-402` for the config files.

No device behaviour touched, nothing to run on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
