### PR TITLE
refactor(scripts): dispatch integration tests by capability, not by kind

### DIFF
--- a/.claude/skills/smarthome-integration-tests/SKILL.md
+++ b/.claude/skills/smarthome-integration-tests/SKILL.md
@@ -6,7 +6,10 @@ description: Run the whole SmartHome on-device integration suite (WiFi, MQTT rou
 # SmartHome integration test suite
 
 Run `scripts\Run-IntegrationTests.ps1` — one call covers every project under
-`src\integrationTests`. Every test is deployed first; the verdict comes from one of three kinds:
+`src\integrationTests`. Every test is deployed first; how its verdict is reached is declared by
+its `$testCatalog` entry — `Verdict` names the function that decides it (no `Verdict` means the
+device decides), and `OwnsBroker` says that function cycles the broker itself. Three shapes exist
+today:
 
 - **`DeviceMarker`** (WifiCheck, MqttCheck, Bmp280Check) — the runner reboots the device,
   captures managed debug output, and reads the `[ITEST] <name> PASS/FAIL` marker.
@@ -21,8 +24,9 @@ Run `scripts\Run-IntegrationTests.ps1` — one call covers every project under
   broker is replaced. It emits no `[ITEST]` marker by design — the evidence
   is what lands on the broker.
 
-Both host-decided kinds (`BrokerOutage`, `HomieConformance`) take the broker away and put a fresh
-one up, so neither can run with `-NoBroker`.
+The two host-decided ones (`BrokerOutage`, `HomieConformance`) take the broker away and put a
+fresh one up. Their entries say `OwnsBroker = $true`, which is what the `-NoBroker` guard reads,
+so neither can run under that switch.
 
 ```powershell
 .\scripts\Run-IntegrationTests.ps1                              # all five checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,8 +405,10 @@ these markers *are* the exit code. Emit one as soon as the outcome is known, bef
 loop. Adding a new integration test means: new project under `src\integrationTests`, emit the
 marker, add it to `$testCatalog` in `Run-IntegrationTests.ps1`. A host-decided test emits no
 marker and instead adds a verdict function, names it in its entry's `Verdict`, and lists that
-function's required settings under the same name in `$requiredCatalogKeys` — which is also what
-gates a `Verdict` the script does not define.
+function's required settings under the same name in `$requiredCatalogKeys` — which doubles as the
+list of names an entry may point at. That the name resolves to a function that actually exists is
+a separate `Get-Command` check in the pre-flight, which is where it has to be: the functions are
+defined further down the script than the catalog validation runs.
 
 `Bmp280Check` links `IntegrationTest.cs` as a shared source file instead of referencing
 `TestSupport` as a project. That kept the WiFi/networking assemblies out of a deliberately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,20 +358,27 @@ for the interface instead of racing it.
   works; that's what `integrationTests` is for.
 
 Those tests differ in which dependency they exercise, as above, and separately in *who decides
-the verdict*. The latter is declared per entry by the `Kind` field in `$testCatalog` in
-`Run-IntegrationTests.ps1`, and there are three (not the same three as the locations above):
+the verdict*. The latter is declared per entry in `$testCatalog` in `Run-IntegrationTests.ps1`,
+by two capability fields rather than by a kind name: `Verdict` names the function that returns
+the outcome, and `OwnsBroker` says that function stops and starts the broker itself — which is
+what `-NoBroker` refuses. An entry that names no `Verdict` is device-decided. The run loop reads
+both generically (one invoke by name, one shared epilogue), so a fourth kind of check is a new
+function plus its catalog entry, with no branch or guard elsewhere to keep in step. The three
+that exist are still worth naming (not the same three as the locations above):
 
 - **`DeviceMarker`** — the device decides. The runner captures managed debug output and reads
-  the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way.
+  the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way, and
+  their entries name no `Verdict`.
 - **`HomieConformance`** — the host measures a purpose-built device against the Homie v4
   convention: mandatory attributes and their retained flags, one property of every datatype with
   its `$format`/`$unit`/`$settable`/`$retained`, a `/set` command applied and reflected back, a
   payload each datatype's own `$format` forbids that must be refused rather than applied, the
   `alert` and `sleeping` states driven through a control property, a refused transition that
   must not be advertised as if it had happened, and a full re-announce after the broker is
-  replaced. `HomieClientCheck` is this kind. Retained-ness is read from a *fresh*
-  subscriber (`mosquitto_sub -F '%t %r %p'`), because MQTT only sets the retain flag when
-  replaying from the store — a live retained publish arrives with the flag clear.
+  replaced. `HomieClientCheck` is this kind (`Verdict = 'Invoke-HomieConformanceCheck'`).
+  Retained-ness is read from a *fresh* subscriber (`mosquitto_sub -F '%t %r %p'`), because MQTT
+  only sets the retain flag when replaying from the store — a live retained publish arrives with
+  the flag clear.
 - **`BrokerOutage`** — the host decides. The device publishes a heartbeat and subscribes to an
   echo topic; the runner takes the broker away, brings a fresh one up, and asserts heartbeats
   reappear on `homie/#` with a *higher* counter than before the outage. A lower counter means the
@@ -380,10 +387,10 @@ the verdict*. The latter is declared per entry by the `Kind` field in `$testCata
   only prove the *connection* returned. Publishing resumes the moment the socket is up, so a
   reconnect that replayed no subscriptions (a live client subscribed to nothing, which is what a
   throw out of `ResubscribeCachedTopics` used to leave behind) is indistinguishable from a
-  healthy one until something is sent *to* the device. `MqttReconnectCheck` is this kind, and it
-  deliberately emits no `[ITEST]` marker — a device claiming it reconnected would be a second,
-  weaker verdict competing with the evidence at the broker. See the `smarthome-mqtt-reconnect`
-  skill.
+  healthy one until something is sent *to* the device. `MqttReconnectCheck` is this kind
+  (`Verdict = 'Invoke-BrokerOutageCheck'`), and it deliberately emits no `[ITEST]` marker — a
+  device claiming it reconnected would be a second, weaker verdict competing with the evidence at
+  the broker. See the `smarthome-mqtt-reconnect` skill.
 
 DeviceMarker tests report by writing a marker line to managed debug output:
 
@@ -396,7 +403,10 @@ DeviceMarker tests report by writing a marker line to managed debug output:
 these, and `Run-IntegrationTests.ps1` parses them. A device app never exits with a status code —
 these markers *are* the exit code. Emit one as soon as the outcome is known, before any idle
 loop. Adding a new integration test means: new project under `src\integrationTests`, emit the
-marker, add it to `$testCatalog` in `Run-IntegrationTests.ps1`.
+marker, add it to `$testCatalog` in `Run-IntegrationTests.ps1`. A host-decided test emits no
+marker and instead adds a verdict function, names it in its entry's `Verdict`, and lists that
+function's required settings under the same name in `$requiredCatalogKeys` — which is also what
+gates a `Verdict` the script does not define.
 
 `Bmp280Check` links `IntegrationTest.cs` as a shared source file instead of referencing
 `TestSupport` as a project. That kept the WiFi/networking assemblies out of a deliberately

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1718,15 +1718,38 @@ try {
             # check that returned $null used to fall through and be measured as a
             # device-decided one, which reads as a device that never emitted a marker.
             if ($settings.Contains('Verdict')) {
-                $verdict = & $settings.Verdict -Settings $settings -Port $mqttPort -LogPath $logFile
+                try {
+                    $verdict = & $settings.Verdict -Settings $settings -Port $mqttPort -LogPath $logFile
 
-                $outcome = $verdict.Outcome
-                $detail = $verdict.Detail
+                    # Named here rather than left to Set-StrictMode. A function that
+                    # falls off the end returns $null, and $verdict.Outcome then throws
+                    # a PropertyNotFoundException -- reported in the host's language,
+                    # naming neither the test nor the contract it broke, which is the
+                    # kind of failure this dispatch exists to stop producing.
+                    if ($null -eq $verdict) {
+                        throw ("{0} returned no verdict. A verdict function must return a hashtable with Outcome and Detail." -f $settings.Verdict)
+                    }
 
-                # A check that owns the broker took it away to make its measurement.
-                # Whatever happened, leave one up for the tests that follow.
-                if ($settings.OwnsBroker -and -not (Get-SmartHomeDevEnvState -Port $mqttPort)) {
-                    Start-SuiteBroker -Port $mqttPort
+                    $outcome = $verdict.Outcome
+                    $detail = $verdict.Detail
+                }
+                finally {
+                    # A check that owns the broker took it away to make its measurement,
+                    # and it can fail with the broker still down -- the conformance check
+                    # replaces the broker mid-run, so anything throwing after that leaves
+                    # none. In the finally for that reason: without it, one failed check
+                    # turns every test after it into a second, unrelated failure that
+                    # hides the first.
+                    if ($settings.OwnsBroker -and -not (Get-SmartHomeDevEnvState -Port $mqttPort)) {
+                        # Caught, because a broker that will not come back must not
+                        # replace the failure already on its way out of this block.
+                        try {
+                            Start-SuiteBroker -Port $mqttPort
+                        }
+                        catch {
+                            Write-Warning ("Could not restore the broker after {0}: {1}" -f $testName, $_.Exception.Message)
+                        }
+                    }
                 }
             }
             else {

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -4,18 +4,21 @@
 
 .DESCRIPTION
     One entry point for every project under src\integrationTests. Every test is
-    deployed to the ESP32 first; how its verdict is reached depends on its kind:
+    deployed to the ESP32 first; how its verdict is reached is declared by its entry
+    in $testCatalog below:
 
-      DeviceMarker  the device decides. The runner reboots it, captures managed
-                    debug output, and reads the "[ITEST] <name> PASS/FAIL" marker
-                    the test emits (see
-                    src\integrationTests\TestSupport\IntegrationTest.cs).
+      device-decided  the entry names no Verdict function. The runner reboots the
+                      device, captures managed debug output, and reads the
+                      "[ITEST] <name> PASS/FAIL" marker the test emits (see
+                      src\integrationTests\TestSupport\IntegrationTest.cs).
 
-      BrokerOutage  the host decides. The device just publishes a heartbeat; the
-                    runner takes the broker away, brings it back, and asserts that
-                    heartbeats reappear on homie/#. A device claiming it
-                    reconnected is weaker evidence than a message actually
-                    arriving at the recreated broker.
+      host-decided    the entry names a Verdict function, which reaches the verdict
+                      from the broker's side. MqttReconnectCheck's takes the broker
+                      away and asserts heartbeats reappear on homie/#;
+                      HomieClientCheck's measures a purpose-built device against the
+                      Homie v4 convention. A device claiming it reconnected, or
+                      conformed, is weaker evidence than what actually reached the
+                      broker.
 
     A local Mosquitto broker is started detached for the run and stopped again at
     the end, even if the suite fails.
@@ -39,9 +42,9 @@
 
 .PARAMETER NoBroker
     Don't start/stop Mosquitto. Use when a broker is already running (started by
-    Start-DevEnv.ps1, or a service), or when running only non-MQTT tests. BrokerOutage
-    tests cannot run under this switch -- they need to own the broker's lifetime, and
-    tearing down someone else's broker is not theirs to do.
+    Start-DevEnv.ps1, or a service), or when running only non-MQTT tests. A test whose
+    catalog entry says OwnsBroker cannot run under this switch -- it needs to own the
+    broker's lifetime, and tearing down someone else's broker is not theirs to do.
 
 .PARAMETER LogDirectory
     Where to write the per-test device logs, and the preserved broker and homie/# logs
@@ -79,16 +82,25 @@ $mqttPort = Get-OptionalEnvValue -Name 'SMARTHOME_MQTT_PORT' -DefaultValue '1883
 # from its name (src\integrationTests\<Name>\<Name>.nfproj). Adding a test is one
 # line here plus the project itself.
 #
+# An entry declares capabilities, not a kind. Verdict names the function that decides
+# the outcome, and OwnsBroker says that function stops and starts the broker itself.
+# Both are read generically -- the run loop invokes Verdict by name, and -NoBroker
+# consults OwnsBroker -- so a new kind of check is a new function plus its entry here,
+# with no list of kinds anywhere else to keep in step. An entry that names no Verdict
+# is device-decided: the runner reads the test's own [ITEST] marker instead. (The three
+# kinds are still described by name in CLAUDE.md; they are no longer a field.)
+#
 # CaptureSeconds is a window -- "long enough that a healthy device has already
-# reported", not how long the test takes. Every DeviceMarker test emits its marker
+# reported", not how long the test takes. Every device-decided test emits its marker
 # as soon as the outcome is known and then idles. WifiCheck gets the longest window
 # because NetworkHelper's own connect timeout is 60s.
 $testCatalog = [ordered]@{
-    'WifiCheck'   = @{ Kind = 'DeviceMarker'; CaptureSeconds = 75 }
-    'MqttCheck'   = @{ Kind = 'DeviceMarker'; CaptureSeconds = 90 }
-    'Bmp280Check' = @{ Kind = 'DeviceMarker'; CaptureSeconds = 45 }
+    'WifiCheck'   = @{ OwnsBroker = $false; CaptureSeconds = 75 }
+    'MqttCheck'   = @{ OwnsBroker = $false; CaptureSeconds = 90 }
+    'Bmp280Check' = @{ OwnsBroker = $false; CaptureSeconds = 45 }
     'HomieClientCheck' = @{
-        Kind = 'HomieConformance'
+        OwnsBroker = $true
+        Verdict    = 'Invoke-HomieConformanceCheck'
         # The device this check deploys is built for the convention, not for a room:
         # one property of every datatype, settable and not, retained and not. These
         # must match src\integrationTests\HomieClientCheck\Program.cs.
@@ -99,7 +111,8 @@ $testCatalog = [ordered]@{
         RecoverySeconds = 90
     }
     'MqttReconnectCheck' = @{
-        Kind = 'BrokerOutage'
+        OwnsBroker = $true
+        Verdict    = 'Invoke-BrokerOutageCheck'
         # Topic the device publishes its heartbeat on. Must match HeartbeatTopic in
         # that project's Program.cs -- the pre-flight below checks that it does.
         HeartbeatTopic = 'homie/mqtt-reconnect-check/heartbeat'
@@ -140,29 +153,42 @@ if ($unknown.Count -gt 0) {
 # Switching those reads to $settings['Foo'] would be worse, not better: that returns
 # $null, so a forgotten CaptureSeconds would silently become a zero-length window.
 # Adding a test is advertised above as "one line here", so that line gets checked.
+#
+# Keyed by the Verdict function an entry names, which makes this table the list of
+# verdict functions the run loop may invoke: a name that is not in it is a one-line
+# error here, not a "term is not recognized" ERROR verdict 90s into the run.
+# $deviceDecidedKeys covers an entry that names no Verdict at all.
+$deviceDecidedKeys = @('CaptureSeconds')
 $requiredCatalogKeys = @{
-    'DeviceMarker'     = @('CaptureSeconds')
-    'HomieConformance' = @('DeviceId', 'NodeId', 'SettleSeconds', 'CommandTimeoutSeconds', 'RecoverySeconds')
-    'BrokerOutage'     = @('HeartbeatTopic', 'SettleSeconds', 'OutageSeconds', 'RecoverySeconds', 'EchoCommandTopic', 'EchoTopic', 'CommandTimeoutSeconds')
+    'Invoke-HomieConformanceCheck' = @('DeviceId', 'NodeId', 'SettleSeconds', 'CommandTimeoutSeconds', 'RecoverySeconds')
+    'Invoke-BrokerOutageCheck'     = @('HeartbeatTopic', 'SettleSeconds', 'OutageSeconds', 'RecoverySeconds', 'EchoCommandTopic', 'EchoTopic', 'CommandTimeoutSeconds')
 }
-$knownKinds = (@($requiredCatalogKeys.Keys) | Sort-Object) -join ', '
+$knownVerdicts = (@($requiredCatalogKeys.Keys) | Sort-Object) -join ', '
 
 foreach ($catalogTestName in $Tests) {
     $catalogEntry = $testCatalog[$catalogTestName]
 
-    if (-not $catalogEntry.Contains('Kind')) {
-        Write-Error ("Catalog entry '{0}' declares no Kind. Known kinds: {1}." -f $catalogTestName, $knownKinds)
+    # Required of every entry, device-decided ones included, because it is read as
+    # $settings.OwnsBroker on every path -- and because leaving it out would default to
+    # whichever answer is quietly wrong for the next check that owns the broker.
+    if (-not $catalogEntry.Contains('OwnsBroker')) {
+        Write-Error ("Catalog entry '{0}' declares no OwnsBroker. Say `$true if its verdict function stops and starts the broker itself, `$false otherwise." -f $catalogTestName)
         exit 1
     }
 
-    if (-not $requiredCatalogKeys.Contains($catalogEntry.Kind)) {
-        Write-Error ("Catalog entry '{0}' has unknown Kind '{1}'. Known kinds: {2}." -f $catalogTestName, $catalogEntry.Kind, $knownKinds)
-        exit 1
+    $requiredKeys = $deviceDecidedKeys
+    if ($catalogEntry.Contains('Verdict')) {
+        if (-not $requiredCatalogKeys.Contains($catalogEntry.Verdict)) {
+            Write-Error ("Catalog entry '{0}' names an unknown Verdict function '{1}'. Known: {2}." -f $catalogTestName, $catalogEntry.Verdict, $knownVerdicts)
+            exit 1
+        }
+
+        $requiredKeys = $requiredCatalogKeys[$catalogEntry.Verdict]
     }
 
-    $missingKeys = @($requiredCatalogKeys[$catalogEntry.Kind] | Where-Object { -not $catalogEntry.Contains($_) })
+    $missingKeys = @($requiredKeys | Where-Object { -not $catalogEntry.Contains($_) })
     if ($missingKeys.Count -gt 0) {
-        Write-Error ("Catalog entry '{0}' (Kind '{1}') is missing required setting(s): {2}." -f $catalogTestName, $catalogEntry.Kind, ($missingKeys -join ', '))
+        Write-Error ("Catalog entry '{0}' is missing required setting(s): {1}." -f $catalogTestName, ($missingKeys -join ', '))
         exit 1
     }
 }
@@ -455,7 +481,12 @@ function Invoke-BrokerOutageCheck {
     # heartbeats published after that phase's broker came up -- no stale hits.
     param(
         [hashtable]$Settings,
-        [string]$Port
+        [string]$Port,
+
+        # Part of the verdict-function contract the catalog dispatches through, and
+        # deliberately unused here: this check's evidence is the broker's own logs, and
+        # it captures no managed debug output from the device.
+        [string]$LogPath
     )
 
     $topic = $Settings.HeartbeatTopic
@@ -1015,9 +1046,9 @@ function Stop-ConformancePhase {
 }
 
 function Write-ConformancePhaseBreakdown {
-    # Called from the test loop, not from the check itself: the check returns from four
-    # places (two of them failure paths), and those are exactly the runs whose timing is
-    # worth seeing. One call after it returns covers all four.
+    # Called from Invoke-HomieConformanceCheck's finally, not from the measurement
+    # itself: that returns from four places (two of them failure paths), and those are
+    # exactly the runs whose timing is worth seeing. One call around it covers all four.
     Stop-ConformancePhase
 
     if ($script:conformancePhases.Count -eq 0) {
@@ -1052,6 +1083,39 @@ function Get-ConformanceCaptureSeconds {
 }
 
 function Invoke-HomieConformanceCheck {
+    # The verdict function the catalog names for HomieClientCheck: everything the
+    # conformance measurement needs around it, so the run loop needs to know none of it.
+    #
+    # -LogPath is where the managed debug output captured alongside the measurement is
+    # written. Only the device's own log can say whether it saw a command at all -- see
+    # Start-DeviceDebugCapture for why a host-decided check wants one.
+    param(
+        [hashtable]$Settings,
+        [string]$Port,
+        [string]$LogPath
+    )
+
+    $debugCapture = Start-DeviceDebugCapture -LogPath $LogPath `
+                                             -TimeoutSeconds (Get-ConformanceCaptureSeconds -Settings $Settings)
+    try {
+        return Measure-HomieConformance -Settings $Settings -Port $Port
+    }
+    finally {
+        # In the finally, because returning is not the measurement's only way out: a
+        # missing mosquitto tool, a capture file that cannot be cleared or a publish
+        # that fails all propagate under $ErrorActionPreference = 'Stop' and land in the
+        # test loop's catch as an ERROR verdict. That is the run whose phase timings are
+        # worth reading most, and it would otherwise be the one run that printed none.
+        Stop-DeviceDebugCapture -Capture $debugCapture
+
+        # After Stop-DeviceDebugCapture, not before: that call releases the COM port the
+        # next deploy needs, and it is documented not to throw -- it warns on a recycled
+        # or already-dead pid -- so ordering it first does not cost the breakdown.
+        Write-ConformancePhaseBreakdown
+    }
+}
+
+function Measure-HomieConformance {
     # Measures a purpose-built device against the Homie v4 convention, from the
     # broker's side. Every assertion is collected rather than thrown, so one run
     # reports everything that is wrong instead of only the first thing.
@@ -1562,8 +1626,20 @@ foreach ($testName in $Tests) {
         }
     }
 
-    if (($settings.Kind -eq 'BrokerOutage' -or $settings.Kind -eq 'HomieConformance') -and $NoBroker) {
+    # Read off the entry's own capability, so a check that owns the broker declares it
+    # once and every guard follows. This one is the reason that matters: forgetting to
+    # list a new kind here produced no error, only a confusing failure once the check
+    # tore down a broker it did not start.
+    if ($settings.OwnsBroker -and $NoBroker) {
         Write-Error "$testName needs to own the broker's lifetime, so it cannot run with -NoBroker. Drop the switch, or exclude it with -Tests."
+        exit 1
+    }
+
+    # The catalog validation above gates Verdict to a name this script knows; this gates
+    # a known name to a function that actually exists. It can only run here, after the
+    # function definitions -- and it still runs before the first build and flash.
+    if ($settings.Contains('Verdict') -and -not (Get-Command -Name $settings.Verdict -CommandType Function -ErrorAction SilentlyContinue)) {
+        Write-Error ("Catalog entry '{0}' names Verdict function '{1}', which this script does not define." -f $testName, $settings.Verdict)
         exit 1
     }
 }
@@ -1632,46 +1708,24 @@ try {
             Write-Host ""
 
             # ── Host-decided ──────────────────────────────────────────────────
-            # Dispatch first, then handle the verdict once. The two kinds differ only in
-            # which function produces it; everything after was duplicated line for line,
-            # and had already drifted -- only one copy carried the comment explaining why
-            # the broker is restarted.
-            $verdict = $null
-            if ($settings.Kind -eq 'HomieConformance') {
-                $debugCapture = Start-DeviceDebugCapture -LogPath $logFile `
-                                                         -TimeoutSeconds (Get-ConformanceCaptureSeconds -Settings $settings)
-                try {
-                    $verdict = Invoke-HomieConformanceCheck -Settings $settings -Port $mqttPort
-                }
-                finally {
-                    Stop-DeviceDebugCapture -Capture $debugCapture
+            # One invoke, by name, for every check whose verdict comes from the broker
+            # rather than from the device. Everything a particular check needs around
+            # itself -- the debug capture and phase breakdown the conformance check runs
+            # under, for instance -- lives inside that function, so a fourth kind of
+            # test adds no branch here and cannot be forgotten in one.
+            #
+            # Keyed off the entry rather than off the returned value: a host-decided
+            # check that returned $null used to fall through and be measured as a
+            # device-decided one, which reads as a device that never emitted a marker.
+            if ($settings.Contains('Verdict')) {
+                $verdict = & $settings.Verdict -Settings $settings -Port $mqttPort -LogPath $logFile
 
-                    # In the finally with it, because returning is not the check's only
-                    # way out: a missing mosquitto tool, a capture file that cannot be
-                    # cleared or a publish that fails all propagate under
-                    # $ErrorActionPreference = 'Stop' and land in the catch below as an
-                    # ERROR verdict. That is the run whose phase timings are worth
-                    # reading most, and outside the finally it was the one run that
-                    # printed none.
-                    #
-                    # After Stop-DeviceDebugCapture, not before: that call releases the
-                    # COM port the next deploy needs, and it is documented not to throw
-                    # -- it warns on a recycled or already-dead pid -- so ordering it
-                    # first does not cost the breakdown.
-                    Write-ConformancePhaseBreakdown
-                }
-            }
-            elseif ($settings.Kind -eq 'BrokerOutage') {
-                $verdict = Invoke-BrokerOutageCheck -Settings $settings -Port $mqttPort
-            }
-
-            if ($null -ne $verdict) {
                 $outcome = $verdict.Outcome
                 $detail = $verdict.Detail
 
-                # Both host-decided kinds take the broker away to make their measurement.
+                # A check that owns the broker took it away to make its measurement.
                 # Whatever happened, leave one up for the tests that follow.
-                if (-not (Get-SmartHomeDevEnvState -Port $mqttPort)) {
+                if ($settings.OwnsBroker -and -not (Get-SmartHomeDevEnvState -Port $mqttPort)) {
                     Start-SuiteBroker -Port $mqttPort
                 }
             }


### PR DESCRIPTION
Closes #21.

`Run-IntegrationTests.ps1` branched on `$settings.Kind` in three places: the `-NoBroker` guard was a two-term OR over kind names, the verdict dispatch was a pair of branches differing only in which function they called, and `$requiredCatalogKeys` was keyed by kind too. Adding a fourth kind meant several coordinated edits, and the `-NoBroker` list was the one that got forgotten — silently, because the result is a confusing failure rather than an error.

## What changed

Catalog entries declare capabilities instead of a kind:

| field | meaning |
|---|---|
| `OwnsBroker` | the verdict function stops and starts the broker itself — what `-NoBroker` refuses |
| `Verdict` | name of the function that returns the outcome. No `Verdict` means device-decided, and the runner reads the test's own `[ITEST]` marker |

```powershell
'WifiCheck'   = @{ OwnsBroker = $false; CaptureSeconds = 75 }
'HomieClientCheck' = @{
    OwnsBroker = $true
    Verdict    = 'Invoke-HomieConformanceCheck'
    ...
```

The run loop is one dynamic invoke and one shared epilogue:

```powershell
if ($settings.Contains('Verdict')) {
    $verdict = & $settings.Verdict -Settings $settings -Port $mqttPort -LogPath $logFile
    ...
    if ($settings.OwnsBroker -and -not (Get-SmartHomeDevEnvState -Port $mqttPort)) {
        Start-SuiteBroker -Port $mqttPort
    }
}
```

Everything a particular check needs *around* itself now lives inside its verdict function. The device debug capture and the phase breakdown that used to wrap the conformance branch move into a thin `Invoke-HomieConformanceCheck`, whose `finally` covers the measurement's four exits exactly as the test loop's did; the measurement itself is unchanged, renamed `Measure-HomieConformance`.

Two smaller consequences, both deliberate:

- The host-decided path keys off the entry rather than off the returned value. A verdict function that returned `$null` used to fall through and be measured as a device-decided test, which reads as a device that never emitted a marker.
- `$requiredCatalogKeys` is keyed by verdict-function name, so it is also the list of functions the loop may invoke. A pre-flight `Get-Command` resolves that name before the first build, so a typo is a one-line error rather than a "term is not recognized" ERROR verdict 90s into a run.

`Invoke-BrokerOutageCheck` gains a `-LogPath` parameter it does not use, to satisfy the dispatch contract; the comment on it says so and points at the gap (see *Filed separately* below).

`CLAUDE.md` and the `smarthome-integration-tests` skill documented `Kind` as a field, so both were updated with the code. The three kind *names* stay as vocabulary — they are still the clearest way to describe the three shapes — but they are no longer a field anything branches on.

## Verification

**Ran on hardware, on the merged tree.** The full suite, on the real ESP32 on COM3 against a local Mosquitto — all five checks passed, exit 0, no conformance warnings:

```
  WifiCheck            PASS         20s (15s deploy) connected to the configured WiFi network
  MqttCheck            PASS         21s (15s deploy) round-trip through 192.168.1.238 on smarthome-test/echo
  Bmp280Check          PASS         18s (13s deploy) 24.51°C, 943.55hPa, 56.52%RH
  HomieClientCheck     PASS         65s (16s deploy) attributes, datatypes, retained flags, /set round-trip, refused
                                                     out-of-format payloads, alert/sleeping, a refused transition
                                                     and re-announce all conform
  MqttReconnectCheck   PASS         48s (14s deploy) republished and stayed subscribed across outages of 3s, 20s
  TOTAL                             172s (73s deploy)
```

The same suite passed identically on this branch before `main` was merged in. This run is the one that counts, because it is the first to exercise the merge: the dispatch restructure here together with `main`'s reworked refused-transition assertion and its new `$script:conformanceWarnings` path inside the conformance measurement.

That covers both dispatch branches: the device-decided `else` path and its `[ITEST]` marker parsing (the first three), and the dynamic invoke, `-LogPath` binding and broker epilogue for both host-decided checks. The conformance check's phase breakdown still prints all six phases from the wrapper's `finally` rather than from the test loop:

```
  phase breakdown (3s per snapshot):
    announce                 10.2s   3 snapshot(s)
    attributes                0.0s   0 snapshot(s)
    /set round-trip           3.6s   1 snapshot(s)
    out-of-format /set        4.0s   1 snapshot(s)
    lifecycle                17.1s   5 snapshot(s)
    re-announce              13.7s   2 snapshot(s)
```

One gap the green run leaves: the `finally` that restores the broker after a *failed* host-decided check never fired, because nothing failed. A passing suite cannot show that path; it is covered only by the stubbed harness below.

What was checked desk-side, before and after the hardware run:

- The script parses (`[Parser]::ParseFile`, no errors).
- A throwaway copy that stops before the first build was run against five broken catalogs. Each exits 1 with its own one-line message, before anything is built or flashed:

  | mutation | message |
  |---|---|
  | `OwnsBroker` removed | `Catalog entry 'WifiCheck' declares no OwnsBroker. Say $true if its verdict function stops and starts the broker itself, $false otherwise.` |
  | unknown `Verdict` | `Catalog entry 'MqttReconnectCheck' names an unknown Verdict function 'Invoke-TyposquattedCheck'. Known: Invoke-BrokerOutageCheck, Invoke-HomieConformanceCheck.` |
  | `Verdict` names an undefined function | `Catalog entry 'MqttReconnectCheck' names Verdict function 'Invoke-BrokerOutageCheckXyz', which this script does not define.` |
  | host-decided entry missing a setting | `Catalog entry 'MqttReconnectCheck' is missing required setting(s): EchoTopic.` |
  | device-decided entry missing `CaptureSeconds` | `Catalog entry 'Bmp280Check' is missing required setting(s): CaptureSeconds.` |

- With a valid catalog: the pre-flight passes; `-NoBroker` is refused for the two `OwnsBroker` entries (`HomieClientCheck needs to own the broker's lifetime, so it cannot run with -NoBroker.`) and passes for the three device-decided ones.
- A second throwaway copy with the deploy, monitor, broker and both verdict functions stubbed runs the whole loop on this machine. It is what covers the failure paths the hardware run could not: a verdict function that throws now leaves a broker up for the tests that follow (it previously did not, which is the `finally` in the review-fix commit), a verdict function returning `$null` reports `Invoke-HomieConformanceCheck returned no verdict...` instead of a localized PropertyNotFoundException, and a missing or mismatched `[ITEST]` marker still yields `NO-RESULT` / `WRONG-TEST`.

No C# changed, so CI's build and unit-test run is unaffected.

## Filed separately

`MqttReconnectCheck` produces no device-side log at all — the broker-outage check captures no managed debug output, so its row's log path is always empty and a `RESTARTED` or `NO-RESULT` verdict leaves nothing device-side to read. Noticed while giving the verdict functions a common signature; filed rather than fixed here, since capturing on that path is a behaviour change that needs a hardware run of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


