### PR TITLE
feat(scripts): keep the snapshot captures a conformance verdict is read from

### DIFF
--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -24,7 +24,9 @@
     look at. On failure it exits 1 and prints the captured device log path for the
     failing test, which is where any real investigation starts. Alongside it in the same
     directory are the broker's own log and the homie/# log for every broker generation
-    the run went through, kept because the dev environment deletes both at teardown.
+    the run went through, kept because the dev environment deletes both at teardown, and
+    -- for the conformance check -- one file per snapshot window, which is the only place
+    the retain flags a verdict was reached on can still be read.
 
     *** HARDWARE: this flashes and runs code on the physical device on the configured
     COM port, once per test. Treat it exactly like Deploy-ToDevice.ps1. ***
@@ -44,9 +46,10 @@
     tearing down someone else's broker is not theirs to do.
 
 .PARAMETER LogDirectory
-    Where to write the per-test device logs, and the preserved broker and homie/# logs
-    that go with them. Defaults to a timestamped folder under the system temp directory;
-    the path is printed at the end of the run.
+    Where to write the per-test device logs, the preserved broker and homie/# logs that
+    go with them, and the conformance check's snapshot captures. Defaults to a
+    timestamped folder under the system temp directory; the path is printed at the end
+    of the run.
 
 .EXAMPLE
     .\scripts\Run-IntegrationTests.ps1
@@ -230,6 +233,40 @@ function Save-BrokerEvidence {
             # called from a finally where a throw would replace the suite's own outcome.
             Write-Warning ("Could not preserve {0}: {1}" -f $source, $_.Exception.Message)
         }
+    }
+}
+
+function Save-SnapshotEvidence {
+    # The fresh-subscriber window a conformance verdict is actually computed from.
+    #
+    # Save-BrokerEvidence keeps the broker's own log and the long-running homie/# log,
+    # and neither can answer the question a lost /set raises: what the check *saw*. The
+    # long-running log carries no retain flags -- MQTT sets the flag only when replaying
+    # from the store to a new subscriber -- so "was this the retained store or a live
+    # echo" is readable in the snapshot capture and nowhere else. Start-HomieCapture
+    # deletes the previous capture at the start of every window, so a conformance run
+    # opened ~25 of them and kept none. That is the "left no evidence" half of issue #35:
+    # the run that lost all five /set commands left nothing behind to read.
+    #
+    # Named by the phase as well as the number so the files can be picked out without the
+    # console breakdown next to them -- a /set phase that cost ten windows leaves ten
+    # files saying so.
+    param([hashtable]$Capture)
+
+    $phase = if ($null -eq $script:currentPhase) { 'unphased' } else { $script:currentPhase.Name }
+    # Phase names are prose -- '/set round-trip', 'out-of-format /set' -- and two of them
+    # carry a path separator.
+    $slug = ($phase -replace '[^A-Za-z0-9]+', '-').Trim('-').ToLowerInvariant()
+
+    $destination = Join-Path $LogDirectory ("{0}-snapshot-{1:d3}-{2}.log" -f $script:evidenceLabel, $script:snapshotsTaken, $slug)
+    try {
+        # The subscriber has just been killed, so nothing holds this open -- but the copy
+        # is in a finally either way, for the same reason as above: evidence must never
+        # be what fails a run.
+        Copy-Item -LiteralPath $Capture.Path -Destination $destination -ErrorAction Stop
+    }
+    catch {
+        Write-Warning ("Could not preserve the snapshot capture {0}: {1}" -f $Capture.Path, $_.Exception.Message)
     }
 }
 
@@ -648,6 +685,12 @@ $SnapshotSettleSeconds = 3
 # terminating error, which would arrive as an 'ERROR' verdict blamed on the device.
 $script:snapshotsTaken = 0
 
+# The conformance phase a snapshot belongs to, for the file Save-SnapshotEvidence names
+# after it. Set by Start-ConformancePhase, and declared here for the same StrictMode
+# reason as the counter above: Stop-HomieCapture reads it on every window, and only the
+# conformance check ever assigns it.
+$script:currentPhase = $null
+
 function Get-HomieRetainedSnapshot {
     # What a controller joining *now* would see: the broker's retained store.
     #
@@ -765,15 +808,31 @@ function Stop-HomieCapture {
     # figure that explains a run's duration, and it cannot be read off the code.
     $script:snapshotsTaken++
 
-    Start-Sleep -Seconds $SettleSeconds
-    # See #36: taskkill /F does not wait for mosquitto_sub to flush. Its stdout is
-    # redirected to a file, so the CRT buffers fully (~4KB) rather than by line, and
-    # whatever is still in that buffer dies with the process. Only the refused-transition
-    # step depends on the TAIL of a window -- every other caller needs the bulk retained
-    # replay, which is far past the buffer boundary by the time the window closes.
-    Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
+    # Item 2 of #36 recorded that taskkill /F would lose whatever mosquitto_sub still had
+    # in its stdio buffer -- redirected to a file, so full buffering (~4KB) rather than
+    # line buffering -- and that a capture smaller than that boundary would therefore
+    # arrive truncated. Measured against Mosquitto 2.0.22 on this machine and it does not
+    # happen: mosquitto_sub flushes per message. A five-topic store is 105 bytes on disk
+    # 200ms into the window, a message published 1s later is on disk 200ms after that,
+    # and both survive the kill unchanged; a 200-topic store came back complete, all 200
+    # lines. The tail of a window is not at risk, whatever its size.
+    #
+    # Which is why the capture below is preserved rather than treated as unreliable: what
+    # it holds is what the subscriber received.
+    try {
+        Start-Sleep -Seconds $SettleSeconds
+        Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
 
-    return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+        return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
+    }
+    finally {
+        # In a finally so the evidence outlives a stop that throws. Stop-SmartHomeProcessTree
+        # on an already-dead subscriber does throw (#54), and it throws before the
+        # Get-Content above -- so the run loses the lines and, without this, the file they
+        # were in as well. #54 is the fix for the throw; this only makes sure the window
+        # is still readable afterwards.
+        Save-SnapshotEvidence -Capture $Capture
+    }
 }
 
 function ConvertFrom-HomieCaptureLine {
@@ -1219,7 +1278,9 @@ function Invoke-HomieConformanceCheck {
     # nothing is ever re-sent. Only still-pending properties are republished, and a
     # repeated command is idempotent -- the device applies the same value again and
     # publishes back the same reflection.
+    $rounds = 0
     while ($pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
+        $rounds++
         foreach ($property in $pending) {
             Publish-HomieCommand -Port $Port -Topic "$node/$property/set" -Payload $commands[$property]
         }
@@ -1252,6 +1313,15 @@ function Invoke-HomieConformanceCheck {
     foreach ($property in $pending) {
         $wanted = if ($expectedEcho.Contains($property)) { $expectedEcho[$property] } else { $commands[$property] }
         $script:conformanceFailures += "/set on $property did not come back on the property topic (saw '$($lastSeen[$property])', expected '$wanted')"
+    }
+
+    # A second round means a command was lost and re-sent, which is the condition issue
+    # #35 is about -- and since the retry above makes the run PASS through it, nothing
+    # else would say so. The phase breakdown shows it as extra snapshots, but only to a
+    # reader who already knows to look; this names it, next to the preserved snapshot
+    # captures that can be read to find out what the round actually saw.
+    if ($rounds -gt 1) {
+        Write-Warning ("The /set round trip needed {0} rounds: at least one command was lost and re-sent (issue #35). The snapshot captures for this phase are in {1}." -f $rounds, $LogDirectory)
     }
 
     # ── payloads the properties' own $datatype/$format forbid ────────────────

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -245,28 +245,34 @@ function Save-SnapshotEvidence {
     # from the store to a new subscriber -- so "was this the retained store or a live
     # echo" is readable in the snapshot capture and nowhere else. Start-HomieCapture
     # deletes the previous capture at the start of every window, so a conformance run
-    # opened ~25 of them and kept none. That is the "left no evidence" half of issue #35:
-    # the run that lost all five /set commands left nothing behind to read.
+    # opened a dozen of them and kept none. That is the "left no evidence" half of issue
+    # #35: the run that lost all five /set commands left nothing behind to read.
+    # (Measured over ten hardware runs on 2026-08-31: 12 to 13 windows per run.)
     #
     # Named by the phase as well as the number so the files can be picked out without the
-    # console breakdown next to them -- a /set phase that cost ten windows leaves ten
+    # console breakdown next to them -- a /set phase that cost three windows leaves three
     # files saying so.
     param([hashtable]$Capture)
 
-    $phase = if ($null -eq $script:currentPhase) { 'unphased' } else { $script:currentPhase.Name }
-    # Phase names are prose -- '/set round-trip', 'out-of-format /set' -- and two of them
-    # carry a path separator.
-    $slug = ($phase -replace '[^A-Za-z0-9]+', '-').Trim('-').ToLowerInvariant()
-
-    $destination = Join-Path $LogDirectory ("{0}-snapshot-{1:d3}-{2}.log" -f $script:evidenceLabel, $script:snapshotsTaken, $slug)
+    # EVERYTHING is inside the try, not just the copy. This runs from a finally, where a
+    # throw replaces the exception already in flight -- Stop-SmartHomeProcessTree over an
+    # already-dead subscriber (#54), or the verdict the refused-transition step had
+    # reached. Under Set-StrictMode -Version Latest a phase object that has no Name, or a
+    # capture with no Path, is a terminating error, so naming the file has to be as
+    # guarded as writing it. Preserving evidence must never be the reason a run fails.
     try {
-        # The subscriber has just been killed, so nothing holds this open -- but the copy
-        # is in a finally either way, for the same reason as above: evidence must never
-        # be what fails a run.
+        $phase = if ($null -eq $script:currentPhase) { 'unphased' } else { $script:currentPhase.Name }
+        # Phase names are prose -- '/set round-trip', 'out-of-format /set' -- and two of
+        # them carry a path separator.
+        $slug = ($phase -replace '[^A-Za-z0-9]+', '-').Trim('-').ToLowerInvariant()
+
+        $destination = Join-Path $LogDirectory ("{0}-snapshot-{1:d3}-{2}.log" -f $script:evidenceLabel, $script:snapshotsTaken, $slug)
         Copy-Item -LiteralPath $Capture.Path -Destination $destination -ErrorAction Stop
     }
     catch {
-        Write-Warning ("Could not preserve the snapshot capture {0}: {1}" -f $Capture.Path, $_.Exception.Message)
+        # $Capture.Path is deliberately not named here: reading it is one of the things
+        # that can have thrown.
+        Write-Warning ("Could not preserve a snapshot capture: {0}" -f $_.Exception.Message)
     }
 }
 
@@ -1315,13 +1321,20 @@ function Invoke-HomieConformanceCheck {
         $script:conformanceFailures += "/set on $property did not come back on the property topic (saw '$($lastSeen[$property])', expected '$wanted')"
     }
 
-    # A second round means a command was lost and re-sent, which is the condition issue
-    # #35 is about -- and since the retry above makes the run PASS through it, nothing
-    # else would say so. The phase breakdown shows it as extra snapshots, but only to a
-    # reader who already knows to look; this names it, next to the preserved snapshot
-    # captures that can be read to find out what the round actually saw.
+    # A second round is the condition issue #35 is about -- and since the retry above
+    # makes the run PASS through it, nothing else would say so. The phase breakdown shows
+    # it as extra snapshots, but only to a reader who already knows to look; this names
+    # it, next to the preserved snapshot captures that can be read to find out what the
+    # round actually saw.
+    #
+    # Worded as what was measured, not as what it usually means. An extra round proves
+    # only that a window held no echo: a lost command is the common cause and the one #35
+    # confirmed on hardware, but a reflection that lands after the 3s window closes, or a
+    # QoS-1 retransmission on M2Mqtt's 1s DelayOnRetry, produces the same count against a
+    # device that received the command and applied it. This line is the documented tell
+    # for #35, so it must not assert the cause the captures are there to establish.
     if ($rounds -gt 1) {
-        Write-Warning ("The /set round trip needed {0} rounds: at least one command was lost and re-sent (issue #35). The snapshot captures for this phase are in {1}." -f $rounds, $LogDirectory)
+        Write-Warning ("The /set round trip needed {0} rounds: a command produced no echo within its snapshot window and was re-sent (issue #35). The snapshot captures for this phase are in {1}." -f $rounds, $LogDirectory)
     }
 
     # ── payloads the properties' own $datatype/$format forbid ────────────────


### PR DESCRIPTION
Works issue #35, and refutes the hypothesis that was standing against it.

## What was checked first

The comment thread on #35 named a host-side mechanism that would produce this exact symptom —
item 2 of #36: `Stop-HomieCapture` ends its window with `taskkill /PID .. /T /F`,
`mosquitto_sub`'s stdout is redirected to a file so the CRT buffers fully (~4KB) rather than by
line, and anything still in that buffer dies with the process. Payload-volume dependence is the
right shape for a 1-in-8 intermittent, and checking it is much cheaper than investigating the
device.

It is refuted. Measured against Mosquitto 2.0.22 on this machine, replicating the script's exact
capture shape (same `cmd.exe` redirect, same 3s settle, same `taskkill /T /F`):

| Capture | Result |
|---|---|
| 5 retained topics (275 bytes) | 5 of 5 lines, complete |
| 53 retained topics | complete |
| 200 retained topics (11000 bytes) | 200 of 200 lines, complete |
| 5-topic replay + a live publish 1.5s into the window | tail present, last line is the late message |
| 53-topic replay + the same late publish | tail present |

The decisive measurement is taken before anything is killed: polling the capture file's length
while the window is open, a five-topic replay is 105 bytes on disk 200ms into the window, and a
message published at t=1000ms is on disk by t=1200ms. `mosquitto_sub` flushes per message, so
`taskkill` has nothing to discard. Full buffering would have left the file empty until the
process died.

The script already contained corroboration nobody had connected to the claim:
`Start-HomieCapture -WaitForConnectSeconds` takes "the file has bytes" as proof the subscriber is
live, and that wait works — which it could not against a subscriber holding 4KB before its first
write.

Both places the claim was made have been corrected: the comment in `Stop-HomieCapture` (in this
diff) and issue #36's item 2 (a comment on that issue, saying the item needs no fix and that
neither remedy it proposes should be pursued on this reasoning). Items 1 and 3 of #36 are
untouched.

## What this changes

**Snapshot captures are preserved.** `Save-BrokerEvidence` already keeps the broker's own log
and the long-running `homie/#` log for every broker generation, and the conformance path now
captures managed debug output. What was still discarded is the fresh-subscriber snapshot
capture, which is the file a conformance verdict is actually computed from — and the only place
retain flags can be read, since MQTT sets the flag only when replaying from the store to a new
subscriber. A conformance run opens roughly twenty-five of these windows and
`Start-HomieCapture` deletes the previous one at the start of each, so it kept none. That is the
"left no evidence" half of #35, and it is host-side whichever cause turns out to be real.

Each window is now copied into the run's log directory as
`<test>-snapshot-<nnn>-<phase>.log`.

**The copy is in a `finally`**, so evidence survives a stop that throws.
`Stop-SmartHomeProcessTree` over an already-dead subscriber does throw, before the `Get-Content`
that would have returned the lines — that is #54, which is not fixed here. This only makes sure
the window is still readable when it happens.

**The `/set` round trip warns when it needed more than one round.** #32's retry means a lost
command now passes rather than failing, so the condition #35 is about otherwise announces itself
only as extra snapshots in the phase breakdown, to a reader who already knows to look.

## Where that leaves #35 itself

Not diagnosed, and not claimed to be. With the truncation branch gone, the surviving evidence is
consistent with the reading #32 already acts on: the five commanded properties are all retained
(`HomieClientCheck` sets `$retained=false` on `counter` only), so an applied `/set` lands in the
broker's store and every later snapshot replays it in bulk — ten consecutive snapshots holding
boot values means the store held boot values, which is upstream of the capture. Reproducing it
needs the hardware and it was 1 run in 8; what this change buys is that the next occurrence can
be read rather than inferred.

## Verification

Host-side, no hardware. The capture functions were lifted out of the script by AST — the shipped
code, not a paraphrase — and run against a local broker on a port of its own:

- an unphased window, before any phase has started → preserved
- a phased window, the shape every conformance snapshot has → preserved, named by phase
- a window whose subscriber was killed before the stop → the stop threw, and the capture was
  preserved anyway

The broker log's usefulness for the next occurrence was checked the same way: under the config
`Start-DevEnv.ps1` writes (`log_type all`), it records `Received SUBSCRIBE`, `Received PUBLISH`
and `Sending PUBLISH to <client>` — which is what would say whether the device was subscribed
when the five commands arrived and whether the broker routed them to it.

### Hardware

**After the merge with main**, the full suite once on the ESP32 (COM3): all 5 pass — WifiCheck,
MqttCheck, Bmp280Check, HomieClientCheck, MqttReconnectCheck, 173s total. `HomieClientCheck`
preserved 12 snapshot captures, phase-named, counts matching the phase breakdown exactly
(announce 3, `/set` 1, out-of-format 1, lifecycle 5, re-announce 2). No `Could not preserve`
warning, no retry warning, and no short-capture warning from main's new `$wasAlive` path. The 38
build warnings in the run are the pre-existing nanoFramework BuildTasks fallback and the CS8632
nullable annotations in `ReconnectingMqttClient.cs`.

**Before the merge**, on the branch as originally pushed: ten consecutive `HomieClientCheck` runs
— 8 clean, 1 aborted by #54, and **2 that hit the #35 condition**, runs 4 and 6 needing 3 and 2
`/set` rounds. Every run preserved its captures, 12–13 files each. The smallest capture on
hardware is 1027 bytes — a quarter of the boundary the refuted hypothesis needs — and it ends on
a complete line, 19 of 19. The retry warning fired on exactly the two runs that needed it, which
is how they were found; that is also where the diagnosis below comes from.
### And the preserved evidence answered #35

Reported in full on the issue. In short: `Deploy-ToDevice.ps1` resets the device, which drops its
TCP connection without a DISCONNECT, so for up to 1.5 × the 10s keepalive the broker still holds
the *previous* app instance's retained announcement — `$state=ready` included, will not yet fired.
The check starts as soon as the deploy returns, accepts that stale `ready`, and publishes five
non-retained `/set` commands into a gap where nothing is subscribed.

The decisive value is in run 6's announce snapshot: `matrix/integer-value` reads `43`, which only
the previous run's out-of-format phase leaves behind. A freshly booted instance publishes `0`. The
broker log carries the matching `Client homie-client-check has exceeded timeout, disconnecting.` —
present in both retrying runs and in none of the eight others.

None of this diff attempts that fix; the wait predicate is a separate change and the issue records
the candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


