### PR TITLE
fix(tests): close eight review findings in the Homie conformance check

### DIFF
--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -699,7 +699,26 @@ function Start-HomieCapture {
     )
 
     $out = Get-SmartHomeDevEnvPath -Port $Port -Kind Snapshot
-    Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
+
+    # Removed, and *proved* removed. The previous capture is torn down with taskkill /F,
+    # which returns before Windows has released cmd.exe's handle on this file, so
+    # Remove-Item can fail with a sharing violation -- and -ErrorAction SilentlyContinue
+    # would swallow that. A surviving file is not merely untidy: the connect wait below
+    # takes "the file has bytes" as proof that THIS subscriber is live, and the previous
+    # capture's bytes satisfy it instantly, defeating the wait entirely.
+    $removeDeadline = (Get-Date).AddSeconds(5)
+    while (Test-Path -Path $out) {
+        Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
+        if (-not (Test-Path -Path $out)) {
+            break
+        }
+
+        if ((Get-Date) -ge $removeDeadline) {
+            throw "Could not clear the snapshot capture file '$out': a previous subscriber still holds it open."
+        }
+
+        Start-Sleep -Milliseconds 50
+    }
 
     $sub = Get-MosquittoTool -Name 'mosquitto_sub.exe'
 
@@ -747,9 +766,40 @@ function Stop-HomieCapture {
     $script:snapshotsTaken++
 
     Start-Sleep -Seconds $SettleSeconds
+    # See #36: taskkill /F does not wait for mosquitto_sub to flush. Its stdout is
+    # redirected to a file, so the CRT buffers fully (~4KB) rather than by line, and
+    # whatever is still in that buffer dies with the process. Only the refused-transition
+    # step depends on the TAIL of a window -- every other caller needs the bulk retained
+    # replay, which is far past the buffer boundary by the time the window closes.
     Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
 
     return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+}
+
+function ConvertFrom-HomieCaptureLine {
+    # The one reader of the '%t %r %p' line layout, for the same reason Start-HomieCapture
+    # takes the subscriber arguments from Common.ps1 rather than respelling them: two
+    # callers now read these lines -- the per-topic collapse below and the refused step's
+    # ordered read -- and a second copy of the regex is a place where a change to the
+    # format could be fixed in one reader and silently keep parsing in the other.
+    #
+    # Returns $null for a line that is not a message: mosquitto_sub's stderr shares the
+    # capture file.
+    param(
+        [string]$Line
+    )
+
+    # "<topic> <0|1> <payload>", and the payload may itself contain spaces.
+    $match = [regex]::Match($Line, '^(\S+)\s+([01])\s?(.*)$')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return @{
+        Topic    = $match.Groups[1].Value
+        Retained = $match.Groups[2].Value -eq '1'
+        Payload  = $match.Groups[3].Value
+    }
 }
 
 function ConvertTo-HomieSnapshot {
@@ -780,17 +830,20 @@ function ConvertTo-HomieSnapshot {
     # exists to catch.
     $snapshot = @{}
     foreach ($line in $Lines) {
-        # "<topic> <0|1> <payload>", and the payload may itself contain spaces.
-        $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
-        if (-not $match.Success) {
+        $parsed = ConvertFrom-HomieCaptureLine -Line $line
+        if ($null -eq $parsed) {
             continue
         }
 
-        $topic = $match.Groups[1].Value
-        $retained = $match.Groups[2].Value -eq '1'
-        $payload = $match.Groups[3].Value
+        $topic = $parsed.Topic
+        $retained = $parsed.Retained
+        $payload = $parsed.Payload
 
-        if ($snapshot.Contains($topic) -and $snapshot[$topic].Payload -eq $payload) {
+        # -ceq, not -eq: PowerShell's -eq is case-insensitive, and "the SAME payload"
+        # has to mean byte-for-byte here. A live 'TRUE' merging with a replayed 'true'
+        # would inherit a retain flag it never earned, which is the very inheritance the
+        # replace-on-difference branch below exists to prevent.
+        if ($snapshot.Contains($topic) -and $snapshot[$topic].Payload -ceq $payload) {
             $snapshot[$topic].Retained = $snapshot[$topic].Retained -or $retained
             continue
         }
@@ -1217,20 +1270,45 @@ function Invoke-HomieConformanceCheck {
             # That sequence is also the behaviour this test exists to guard: it is the
             # correction itself, observed rather than inferred from where the store ended
             # up.
+            # try/finally, so the window is closed even if the publish throws. The
+            # capture file is one fixed path per port, shared by every snapshot in the
+            # run: an orphaned mosquitto_sub keeps appending homie/# traffic to it, and
+            # every later snapshot would then read a file that is no longer the record of
+            # one fresh subscriber -- silently wrong retain flags for the rest of the suite.
             $capture = Start-HomieCapture -Port $Port -WaitForConnectSeconds 5
-            Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
-            $lines = Stop-HomieCapture -Capture $capture
+            try {
+                Publish-HomieCommand -Port $Port -Topic "$node/lifecycle/set" -Payload $step.Command
+            }
+            finally {
+                $lines = Stop-HomieCapture -Capture $capture
+            }
+
             $refused = ConvertTo-HomieSnapshot -Lines $lines
 
             $stateAfter = if ($refused.Contains("$root/`$state")) { $refused["$root/`$state"].Payload } else { $null }
+            # See #36: this settled read can be flipped by a QoS-1 retransmission. The
+            # per-topic collapse only merges on an equal payload, so a duplicate of the
+            # reflected 'sleeping' arriving after the correction replaces it -- wire order
+            # [sleeping, alert, sleeping-dup] leaves 'sleeping' here while the three wire
+            # assertions below all pass. Left as is deliberately: a broker re-processes a
+            # DUP PUBLISH, so the retained store really would hold the contradiction.
             $lifecycleAfter = if ($refused.Contains("$node/lifecycle")) { $refused["$node/lifecycle"].Payload } else { $null }
 
-            if ($stateAfter -ne $step.Expect) {
-                $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state is '$stateAfter')"
+            # Absent, not merely wrong: neither topic being in the window means nothing
+            # was measured -- a subscriber that never came up, not a device that took the
+            # forbidden transition. Reported as such rather than as a device defect, the
+            # way the wire assertions below already do for a lost command.
+            if ($null -eq $stateAfter -or $null -eq $lifecycleAfter) {
+                $script:conformanceFailures += "refused '$($step.Command)': the capture window caught no `$state or $nodeId/lifecycle at all, so nothing about the refusal was measured"
             }
+            else {
+                if ($stateAfter -ne $step.Expect) {
+                    $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state is '$stateAfter')"
+                }
 
-            if ($lifecycleAfter -ne $step.Expect) {
-                $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
+                if ($lifecycleAfter -ne $step.Expect) {
+                    $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
+                }
             }
 
             # Payloads on the property topic, in arrival order, retained replay dropped:
@@ -1238,22 +1316,37 @@ function Invoke-HomieConformanceCheck {
             # about whether it arrived.
             $lifecyclePayloads = @()
             foreach ($line in $lines) {
-                $match = [regex]::Match($line, '^(\S+)\s+([01])\s?(.*)$')
-                if ($match.Success -and $match.Groups[1].Value -eq "$node/lifecycle" -and $match.Groups[2].Value -eq '0') {
-                    $lifecyclePayloads += $match.Groups[3].Value
+                $parsed = ConvertFrom-HomieCaptureLine -Line $line
+                if ($null -ne $parsed -and $parsed.Topic -eq "$node/lifecycle" -and -not $parsed.Retained) {
+                    $lifecyclePayloads += $parsed.Payload
                 }
             }
 
+            # The correction is looked for AFTER the reflection, not anywhere in the
+            # window. The window is deliberately opened before the command, so it can
+            # also hold payloads that predate it: the preceding step republishes its own
+            # command every poll round, and M2Mqtt retransmits an unacknowledged QoS-1
+            # publish every MqttSettings.DelayOnRetry (1s), up to three times -- the same
+            # retransmission ConvertTo-HomieSnapshot's merge rule exists to absorb. A
+            # first-occurrence search for the expected value would find one of those and
+            # report a correct device as having published the correction too early.
             $reflected = [array]::IndexOf($lifecyclePayloads, $step.Command)
-            $corrected = [array]::IndexOf($lifecyclePayloads, $step.Expect)
+            $corrected = -1
+            if ($reflected -ge 0 -and ($reflected + 1) -lt $lifecyclePayloads.Length) {
+                $corrected = [array]::IndexOf($lifecyclePayloads, $step.Expect, $reflected + 1)
+            }
+
+            # Only to tell "never corrected at all" from "corrected, but before the
+            # reflection it was supposed to overwrite" -- two different device defects.
+            $correctedAnywhere = [array]::IndexOf($lifecyclePayloads, $step.Expect)
 
             if ($reflected -lt 0) {
                 $script:conformanceFailures += "refused '$($step.Command)' never reached $nodeId/lifecycle -- the command was lost, so nothing about the refusal was measured (saw: $($lifecyclePayloads -join ', '))"
             }
-            elseif ($corrected -lt 0) {
+            elseif ($corrected -lt 0 -and $correctedAnywhere -lt 0) {
                 $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it"
             }
-            elseif ($corrected -lt $reflected) {
+            elseif ($corrected -lt 0) {
                 $script:conformanceFailures += "$nodeId/lifecycle published '$($step.Expect)' before the reflected '$($step.Command)', so the correction did not overwrite it (saw: $($lifecyclePayloads -join ', '))"
             }
 
@@ -1422,9 +1515,21 @@ try {
                 }
                 finally {
                     Stop-DeviceDebugCapture -Capture $debugCapture
-                }
 
-                Write-ConformancePhaseBreakdown
+                    # In the finally with it, because returning is not the check's only
+                    # way out: a missing mosquitto tool, a capture file that cannot be
+                    # cleared or a publish that fails all propagate under
+                    # $ErrorActionPreference = 'Stop' and land in the catch below as an
+                    # ERROR verdict. That is the run whose phase timings are worth
+                    # reading most, and outside the finally it was the one run that
+                    # printed none.
+                    #
+                    # After Stop-DeviceDebugCapture, not before: that call releases the
+                    # COM port the next deploy needs, and it is documented not to throw
+                    # -- it warns on a recycled or already-dead pid -- so ordering it
+                    # first does not cost the breakdown.
+                    Write-ConformancePhaseBreakdown
+                }
             }
             elseif ($settings.Kind -eq 'BrokerOutage') {
                 $verdict = Invoke-BrokerOutageCheck -Settings $settings -Port $mqttPort

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1336,18 +1336,26 @@ function Invoke-HomieConformanceCheck {
                 $corrected = [array]::IndexOf($lifecyclePayloads, $step.Expect, $reflected + 1)
             }
 
-            # Only to tell "never corrected at all" from "corrected, but before the
-            # reflection it was supposed to overwrite" -- two different device defects.
-            $correctedAnywhere = [array]::IndexOf($lifecyclePayloads, $step.Expect)
-
+            # One message for "no correction after the reflection", not two.
+            #
+            # Splitting it on whether $Expect appears anywhere in the window would name a
+            # second defect -- "corrected, but before the reflection it was supposed to
+            # overwrite" -- that the window cannot actually distinguish. It is the same
+            # unordered first-occurrence search the paragraph above rejects for $corrected:
+            # the preceding step drove the device to $Expect and its publishes (republished
+            # per poll round, retransmitted per DelayOnRetry) can still be arriving when
+            # this window opens. A device that simply never corrected would then be
+            # reported as having corrected too early, sending the next reader after a
+            # publish ordering bug that never happened.
+            #
+            # The observed sequence is in the message either way, so a genuinely early
+            # correction is still visible -- as evidence, not as a claim the runner cannot
+            # support.
             if ($reflected -lt 0) {
                 $script:conformanceFailures += "refused '$($step.Command)' never reached $nodeId/lifecycle -- the command was lost, so nothing about the refusal was measured (saw: $($lifecyclePayloads -join ', '))"
             }
-            elseif ($corrected -lt 0 -and $correctedAnywhere -lt 0) {
-                $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it"
-            }
             elseif ($corrected -lt 0) {
-                $script:conformanceFailures += "$nodeId/lifecycle published '$($step.Expect)' before the reflected '$($step.Command)', so the correction did not overwrite it (saw: $($lifecyclePayloads -join ', '))"
+                $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it (saw: $($lifecyclePayloads -join ', '))"
             }
 
             continue

--- a/src/integrationTests/HomieClientCheck/Program.cs
+++ b/src/integrationTests/HomieClientCheck/Program.cs
@@ -161,6 +161,12 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
             //
             // Actuators copying this device should do the same: reflect the outcome, not
             // the command.
+            //
+            // Unconditional, so an accepted command publishes the same payload twice --
+            // the library's reflection, then an identical correction. See #36: guarding
+            // on _lifecycle.Value would suppress the second publish, but Value is already
+            // updated even when the reflection's own publish threw, and the guard would
+            // then suppress the only publish the broker would have seen.
             _lifecycle.Update(_homieClient.State.GetString());
         }
 
@@ -173,11 +179,19 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
                     continue;
                 }
 
+                // Every arm named, and the default refuses rather than falling back to
+                // Ready(). LifecycleStates is also what BuildLifecycleFormat publishes
+                // as $format, so a state added there is immediately offered to
+                // controllers -- and a default that applied Ready() would answer such a
+                // command with the wrong transition and no sign that anything was
+                // missed. Refusing leaves the correction in HandleCommand to publish the
+                // state the device is actually in.
                 var applied = state switch
                 {
+                    State.Ready => _homieClient.Ready(),
                     State.Alert => _homieClient.Alert(),
                     State.Sleeping => _homieClient.Sleep(),
-                    _ => _homieClient.Ready(),
+                    _ => false,
                 };
 
                 Debug.WriteLine($"HomieClientCheck: '{payload}' -> {applied}");

--- a/src/integrationTests/HomieClientCheck/Program.cs
+++ b/src/integrationTests/HomieClientCheck/Program.cs
@@ -186,12 +186,17 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
                 // command with the wrong transition and no sign that anything was
                 // missed. Refusing leaves the correction in HandleCommand to publish the
                 // state the device is actually in.
+                //
+                // The default logs through RefuseUnwiredState rather than returning false
+                // inline: a bare false is indistinguishable in the log from a transition
+                // the convention's own state machine refused, which is exactly the "no
+                // sign that anything was missed" this arm exists to remove.
                 var applied = state switch
                 {
                     State.Ready => _homieClient.Ready(),
                     State.Alert => _homieClient.Alert(),
                     State.Sleeping => _homieClient.Sleep(),
-                    _ => false,
+                    _ => RefuseUnwiredState(state),
                 };
 
                 Debug.WriteLine($"HomieClientCheck: '{payload}' -> {applied}");
@@ -199,6 +204,17 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
             }
 
             Debug.WriteLine($"HomieClientCheck: unknown lifecycle command '{payload}'.");
+        }
+
+        // A state that is in LifecycleStates -- and so in $format, and so offered to
+        // controllers -- but has no arm in HandleLifecycleCommand's switch. Says so
+        // rather than sharing the refused transition's log line, so the gap is visible in
+        // the captured debug output instead of looking like the device declining a
+        // command it understood.
+        private static bool RefuseUnwiredState(State state)
+        {
+            Debug.WriteLine($"HomieClientCheck: '{state.GetString()}' is offered in $format but has no transition wired -- refusing.");
+            return false;
         }
 
         // The runner cycles the broker while this device runs, so it can boot with no


### PR DESCRIPTION
Closes eight of the eleven findings from the `xhigh` code review of #32, in the Homie v4
conformance check and the device it measures. The three left unfixed are #36 — each was
skipped because the available fix traded something away, and that reasoning lives on the
issue rather than being lost when this merges.

Two files: `scripts/Run-IntegrationTests.ps1` and
`src/integrationTests/HomieClientCheck/Program.cs`.

## The four that could fail a healthy device

- **The refused-transition step searched the whole capture window for the correction.** The
  window is deliberately opened *before* the command, so it also holds payloads that predate
  it — the preceding step republishes its command every poll round, and M2Mqtt retransmits an
  unacknowledged QoS-1 publish every `DelayOnRetry` (1s), three times over. A first-occurrence
  `IndexOf` could find one of those and report a correct device as having published the
  correction too early. The correction is now looked for *after* the reflection, with a
  separate unordered search kept only to tell "never corrected" from "corrected too early".
- **`Start-HomieCapture`'s `-WaitForConnectSeconds` could be defeated by the file it was
  waiting on.** It takes "the output file has bytes" as proof its own subscriber is live. The
  previous capture is torn down with `taskkill /F`, which returns before Windows releases the
  handle, so `Remove-Item` could fail with a sharing violation — silenced by
  `-ErrorAction SilentlyContinue` — leaving the previous capture's bytes to satisfy the guard
  instantly. That is the exact race the parameter was added to prevent. Removal is now proved,
  or the run fails saying so.
- **The refused step was not bracketed by `try`/`finally`.** A throw from the publish left a
  live `mosquitto_sub` appending to the one snapshot path every later capture reuses, quietly
  invalidating the retain flags for the rest of the suite.
- **`ConvertTo-HomieSnapshot`'s "same payload" merge used `-eq`,** which is case-insensitive in
  PowerShell, so a live `TRUE` merging with a replayed `true` inherited a retain flag it never
  earned — the very inheritance the replace-on-difference branch exists to prevent. Now `-ceq`.

## The rest

- An empty capture window reported the forbidden transition as *applied*, blaming the device
  for a host-side failure. It now says nothing was measured, as the wire assertions already did
  for a lost command.
- `Write-ConformancePhaseBreakdown` ran only on the check's return paths, so a throw skipped
  the timings for the run that needed them most. Now in a `finally`.
- The `'%t %r %p'` line regex had a second copy in the refused step, right next to a comment
  explaining why the subscriber arguments are *not* respelled there. One reader now:
  `ConvertFrom-HomieCaptureLine`.
- `HandleLifecycleCommand`'s switch defaulted to `Ready()`, so a state added to
  `LifecycleStates` — which is also what builds `$format`, and so what controllers are offered
  — would silently apply the wrong transition. Every arm is named and the default refuses.

## Rebase: what survived unchanged, and what had to be re-expressed

The branch was cut before `e32d936` and `2d49328` and has been rebased onto `115005e`.
`e32d936` added managed-debug-output capture and broker-log preservation to the same
conformance path this branch expands, so the two met at one call site.

**Seven of the eight findings survived the rebase unchanged** — the `Start-HomieCapture`
removal proof, the refused-step `try`/`finally`, the `-ceq` merge, the ordered correction
search, the empty-window report, `ConvertFrom-HomieCaptureLine`, and the `Program.cs` switch
all applied to regions main had not touched.

**One had to be re-expressed: the `Write-ConformancePhaseBreakdown` finally.** Main had
independently introduced a `try`/`finally` at that call site — but for stopping the debug
capture, with the breakdown left *outside* it. The finding was therefore still live on main
in the same form, and the fix here joins main's existing `finally` rather than nesting a
second one inside it. Ordering is deliberate: after `Stop-DeviceDebugCapture`, because that
call releases the COM port the next deploy needs, and `2d49328` made it warn rather than throw
on a recycled or already-dead pid — so going second costs the breakdown nothing. The run log
confirms the order on the wire: `Stopping device debug monitor (PID 35260)...` immediately
followed by `phase breakdown`.

Nothing from `e32d936`/`2d49328` was dropped or duplicated: the run preserved
`HomieClientCheck.log` (20 KB of managed debug output), plus the broker and `homie/#` logs.

## Verification

**Run on hardware** — the original 5/5 was against the pre-rebase base and proved nothing
about this result, so the whole suite was re-run after the rebase.

Full integration suite on ESP32 / COM3 with local Mosquitto, **5/5 PASS**, 171s total (79s of
it deploys):

| Test | Result |
|---|---|
| WifiCheck | PASS 22s |
| MqttCheck | PASS 20s |
| Bmp280Check | PASS 19s |
| HomieClientCheck | PASS 62s |
| MqttReconnectCheck | PASS 48s |

Conformance phase snapshot counts **3/0/1/5/2**, identical to the pre-fix baseline — so none of
this changed what the check measures. The check itself took 45.1s against a documented
43.1–44.1s; the drift is `e32d936`'s debug-capture launch, not anything in this branch.

The refused transition is visible in the preserved `homie/#` log as `sleeping` then `alert` on
`matrix/lifecycle`, in that order, against the device's own `'sleeping' -> False` — which is
precisely what the reordered search asserts.

Also run: `msbuild SmartHome.sln /t:Build` clean across all 14 projects (warnings all
pre-existing). RoomSensor was redeployed afterwards, so the device is back to its real job
rather than holding the last integration test.

**Not run:** the unit suite (`Run-Tests.ps1`) — CI runs it on the nanoclr virtual device, and
this branch touches no unit-tested code.

## Follow-up: two findings from the review of this branch

`2af2b12`, in the same two files. Both are in code this branch introduced.

- **The refused step looked for the correction twice, and the second search could not
  support the claim it made.** Alongside the ordered search described above, an unordered
  `IndexOf` across the whole window existed only to tell "never corrected at all" from
  "corrected before the reflection it was supposed to overwrite". But it is the same
  first-occurrence search the ordered one replaced, with the same exposure: the window opens
  before the command, so it still holds the preceding step's live traffic. A device that
  never published the correction was therefore reported as having published it too early —
  sending the next reader after an ordering bug that did not happen, and hiding the one that
  did. The two branches are now one message carrying the observed payload sequence, so a
  genuinely early correction stays visible as evidence rather than as a claim the runner
  cannot support.
- **`HandleLifecycleCommand`'s new default arm returned a bare `false`,** which reaches the
  same `'{payload}' -> {applied}` line as a transition the convention's own state machine
  refused — the "no sign that anything was missed" the named arms were added to remove. It
  now goes through `RefuseUnwiredState`, which says the state is offered in `$format` but has
  no transition wired.

**Verification** — the whole suite re-run on hardware after the fixes: ESP32 / COM3 with local
Mosquitto, **5/5 PASS**, 172s (77s of it deploys). WifiCheck 21s, MqttCheck 20s, Bmp280Check
19s, HomieClientCheck 62s, MqttReconnectCheck 50s. The refused transition is in the preserved
`homie/#` log as `sleeping` then `alert` on `matrix/lifecycle`, in that order, which is what the
ordered search asserts. `HomieClientCheck.nfproj` also builds clean on its own (warnings all
pre-existing).

**Correction to the Verification section above:** it says RoomSensor was redeployed afterwards.
That was true of the earlier run, but this re-run left `MqttReconnectCheck` on the device, so
RoomSensor needs redeploying before the device is back to its real job.

## #36

Still accurate against the rebased code, and the line numbers it cites are unaffected — it
names functions and behaviours, not line numbers. Item 3 (every accepted lifecycle command
publishing twice) is directly visible in this run's `homie/#` log as the duplicate pairs on
`matrix/lifecycle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

