### PR TITLE
fix(scripts): identify the snapshot capture by record, not by bare pid

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -522,12 +522,21 @@ function Get-SmartHomeRecordedProcess {
 function Stop-SmartHomeProcessTree {
     # taskkill /T takes the children too. Stop-Process would kill only the
     # launcher and leave the real process running with no way back to it.
+    #
+    # The redirect is cmd's, not PowerShell's, and that is the whole point. For a pid that
+    # is already gone taskkill writes "FEHLER: Der Prozess ... wurde nicht gefunden" to
+    # stderr, and in Windows PowerShell 5.1 redirecting a native command's stderr is what
+    # wraps it in a NativeCommandError -- so the `*> $null` that used to be here did not
+    # suppress a failure, it manufactured one, terminating under the callers'
+    # $ErrorActionPreference = 'Stop'. Stop-SmartHomeRecordedProcess checks liveness first,
+    # but that is check-then-act and a process can exit in the gap. Letting cmd swallow
+    # both streams keeps this silent AND non-throwing.
     param(
         [Parameter(Mandatory = $true)]
         [int]$ProcessId
     )
 
-    & taskkill.exe /PID $ProcessId /T /F *> $null
+    & cmd.exe /c "taskkill /PID $ProcessId /T /F >nul 2>&1"
 }
 
 function Stop-SmartHomeRecordedProcess {

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -744,7 +744,18 @@ function Start-HomieCapture {
         }
     }
 
-    return @{ ProcessId = $process.Id; Path = $out }
+    # A record, not a bare pid. mosquitto_sub quits by itself when it cannot reach the
+    # broker -- measured at between 2 and 3 seconds, and it takes its cmd.exe with it --
+    # while Stop-HomieCapture holds the window open for $SnapshotSettleSeconds (3). So an
+    # unreachable broker leaves this launcher dead just BEFORE the stop, as the ordinary
+    # outcome rather than as a narrow race, and taskkill on a dead pid throws under this
+    # script's error preference (see Stop-HomieCapture). New-SmartHomeProcessRecord carries
+    # the name and start time that also tell a dead pid apart from a recycled one; -Tree
+    # because the real work is in the mosquitto_sub grandchild.
+    return @{
+        Record = New-SmartHomeProcessRecord -Label 'homie snapshot subscriber' -Process $process -Tree
+        Path   = $out
+    }
 }
 
 function Stop-HomieCapture {
@@ -771,9 +782,44 @@ function Stop-HomieCapture {
     # whatever is still in that buffer dies with the process. Only the refused-transition
     # step depends on the TAIL of a window -- every other caller needs the bulk retained
     # replay, which is far past the buffer boundary by the time the window closes.
-    Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
+    #
+    # Through the recorded-process helper rather than Stop-SmartHomeProcessTree, for the
+    # reason Stop-DeviceDebugCapture uses it: taskkill on a pid that has already exited
+    # writes to stderr, PowerShell 5.1 wraps that in a NativeCommandError, and under this
+    # script's $ErrorActionPreference = 'Stop' that is terminating -- thrown out of the
+    # finally the refused-transition step closes its window in, replacing the verdict that
+    # step had already reached. Per Start-HomieCapture the subscriber really is dead by
+    # then whenever the broker is unreachable, so this was the routine path, not the edge.
+    # The helper also declines to kill a pid Windows has since reissued.
+    #
+    # Its per-process progress lines go nowhere (stream 6 is Write-Host): one line per
+    # snapshot, dozens per conformance run, for a window that is not an event worth
+    # narrating. Warnings are stream 3 and still come through, which is what the recycled
+    # pid case reports on.
+    $wasAlive = Stop-SmartHomeRecordedProcess -Record $Capture.Record 6> $null
 
-    return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+    $lines = @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+
+    # A subscriber that was already gone did not observe the whole window, so its capture
+    # is short for a host-side reason -- indistinguishable, in the lines alone, from a
+    # device that published nothing. Said here, where the difference is known, rather than
+    # left for a caller to misread as evidence about the device.
+    #
+    # mosquitto_sub's own reason is already in $lines: its stderr shares this file, so an
+    # unreachable broker leaves 'Error: ... Connection refused' among them. That is the
+    # detail #54 records as available but unread -- and the one the old throw discarded,
+    # because it happened before this Get-Content.
+    #
+    # A warning rather than a failure, for the same reason Stop-DeviceDebugCapture warns:
+    # this also runs inside that finally, so throwing here would recreate the masking the
+    # change above exists to remove.
+    if (-not $wasAlive) {
+        $reasons = @($lines | Where-Object { $_ -match '\S' -and $null -eq (ConvertFrom-HomieCaptureLine -Line $_) })
+        $detail = if ($reasons.Count -gt 0) { $reasons -join ' / ' } else { 'it recorded no reason' }
+        Write-Warning ("The snapshot subscriber exited before its {0}s window closed, so this capture is short for a host-side reason and says nothing about the device: {1} (capture file: {2})." -f $SettleSeconds, $detail, $Capture.Path)
+    }
+
+    return $lines
 }
 
 function ConvertFrom-HomieCaptureLine {

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -732,6 +732,25 @@ function Start-HomieCapture {
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
+    # A record, not a bare pid. mosquitto_sub quits by itself when it cannot reach the
+    # broker -- measured at between 2 and 3 seconds, and it takes its cmd.exe with it --
+    # while Stop-HomieCapture holds the window open for $SnapshotSettleSeconds (3). So an
+    # unreachable broker leaves this launcher dead just BEFORE the stop, as the ordinary
+    # outcome rather than as a narrow race, and taskkill on a dead pid throws under this
+    # script's error preference (see Stop-HomieCapture). New-SmartHomeProcessRecord carries
+    # the name and start time that also tell a dead pid apart from a recycled one; -Tree
+    # because the real work is in the mosquitto_sub grandchild.
+    #
+    # Taken HERE, before the connect wait, rather than at the return: Process.ProcessName
+    # reads back $null once the process has exited -- StartTime survives, the name does not
+    # -- and Get-SmartHomeRecordedProcess skips its name comparison for a record that
+    # carries no name. A record built after the wait would therefore fall back to the
+    # start-time window alone, silently giving up the recycled-pid defence this record is
+    # here for. The wait really can outlive the launcher: against an unreachable broker it
+    # returns at ~2.4s, satisfied by the subscriber's own error rather than by a message
+    # (#59), and the launcher is gone by 3s.
+    $record = New-SmartHomeProcessRecord -Label 'homie snapshot subscriber' -Process $process -Tree
+
     if ($WaitForConnectSeconds -gt 0) {
         $connectDeadline = (Get-Date).AddSeconds($WaitForConnectSeconds)
         while ((Get-Date) -lt $connectDeadline) {
@@ -744,18 +763,7 @@ function Start-HomieCapture {
         }
     }
 
-    # A record, not a bare pid. mosquitto_sub quits by itself when it cannot reach the
-    # broker -- measured at between 2 and 3 seconds, and it takes its cmd.exe with it --
-    # while Stop-HomieCapture holds the window open for $SnapshotSettleSeconds (3). So an
-    # unreachable broker leaves this launcher dead just BEFORE the stop, as the ordinary
-    # outcome rather than as a narrow race, and taskkill on a dead pid throws under this
-    # script's error preference (see Stop-HomieCapture). New-SmartHomeProcessRecord carries
-    # the name and start time that also tell a dead pid apart from a recycled one; -Tree
-    # because the real work is in the mosquitto_sub grandchild.
-    return @{
-        Record = New-SmartHomeProcessRecord -Label 'homie snapshot subscriber' -Process $process -Tree
-        Path   = $out
-    }
+    return @{ Record = $record; Path = $out }
 }
 
 function Stop-HomieCapture {


### PR DESCRIPTION
Closes #54.

## What was wrong

`Stop-HomieCapture` identified its subscriber by a bare pid and killed it with
`Stop-SmartHomeProcessTree`. `taskkill` on a pid that has already exited writes to stderr,
PowerShell 5.1 wraps that in a `NativeCommandError`, and under this script's
`$ErrorActionPreference = 'Stop'` that is terminating.

Not a narrow race: `mosquitto_sub` quits by itself when it cannot reach the broker — between 2
and 3 seconds, its `cmd.exe` wrapper included — while `Stop-HomieCapture` holds the window open
for `$SnapshotSettleSeconds` (3) before killing. An unreachable broker therefore leaves the
launcher dead just *before* the stop as the ordinary outcome.

Two costs, both in #54. The throw happens before the `Get-Content` that would have returned the
capture, so the subscriber's own "connection refused" is discarded in favour of "process not
found". And #51 put `Stop-HomieCapture` in a `finally` in the refused-transition step, where a
throw replaces the verdict that step had already reached.

## What changed

`scripts/Run-IntegrationTests.ps1`, two functions:

- `Start-HomieCapture` records the launcher with `New-SmartHomeProcessRecord -Tree` instead of
  returning a bare `ProcessId`.
- `Stop-HomieCapture` stops it with `Stop-SmartHomeRecordedProcess`, which handles the
  already-exited case and declines to kill a pid Windows has since reissued.

This is what `2d49328` already did for the managed-debug capture; only that one had been
converted. Its per-process progress lines are dropped (stream 6 is `Write-Host`) — one per
snapshot, dozens per conformance run, for a window that is not an event worth narrating.
Warnings are stream 3 and still come through, which is what the recycled-pid case reports on.

## The scope question in the issue, answered

#54 asks whether a capture whose subscriber died should be a **failure** in its own right rather
than silently returning a short capture. Answered here as **report, do not fail**, and it is
worth being explicit about why.

The conflation is real and is now addressed: `Stop-HomieCapture` warns when the subscriber was
already gone, and quotes `mosquitto_sub`'s own reason for quitting — its stderr shares the
capture file, so `Error: ... connection refused` is already in hand. That is the detail #54
records as "available; nothing currently looks at it", and the one the old throw discarded.

It warns rather than throwing because a throw would land in the very `finally` this change exists
to protect, recreating the masking under a different cause. That is also the precedent
`Stop-DeviceDebugCapture` set in the same file for the same situation. Making it a *verdict*
instead would mean restructuring that `finally` so a stop-path failure and a publish failure stay
distinguishable — a separate change, not a line in this one.

Fixing the throw without this warning would have been a regression in one respect worth naming:
`Wait-ForRetainedValue` polls captures in a `while` loop, so an unreachable broker used to throw
on the first round. Without the warning it would now poll silently to its timeout and report
`Seen = '<nothing>'`, which reads as a device defect. The warning is what keeps the diagnostic
from getting quieter as the crash gets fixed.

## Verification

Desk work — no hardware, matching how #54 was reproduced. The real `Start-HomieCapture` and
`Stop-HomieCapture` bodies were extracted from the script by AST (so no replica could drift from
the thing under test), given the script's own `$SnapshotSettleSeconds` and error preferences, and
run against a port with nothing listening.

Before:

```
launcher alive after 3s: False
RESULT: Stop-HomieCapture THREW -> RemoteException: FEHLER: Der Prozess "65176" wurde nicht gefunden.
```

After:

```
WARNUNG: The snapshot subscriber exited before its 3s window closed, so this capture is short
for a host-side reason and says nothing about the device: Error: Es konnte keine Verbindung
hergestellt werden, da der Zielcomputer die Verbindung verweigerte. (capture file: ...)
RESULT: Stop-HomieCapture RETURNED 3 line(s)
  | Error: Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte.
```

Against a live Mosquitto on an isolated port with one retained topic, before and after are
identical — one retained line each, no warning, no added output.

`Parser::ParseFile` over the modified script reports no errors.

**Also run on hardware.** The full integration suite passed 5/5 on the real ESP32 (COM3, local
Mosquitto on 1883, device dialling 192.168.1.238) with both commits in place:

```
  WifiCheck            PASS   23s   connected to the configured WiFi network
  MqttCheck            PASS   19s   round-trip through 192.168.1.238 on smarthome-test/echo
  Bmp280Check          PASS   21s   24.56 degC, 943.75 hPa, 56.74 %RH
  HomieClientCheck     PASS   66s   attributes, datatypes, retained flags, /set round-trip,
                                    refused out-of-format payloads, alert/sleeping, a refused
                                    transition and re-announce all conform
  MqttReconnectCheck   PASS   51s   republished and stayed subscribed across outages of 3s, 20s
  TOTAL                       180s (80s deploy)
```

Two things worth reading off that run rather than only the PASS line. The new
`Stop-HomieCapture` warning never fired, which is correct: the broker was up for every capture, so
no subscriber died early. The warning is for the failure path, and this run had none — the
hardware run confirms the change is inert on the happy path, it does not exercise the path the
change is about. That one is covered by the dead-port reproduction above.

And the conformance phase breakdown shows 12 snapshots (announce 3, `/set` 1, out-of-format 1,
lifecycle 5, re-announce 2), so routing `Stop-SmartHomeRecordedProcess`'s per-process progress
lines to stream 6 removed about two dozen lines of per-snapshot chatter from the suite output
without changing what it measures.

`MqttReconnectCheck` is what the suite leaves flashed on the device; redeploy RoomSensor with
`Deploy-ToDevice.ps1` before expecting it to do its real job again.

## Filed alongside

- #59 — `Start-HomieCapture`'s connect wait breaks on the first byte in the capture file, and
  stderr shares that file, so `mosquitto_sub`'s own error satisfies it. Measured: a 5s wait
  against a dead port returned after 2.39s with only the connection error in the file. Same
  function; deliberately left out of this diff.

---

## Self-review pass (`/code-review high --fix`)

Two defects in the commit above, both found by reviewing it, both verified on this machine with
no hardware, both fixed in `7c05ebe`.

**1. The record was built after the connect wait, and lost its process name.**
`Process.StartTime` survives an exit but `Process.ProcessName` reads back `$null`, and
`Get-SmartHomeRecordedProcess` guards its name comparison with `if ($Record['Name'] -and ...)`
(`scripts/Common.ps1:499`). So a record built after the launcher died carried no name and silently
fell back to the ±2s start-time window alone — giving up precisely the recycled-pid defence the
record was introduced for. The wait does outlive the launcher: against an unreachable broker it
returns at ~2.4s, satisfied by the subscriber's own error rather than by a message (#59), and the
launcher is gone by 3s. Fixed by taking the record immediately after `Start-Process`, as
`Start-DeviceDebugCapture` already does. Verified: with the launcher dead by the time
`Start-HomieCapture` returns, the record now reads `Name 'cmd'` where it previously read `$null`.

**2. `Stop-SmartHomeProcessTree`'s `*> $null` manufactured the very error it looked like it
suppressed.** In Windows PowerShell 5.1, redirecting a native command's stderr is what wraps it in
a `NativeCommandError`. `Stop-SmartHomeRecordedProcess` checks liveness and only then kills, which
is check-then-act — a process exiting in that gap would still throw out of `Stop-HomieCapture` and
into the refused-transition step's `finally`. Narrow, but the same crash this PR set out to
remove, so it was worth closing rather than documenting. Measured:

```
& taskkill.exe /PID <dead> /T /F *> $null                 -> THREW RemoteException
& cmd.exe /c "taskkill /PID <dead> /T /F >nul 2>&1"       -> silent, no throw
```

This is the one change outside `Run-IntegrationTests.ps1`. It is two lines in `Common.ps1` and
strictly safer for its other callers (`Stop-DevEnv.ps1`, `Stop-DeviceDebugCapture`), which already
wanted the kill to be silent. No caller reads `$LASTEXITCODE` after it — checked.

Both the dead-port and live-broker checks re-run unchanged after the fixes.


