### PR TITLE
fix(scripts): say which target the test run actually used

### DIFF
--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -10,10 +10,15 @@
     4. Runs vstest.console against the built test assembly using
        src\tests\Unit\nano.runsettings.
 
-    nano.runsettings has <IsRealHardware>True</IsRealHardware> — this
-    deploys test code to and executes it on the physical device on the
-    configured COM port, same as Deploy-ToDevice.ps1. Treat it as a
-    hardware-touching action.
+    The default run settings file, nano.runsettings, has
+    <IsRealHardware>True</IsRealHardware> — this deploys test code to and
+    executes it on the physical device on the configured COM port, same as
+    Deploy-ToDevice.ps1. Treat it as a hardware-touching action.
+
+    -RunSettings nano.ci.runsettings sets IsRealHardware=False instead and runs
+    the same tests on the nanoclr virtual device, touching no COM port and
+    deploying nothing. The script reads that flag out of the resolved settings
+    file and reports which of the two it did, so a log can be told apart later.
 
 .NOTES
     Requires:
@@ -106,9 +111,51 @@ Visual Studio's "Restore NuGet Packages", then re-run this script.
     exit 1
 }
 
-# ── Run tests on hardware ─────────────────────────────────────────────────────
+# ── Run tests ─────────────────────────────────────────────────────────────────
+# Which target the run uses is declared by the settings file, so read it instead of
+# assuming the hardware default: -RunSettings nano.ci.runsettings sets IsRealHardware
+# False and executes on the nanoclr virtual device, with no COM port and no deploy.
+# CLAUDE.md singles this script out as one of three that talk to the physical ESP32,
+# and this line is the only thing in the output saying which of the two a given run
+# was -- a virtual run announcing "on hardware" misleads exactly the person trying to
+# reconcile what was and was not exercised on the device.
+#
+# SelectSingleNode rather than $xml.RunSettings.nanoFrameworkAdapter.IsRealHardware:
+# under Set-StrictMode a missing element is an error on property access, and a
+# caller-supplied settings file is allowed to omit it.
+#
+# Name it from the resolved path, not from $RunSettings: PowerShell variables are
+# case-insensitive, so the $runSettings assignment above has already overwritten the
+# parameter of that name with the full path.
+$runSettingsName = Split-Path $runSettings -Leaf
+[xml]$runSettingsXml = Get-Content -Path $runSettings -Raw
+$hardwareNode = $runSettingsXml.SelectSingleNode('/RunSettings/nanoFrameworkAdapter/IsRealHardware')
+$portNode     = $runSettingsXml.SelectSingleNode('/RunSettings/nanoFrameworkAdapter/RealHardwarePort')
+$hardwareFlag = if ($hardwareNode) { $hardwareNode.InnerText.Trim() } else { '' }
+$hardwarePort = if ($portNode) { $portNode.InnerText.Trim() } else { '' }
+
+if ($hardwareFlag -eq 'True') {
+    $target = 'real hardware'
+    $targetDetail = if ($hardwarePort) {
+        "COM port $hardwarePort from $runSettingsName"
+    } else {
+        # An empty RealHardwarePort means the adapter takes the first nanoDevice it
+        # finds, which is not necessarily SMARTHOME_COM_PORT. Don't name a port the
+        # run may not have used.
+        "first device found; $runSettingsName names no COM port"
+    }
+} elseif ($hardwareFlag -eq 'False') {
+    $target = 'the nanoclr virtual device'
+    $targetDetail = "no COM port, no deploy; from $runSettingsName"
+} else {
+    # Only reachable through a -RunSettings file declaring neither value, in which case
+    # the adapter picks and this script genuinely cannot say which target ran.
+    $target = 'an undeclared target'
+    $targetDetail = "$runSettingsName sets no IsRealHardware, so the adapter chooses"
+}
+
 Write-Host ""
-Write-Host "Running tests on hardware via vstest.console..." -ForegroundColor Cyan
+Write-Host "Running tests on $target ($targetDetail) via vstest.console..." -ForegroundColor Cyan
 Write-Host "  Adapter: $adapterDir"
 Write-Host "  Settings: $runSettings"
 
@@ -173,7 +220,7 @@ Results: $trxPath
 }
 
 Write-Host ""
-Write-Host "Tests passed." -ForegroundColor Green
+Write-Host "Tests passed on $target." -ForegroundColor Green
 
 # Explicit success code -- see the note in Sync-NanoFrameworkRepos.ps1.
 exit 0


### PR DESCRIPTION
## Summary

`Run-Tests.ps1` announced "Running tests on hardware" for every run, including virtual-device ones; it now reads `IsRealHardware` from the resolved run settings file and says which target actually ran.

## Changes

- Read `IsRealHardware` out of `$runSettings` and word the status line from it: `real hardware`, `the nanoclr virtual device`, or — for a caller-supplied file declaring neither — `an undeclared target` the adapter chooses. Still one line.
- `Tests passed.` → `Tests passed on <target>.` That line is what gets quoted as evidence in a PR, and `CONTRIBUTING.md` asks what was run on hardware. The `Results: N passed, ...` counters line above it is target-neutral already and is unchanged.
- The COM port is named only when the settings file declares one. `nano.runsettings` leaves `RealHardwarePort` empty, so the adapter takes the first nanoDevice it finds — not necessarily `SMARTHOME_COM_PORT`. Naming a port the run may not have used would trade one wrong claim for another.
- `SelectSingleNode` rather than `$xml.RunSettings.nanoFrameworkAdapter.IsRealHardware`: under `Set-StrictMode -Version Latest` a missing element throws on property access, and `-RunSettings` accepts any file.
- Uses a leaf name derived from the resolved path rather than `$RunSettings`. PowerShell variables are case-insensitive, so line 85's `$runSettings = Join-Path $projectDir $RunSettings` has already overwritten the parameter of that name with the full path — the first version of this change printed the whole path in the message. Pre-existing and harmless elsewhere (nothing else reads `$RunSettings` after that line), now commented so it is not reintroduced.
- Header doc comment updated: it asserted the hardware path unconditionally, while `-RunSettings` has existed for a while.

**Why this is not just a string fix:** `CLAUDE.md`'s hardware-safety section singles this script out as one of three that talk to the physical ESP32, and this line is the only signal in the output about which mode a run was in. A log saying "on hardware" for a virtual run misleads exactly the person reconciling what was and was not exercised on the device. Observed for real: a virtual run on 2026-08-29 printed "Running tests on hardware" while touching no hardware at all.

Exit-code and TRX-counter behaviour is untouched — the diff makes no change below the status line.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [x] Infrastructure / tooling

## Testing Done

- **On hardware:** `.\scripts\Run-Tests.ps1` against a real ESP32 — `[nanoTestAdapter]: Getting things ready with ESP32_REV3 @ COM3`, `Results: 40 passed, 0 failed, 40 of 40 executed.`, exit 0. Output read as intended:

  ```
  Running tests on real hardware (first device found; nano.runsettings names no COM port) via vstest.console...
  Tests passed on real hardware.
  ```

  The "first device found" branch was the accurate one here — the adapter picked the device itself, since `nano.runsettings` names no port.

- **All four branches**, exercised under `Set-StrictMode -Version Latest` with the mode block extracted from the script: `nano.runsettings` (real hardware, no port declared), `nano.ci.runsettings` (virtual device), a synthetic file declaring `COM7` (real hardware, port named), and one declaring neither (undeclared target). Each produced the right line.

- `[System.Management.Automation.Language.Parser]::ParseFile` clean.

- **Not run on hardware:** the virtual path end-to-end (`-RunSettings nano.ci.runsettings`) — that branch is covered by the standalone harness above and by CI on this PR, which is what exercises it for real.

Note for anyone reproducing in a fresh worktree: `scripts\local.env.ps1` is git-ignored and `packages\` starts empty, so `Restore-Packages.ps1` is needed first or the build fails with `System.String ... not defined` (missing mscorlib), which looks alarming but is only a missing restore.

## Checklist

- [x] Code compiles without errors
- [x] Relevant tests pass (or N/A for non-code changes)
- [x] No secrets or credentials committed
- [x] PR title follows Conventional Commits (it becomes the merge commit message)
