### PR TITLE
fix(scripts): make the deploy-pad record's failure directions safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,10 @@ pessimistically before the flash and tightened after it) and pads to `max(this i
 record)` rounded up to a 4KB sector — same guarantee, roughly half the erase-and-verify
 footprint across a suite run. Anything the record can't vouch for — missing, corrupt, a
 different `-DeployAddress`, `-FullPad` — falls back to the flat 400KB, never to the bare
-image size.
+image size, and never below a larger footprint the record does vouch for at this address
+(`-FullPad` distrusts how *tight* the record is, not its floor). An image bigger than the
+400KB fallback deploys fine but warns, because the fallback stops being a worst case the
+moment one exists.
 
 The record only describes what *this script* flashed. Visual Studio's F5 deploy and the
 nanoFramework test adapter both write the deployment partition themselves, and erase only

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -812,11 +812,23 @@ function Clear-SmartHomeDeployState {
         [string]$ComPort
     )
 
+    # A clear that quietly did not happen is the one failure this whole mechanism has
+    # to avoid: it leaves a record SMALLER than what is actually on the device, and the
+    # next deploy pads to it. So a missing file is fine (nothing to clear) but a removal
+    # that fails is not swallowed -- callers run under $ErrorActionPreference = 'Stop'
+    # and should stop rather than flash against a record they were told was gone.
     if ($ComPort) {
-        Remove-Item -Path (Get-SmartHomeDeployStatePath -ComPort $ComPort) -Force -ErrorAction SilentlyContinue
+        $stateFile = Get-SmartHomeDeployStatePath -ComPort $ComPort
+        if (Test-Path -LiteralPath $stateFile) {
+            Remove-Item -LiteralPath $stateFile -Force
+        }
         return
     }
 
-    Get-ChildItem -Path (Get-SmartHomeDeployStatePath -ComPort '*') -ErrorAction SilentlyContinue |
-        Remove-Item -Force -ErrorAction SilentlyContinue
+    # -LiteralPath on the directory plus -Filter, not a wildcard -Path: Get-ChildItem
+    # reads [ and ] in a -Path as wildcard metacharacters, so a temp directory whose
+    # name contains either would match nothing at all and clear silently.
+    $pattern = Split-Path (Get-SmartHomeDeployStatePath -ComPort '*') -Leaf
+    Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Filter $pattern -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force
 }

--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -155,37 +155,78 @@ $imageBytes = [System.IO.File]::ReadAllBytes($deployImage)
 # under-padding costs a device booting somebody else's assemblies.
 $sectorSize = 4096   # ESP32 flash erase granularity; keeps the write sector-aligned.
 
+# Read even under -FullPad. That switch distrusts how TIGHT the record is -- something
+# else has flashed the device since -- but a record proving a bigger image was written
+# to this same address is still a lower bound, and honouring it is what keeps -FullPad
+# the pessimistic option it is documented to be.
+$deployState   = Get-SmartHomeDeployState -ComPort $comPort
+$recordedBytes = $null
+$recordReason  = $null
+
+if ($null -eq $deployState) {
+    $recordReason = "no usable deploy record for $comPort"
+}
+elseif ($deployState['DeployAddress'] -ne $DeployAddress) {
+    # A different address is a different region: what that record describes says
+    # nothing about what is sitting at this one -- not even as a floor.
+    $recordReason = "the deploy record for $comPort covers $($deployState['DeployAddress']), not $DeployAddress"
+}
+elseif ($deployState['StaleBytes'] -gt $DeployPartitionSize) {
+    # Parseable but impossible: nothing this script flashed can be larger than the
+    # partition. Rejecting it here keeps a corrupt record costing one full-size deploy
+    # -- the documented failure direction -- instead of tripping the partition check
+    # below and refusing every deploy to this port until the file is deleted by hand.
+    $recordReason = "the deploy record for $comPort claims $($deployState['StaleBytes']) bytes, larger than the deploy partition ($DeployPartitionSize)"
+}
+else {
+    $recordedBytes = $deployState['StaleBytes']
+}
+
 $staleBytes = $null
 $padReason  = $null
 
 if ($FullPad) {
     $padReason = '-FullPad was passed'
 }
+elseif ($null -eq $recordedBytes) {
+    $padReason = $recordReason
+}
 else {
-    $deployState = Get-SmartHomeDeployState -ComPort $comPort
-    if ($null -eq $deployState) {
-        $padReason = "no usable deploy record for $comPort"
-    }
-    elseif ($deployState['DeployAddress'] -ne $DeployAddress) {
-        # A different address is a different region: what that record describes says
-        # nothing about what is sitting at this one.
-        $padReason = "the deploy record for $comPort covers $($deployState['DeployAddress']), not $DeployAddress"
-    }
-    else {
-        $staleBytes = $deployState['StaleBytes']
-    }
+    $staleBytes = $recordedBytes
 }
 
-$padFloor  = if ($null -ne $staleBytes) { $staleBytes } else { $FallbackPadSize }
+# -FallbackPadSize is a worst case only while every image fits under it. An image that
+# does not is padded to itself, which is correct for THIS deploy but leaves the fallback
+# unable to cover it later -- after Run-Tests.ps1 clears the record, or under -FullPad.
+if ($imageBytes.Length -gt $FallbackPadSize) {
+    Write-Warning @"
+This image is $($imageBytes.Length) bytes, larger than -FallbackPadSize ($FallbackPadSize).
+It deploys correctly, but once anything drops the deploy record for $comPort (a hardware
+Run-Tests.ps1 run, a corrupt record) the fallback no longer covers this image, and the next
+deploy of a smaller app will leave its tail on the device. Raise -FallbackPadSize.
+"@
+}
+
+$padFloor = if ($null -ne $staleBytes) {
+    $staleBytes
+}
+elseif ($null -ne $recordedBytes) {
+    # Falling back, but with a trustworthy floor to fall back to.
+    [Math]::Max($FallbackPadSize, $recordedBytes)
+}
+else {
+    $FallbackPadSize
+}
+
 $padTarget = [Math]::Max($imageBytes.Length, $padFloor)
 $paddedImageSize = [int][Math]::Ceiling($padTarget / [double]$sectorSize) * $sectorSize
 
 if ($paddedImageSize -gt $DeployPartitionSize) {
     Write-Error @"
 Padded deploy image ($paddedImageSize bytes) does not fit the deploy partition ($DeployPartitionSize bytes).
-The image itself is $($imageBytes.Length) bytes. Either the app has outgrown the partition, or
--DeployPartitionSize is stale -- re-read the "deploy" line of the partition table printed by
-.\scripts\Watch-DeviceSerial.ps1 and pass the real size.
+The image itself is $($imageBytes.Length) bytes, padded up to a floor of $padFloor bytes. Either the
+app has outgrown the partition, or -DeployPartitionSize is stale -- re-read the "deploy" line of the
+partition table printed by .\scripts\Watch-DeviceSerial.ps1 and pass the real size.
 "@
     exit 1
 }
@@ -208,12 +249,19 @@ while ($filled -lt $paddedImageSize) {
 [Array]::Copy($imageBytes, $padded, $imageBytes.Length)
 [System.IO.File]::WriteAllBytes($paddedImage, $padded)
 
-if ($null -ne $staleBytes) {
-    Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, covering the $staleBytes bytes the last deploy to $comPort left on the device)." -ForegroundColor DarkGray
+# Names whichever input actually set the size: the pad floor only drives it while the
+# image is smaller than the floor, and a message crediting the floor for a size the
+# image chose misleads exactly the person reading this line to explain a pad.
+$padDriver = if ($imageBytes.Length -ge $padFloor) {
+    'the image itself is the larger of the two'
+}
+elseif ($null -ne $staleBytes) {
+    "covering the $staleBytes bytes the last deploy to $comPort left on the device"
 }
 else {
-    Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, full-size pad -- $padReason)." -ForegroundColor DarkGray
+    "full-size pad -- $padReason"
 }
+Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, $padDriver)." -ForegroundColor DarkGray
 
 # Recorded before the flash, and pessimistically: if nanoff dies partway, or the shell
 # is killed, anything up to $paddedImageSize may have landed and the next deploy has to


### PR DESCRIPTION
Follow-up to #45. That PR sized `Deploy-ToDevice.ps1`'s 0xFF pad from a per-COM-port record of
the last flash instead of a flat 400KB. The scheme is right and its central guarantee holds —
this changes none of it. What it fixes is four edges of that scheme that fail in the *unsafe*
direction: padding less than the footprint actually on the device, or refusing to deploy at all.

## A corrupt record refused every deploy to that port

A record whose `StaleBytes` exceeds the deploy partition passed `Get-SmartHomeDeployState`'s
validation — which only rejects negatives and non-numerics — and then tripped the partition
check downstream. One garbled temp file therefore refused *every* deploy to that COM port until
someone deleted it by hand, with an error blaming the app for outgrowing the partition and
naming neither the record nor `-FullPad`.

That directly broke the reader's own stated contract, that every rejection costs at most one
full-size deploy. Such a record is now rejected alongside every other untrustworthy one, and the
partition error names the pad floor it used so the record is visible in it.

## `-FullPad` could pad *less* than trusting the record

`-FullPad` dropped the record entirely and padded `-FallbackPadSize`. Once an image grows past
409,600 — the partition allows 1,835,008 — the documented "pessimistic escape hatch" pads less
than doing nothing would:

- image grows to 450,000, gets deployed, record says 450,000
- someone F5-deploys from Visual Studio
- the user follows CLAUDE.md and the `smarthome-deploy` skill — "pass `-FullPad` on the first
  deploy after one" — while deploying WifiCheck (89,512)
- pad floor is 409,600, so bytes 409,600..450,000 of the older image survive, and
  `ContiguousBlockAssemblies` finds them

`-FullPad` distrusts how *tight* the record is, not its floor. A record proving a bigger image
was written to this same address is still a lower bound, so the fallback now takes the larger of
the two. A record for a different `-DeployAddress` is deliberately left out of this — a different
region is not a floor for this one.

## Nothing enforced that the fallback covers the largest image

`-FallbackPadSize` is a worst case only while every image fits under it. An image larger than it
deploys correctly and records itself, but the next deploy that has to fall back — after
`Run-Tests.ps1` clears the record, or under `-FullPad` — will not cover it. Only a comment on the
parameter guarded this. Deploying such an image now warns.

## The all-ports clear could silently no-op

`Clear-SmartHomeDeployState`'s all-ports branch globbed with `-Path` and silenced errors on both
the enumeration and the removal, so a clear that did not happen was indistinguishable from one
that did — while `Run-Tests.ps1` printed "Cleared the deploy padding record" regardless. A
momentarily locked file, or a temp directory whose name contains `[` or `]` (wildcard
metacharacters to `-Path`, matching nothing), left the record in place after the test adapter had
already flashed the device. The next deploy then padded from a too-small number: a device booting
leftover test assemblies — precisely the failure this mechanism exists to prevent — reported as
success.

It now enumerates with `-LiteralPath` plus `-Filter`, and lets removal failures surface rather
than swallowing them. Callers run under `$ErrorActionPreference = 'Stop'` and should stop rather
than flash against a record they were told was gone.

## The pad message credited the wrong input

"covering the 89512 bytes the last deploy left" printed while padding to 262,144 for a 259,168
image — the image set that size, not the record. It now names whichever input actually did.

## Verified on hardware

Full integration suite on the real ESP32 on COM3, **5/5 PASS** (168s, 73s of it deploys). All
three pad-driver branches were exercised:

| Test | Image | Pad | Erased | Driver |
|---|---|---|---|---|
| WifiCheck | 89,512 | 409,600 | `0x1e0000..0x243fff` | no record (fallback) |
| MqttCheck | 141,912 | 143,360 | `..0x202fff` | image larger |
| Bmp280Check | 132,384 | 143,360 | `..0x202fff` | record (141,912) larger |
| HomieClientCheck | 181,812 | 184,320 | `..0x20cfff` | image larger |
| MqttReconnectCheck | 150,980 | 184,320 | `..0x20cfff` | record (181,812) larger |

The two record-driven rows are the smaller-after-larger case the padding exists for, and the
reported ROM total is the decisive evidence — each is the test's own image exactly, with no stale
tail: WifiCheck 89,512, MqttCheck 141,912, Bmp280Check 132,384 (deployed directly after
MqttCheck's larger image). Every flash reported `Hash of data verified.`

No `-FallbackPadSize` warning fired, correctly — every image in this repo is under 409,600 today.

That run was against #45's tree with these exact fixes applied. `main` has since advanced only by
#48, which touches `src/tests/Unit/HomieClientTests.cs` and nothing on this path, so the run
stands for this branch.

## Verified off hardware

16 assertions over the `Common.ps1` helpers and the padding arithmetic: round-trip; rejection of
corrupt JSON and of an over-partition record; per-port and all-ports clear, including idempotence;
that the pad is always sector-aligned and always covers the image; the `-FullPad` floor
(450,000-byte record under `-FullPad` pads 450,560, not 409,600); and a suite-like sequence of
image sizes in which every pad covers the previous image. All passed. Not committed — this repo's
unit suite runs device-side under nanoFramework, which is the wrong home for host PowerShell
helpers.

Both modified scripts parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
