### PR TITLE
docs(scripts): record that -DeployPartitionSize was measured, not assumed

### DIFF
--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -70,16 +70,22 @@ param(
     # with the whole of src\devices and src\integrationTests in mind.
     [int]$FallbackPadSize = 409600,
 
-    # Refuse to pad past the deploy partition; writing beyond it would run into the
-    # "config" partition that starts where this one ends, at 0x3C0000. Measured
-    # 2026-08-30 off the device the same way -DeployAddress above was -- the boot-log
-    # partition table from .\scripts\Watch-DeviceSerial.ps1, this time the "deploy"
+    # Refuse to pad past the deploy partition; nothing outside it is ours to erase.
+    # Measured 2026-08-30 off the device from the same boot-log partition table as
+    # -DeployAddress above (.\scripts\Watch-DeviceSerial.ps1), this time the "deploy"
     # line's Length column rather than its Offset:
+    #   2 factory   factory app    00 00 00010000 001d0000
     #   3 deploy    Unknown data   01 84 001e0000 001c0000
     #   4 config    Unknown data   01 83 003c0000 00040000
-    # (4MB flash, nanoCLR 1.17.0.339, ESP-IDF v5.5.4). Until then the value had only
-    # ever been copied from a prose comment of unclear provenance -- issue #47.
-    # Re-derive it there if a firmware update changes the layout.
+    # on a 4MB flash running nanoCLR 1.17.0.339 / ESP-IDF v5.5.4. So deploy runs
+    # 0x1E0000..0x3A0000, and what follows it is NOT the next partition: config does
+    # not start until 0x3C0000, leaving 0x20000 (128KB) of unallocated flash in
+    # between. Don't reach for that headroom -- it is outside the partition the CLR
+    # scans and outside what nanoff was told to write, so it buys nothing, and the
+    # next firmware image is free to lay its partitions out differently.
+    # Until this was measured the value had only ever been copied from a prose
+    # comment of unclear provenance -- issue #47. Re-read that "deploy" line if a
+    # firmware update changes the layout.
     [int]$DeployPartitionSize = 0x1C0000,
 
     # Ignore any recorded size and pad to -FallbackPadSize. Use this after something

--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -70,10 +70,16 @@ param(
     # with the whole of src\devices and src\integrationTests in mind.
     [int]$FallbackPadSize = 409600,
 
-    # Refuse to pad past the deploy partition; writing beyond it would run into
-    # whatever partition follows. Advisory, from the same boot-log partition table as
-    # -DeployAddress above (.\scripts\Watch-DeviceSerial.ps1, the "deploy" line's
-    # Size column) -- re-derive it there if a firmware update changes the layout.
+    # Refuse to pad past the deploy partition; writing beyond it would run into the
+    # "config" partition that starts where this one ends, at 0x3C0000. Measured
+    # 2026-08-30 off the device the same way -DeployAddress above was -- the boot-log
+    # partition table from .\scripts\Watch-DeviceSerial.ps1, this time the "deploy"
+    # line's Length column rather than its Offset:
+    #   3 deploy    Unknown data   01 84 001e0000 001c0000
+    #   4 config    Unknown data   01 83 003c0000 00040000
+    # (4MB flash, nanoCLR 1.17.0.339, ESP-IDF v5.5.4). Until then the value had only
+    # ever been copied from a prose comment of unclear provenance -- issue #47.
+    # Re-derive it there if a firmware update changes the layout.
     [int]$DeployPartitionSize = 0x1C0000,
 
     # Ignore any recorded size and pad to -FallbackPadSize. Use this after something


### PR DESCRIPTION
Closes #47.

`-DeployPartitionSize` in `scripts/Deploy-ToDevice.ps1` defaulted to `0x1C0000`, a value
PR #45 lifted from a prose comment already in the script rather than from a measurement.
`-DeployAddress`, immediately above it, was derived from a real boot log and says so. The
problem was never that `0x1C0000` was likely wrong — it bounds an error path, so too large
means the guard never fires and too small means a deploy is refused with a message naming
the number to re-derive — but that an unverified constant sitting next to a verified one
invites the wrong conclusion about how far either can be trusted.

## What was measured

Read off the device on 2026-08-30 with `.\scripts\Watch-DeviceSerial.ps1` (COM3, ESP32 with
4MB flash, nanoCLR 1.17.0.339, ESP-IDF v5.5.4). The ESP-IDF bootloader's partition table:

```
I (49) boot: ## Label            Usage          Type ST Offset   Length
I (56) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (62) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (69) boot:  2 factory          factory app      00 00 00010000 001d0000
I (75) boot:  3 deploy           Unknown data     01 84 001e0000 001c0000
I (82) boot:  4 config           Unknown data     01 83 003c0000 00040000
I (88) boot: End of partition table
```

The `deploy` line's Length column is `0x001C0000`, so the existing default is correct and
**no value changes**. Laid out, with each partition's computed end:

| Label | Start | End | Length |
|---|---|---|---|
| `factory` | `0x010000` | `0x1E0000` | `0x1D0000` |
| `deploy` | `0x1E0000` | `0x3A0000` | `0x1C0000` |
| *(unallocated)* | `0x3A0000` | `0x3C0000` | `0x020000` |
| `config` | `0x3C0000` | `0x400000` | `0x040000` |

Two things the same capture settles as a side effect:

- `-DeployAddress = 0x1E0000` is re-confirmed from the Offset column of the `deploy` line.
- `factory` spans `0x10000`–`0x1E0000`, which is why nanoFirmwareFlasher's own `0x1B0000`
  default landed inside it — the claim the `-DeployAddress` comment already makes, now
  visible in the same table.

And one thing worth not misreading: `deploy` is **not** adjacent to `config`. It ends at
`0x3A0000` and `config` does not start until `0x3C0000`, leaving 128KB of unallocated flash
between them. That headroom is not usable — it is outside the partition the CLR scans and
outside what `nanoff` is told to write — and the next firmware image is free to lay the
partitions out differently, so the comment says so explicitly rather than leaving the next
reader to rediscover the gap and wonder whether the bound should have been `0x1E0000`.

## Change

Comment only. It now records that the value was measured and when, quotes the table rows it
came from, states `deploy`'s real extent and the gap that follows it, and notes the value's
previous provenance so the history isn't lost.

## Verification

- Hardware: the boot-log capture above. Nothing was flashed — `Watch-DeviceSerial.ps1` only
  toggles RTS to reset the device and reads the serial port.
- `scripts/Deploy-ToDevice.ps1` re-parses clean and the parameter defaults are unchanged:
  `DeployPartitionSize = 1835008` (`0x1C0000`), `DeployAddress = 0x1E0000`,
  `FallbackPadSize = 409600` — checked via
  `[System.Management.Automation.Language.Parser]::ParseFile` and the AST's `DefaultValue`.
- No deploy was run, so the padding path itself is unexercised by this PR — it is unchanged,
  and a comment cannot affect it.

## Correction

The first version of this description, and the comment in commit cb57156, both claimed
`config` "starts at `0x3C0000`, which is exactly where `deploy` ends". That is wrong —
`0x1E0000 + 0x1C0000 = 0x3A0000`, as the quoted table shows. Caught in review and fixed in
cef96a9; the table and the paragraph above now carry the correct arithmetic. The measured
value of `-DeployPartitionSize` was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
