### PR TITLE
fix(tests): assert the refused transition about the device, not the store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,18 @@ the verdict*. The latter is declared per entry by the `Kind` field in `$testCata
   replaced. `HomieClientCheck` is this kind. Retained-ness is read from a *fresh*
   subscriber (`mosquitto_sub -F '%t %r %p'`), because MQTT only sets the retain flag when
   replaying from the store — a live retained publish arrives with the flag clear.
+
+  The refused transition is asserted **on the wire, about the device**, not on where the
+  retained store settled — issue #36 closed on that distinction. A settled per-topic read
+  can be flipped by a QoS-1 retransmission the broker re-processes ([MQTT 3.1.1
+  §3.3.1.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038):
+  a receiver "cannot assume that it has seen an earlier copy" of a DUP packet), which is a
+  true statement about the store and a false one about a device that reflected and corrected
+  exactly as required — and the runner cannot tell it apart from a device that genuinely
+  republished the refused value. So the verdict comes from the ordered payloads (the
+  reflection, then the correction over it, and `$state` never carrying the forbidden value),
+  and a store that disagrees with them is reported as a warning carrying the observed
+  sequence. Same call as `2af2b12`: don't name a defect the window cannot distinguish.
 - **`BrokerOutage`** — the host decides. The device publishes a heartbeat and subscribes to an
   echo topic; the runner takes the broker away, brings a fresh one up, and asserts heartbeats
   reappear on `homie/#` with a *higher* counter than before the outage. A lower counter means the

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1073,6 +1073,16 @@ function Get-ConformanceCaptureSeconds {
            60
 }
 
+function Add-ConformanceWarning {
+    # Both at once, on purpose: to the console while the run is happening, and to the
+    # list the verdict's detail is built from so it survives into the summary and the
+    # log. Either alone is a way to lose it.
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    $script:conformanceWarnings += $Message
+    Write-Warning $Message
+}
+
 function Invoke-HomieConformanceCheck {
     # Measures a purpose-built device against the Homie v4 convention, from the
     # broker's side. Every assertion is collected rather than thrown, so one run
@@ -1092,6 +1102,12 @@ function Invoke-HomieConformanceCheck {
     # reconcile, and an assertion added against the wrong one would have been collected
     # into a list the verdict never reads: a silently passing conformance test.
     $script:conformanceFailures = @()
+    # Things a run should report without failing on: observed, attributable to something
+    # other than the device, and therefore not a conformance verdict. Kept next to the
+    # failures rather than left to Write-Warning alone, because a warning only exists in
+    # the console -- it reaches neither the summary nor the run's log directory, which is
+    # the "left no evidence" gap #35 is about.
+    $script:conformanceWarnings = @()
     $script:conformancePhases = @()
     $script:currentPhase = $null
 
@@ -1477,14 +1493,33 @@ function Invoke-HomieConformanceCheck {
                 $script:conformanceFailures += "refused '$($step.Command)': the capture window caught no `$state or $nodeId/lifecycle at all, so nothing about the refusal was measured"
             }
             else {
-                # Named value, not last value. A device that took the forbidden transition
-                # must have published $state=sleeping, and it can only ever have published
-                # that by taking it -- so looking for the command itself is both stronger
-                # and immune to the flip above, where an older retransmitted 'ready' would
-                # settle here and be reported as a transition nobody asked for.
+                # Published values, not the last value. A refusal publishes nothing on
+                # $state, so anything the device puts there live inside this window is a
+                # move it should not have made -- and reading the published payloads
+                # rather than where the topic settled is what makes that immune to the
+                # flip above.
+                #
+                # $step.Expect is the one payload tolerated, and only that one. It is the
+                # value $state already holds, and the preceding step republishes its
+                # command every poll round while M2Mqtt retransmits an unacknowledged
+                # QoS-1 publish for MaximumAttemptsRetry (3) x DelayOnRetry (1000ms), so
+                # a fresh copy of it can legitimately still be arriving. Nothing else can:
+                # every older $state value was published well outside that ~3s budget --
+                # the preceding step polls in 3s snapshots before it returns.
+                #
+                # Which is why this is NOT narrowed to $step.Command. Looking only for the
+                # commanded value would pass a device that answered the refused command by
+                # moving $state somewhere else entirely (a CanChangeState regression
+                # leaving it at 'init' or 'lost'), and that is a defect this step used to
+                # catch before it read the wire.
                 $statePayloads = Get-HomieLivePayloads -Lines $lines -Topic "$root/`$state"
-                if ([array]::IndexOf($statePayloads, $step.Command) -ge 0) {
+                $moved = @($statePayloads | Where-Object { $_ -ne $step.Expect })
+
+                if ([array]::IndexOf($moved, $step.Command) -ge 0) {
                     $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state went to '$($step.Command)'; saw: $($statePayloads -join ', '))"
+                }
+                elseif ($moved.Count -gt 0) {
+                    $script:conformanceFailures += "refused '$($step.Command)' moved `$state off '$($step.Expect)' to '$($moved -join "', '")' -- not the forbidden transition, but not a refusal either (saw: $($statePayloads -join ', '))"
                 }
             }
 
@@ -1525,18 +1560,33 @@ function Invoke-HomieConformanceCheck {
             elseif ($corrected -lt 0) {
                 $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it (saw: $($lifecyclePayloads -join ', '))"
             }
-            elseif ($lifecycleAfter -ne $step.Expect) {
-                # The device corrected, and the topic still settled somewhere else. By the
-                # reasoning at the settled reads above that is the store disagreeing with
-                # the device, not the device misbehaving -- so it is reported and not
-                # counted, which is the whole of #36 item 1.
+            elseif ($lifecycleAfter -eq $step.Command) {
+                # The device corrected, and the topic still settled back on the value it
+                # corrected AWAY from. That is the duplicate #36 item 1 describes: a DUP of
+                # the reflection re-processed by the broker after the correction. The store
+                # disagrees with the device, and the device is not what is wrong -- so it is
+                # reported and not counted.
                 #
                 # Not swallowed, because it is a real contradiction in the retained store
                 # while it lasts: a controller connecting before the next lifecycle publish
                 # reads the refused value beside a $state that never took it. It is
                 # transient (the next command overwrites it) and outside this device's
-                # control, but a run that hits it should say so rather than look clean.
-                Write-Warning ("refused '{0}': {1}/lifecycle settled on '{2}' beside `$state='{3}' even though the correction to '{4}' is on the wire -- a retransmitted duplicate re-processed by the broker, not a device defect (saw: {5})" -f $step.Command, $nodeId, $lifecycleAfter, $stateAfter, $step.Expect, ($lifecyclePayloads -join ', '))
+                # control, but a run that hits it should say so rather than look clean --
+                # so it also goes into the verdict's detail below, where the summary and
+                # the run's log can carry it. A console-only warning is exactly the kind of
+                # evidence #35 was unable to go back and read.
+                Add-ConformanceWarning ("refused '{0}': {1}/lifecycle settled back on '{2}' beside `$state='{3}' even though the correction to '{4}' is on the wire -- a retransmitted duplicate re-processed by the broker, not a device defect (saw: {5})" -f $step.Command, $nodeId, $lifecycleAfter, $stateAfter, $step.Expect, ($lifecyclePayloads -join ', '))
+            }
+            elseif ($lifecycleAfter -ne $step.Expect) {
+                # Settled on something that is neither the corrected value nor the value it
+                # corrected away from. A retransmission can only ever repeat a payload the
+                # device already published, and everything it published before this window
+                # is outside M2Mqtt's ~3s retry budget (see the $state read above), so this
+                # is a genuine new publish onto the property after the correction -- the
+                # store left advertising a state the device is not in, which is the defect
+                # this step exists for. Counted, not demoted: the duplicate reasoning above
+                # does not reach it.
+                $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' after correcting to '$($step.Expect)', while `$state is '$stateAfter' (saw: $($lifecyclePayloads -join ', '))"
             }
 
             continue
@@ -1580,16 +1630,26 @@ function Invoke-HomieConformanceCheck {
         }
     }
 
+    # Appended to whichever verdict is returned, so a run that observed one carries it
+    # into the summary line and the log instead of only into scrollback. A PASS with a
+    # note is still a PASS: nothing here is a conformance failure.
+    $warningDetail = if ($script:conformanceWarnings.Count -gt 0) {
+        " [$($script:conformanceWarnings.Count) warning(s): " + ($script:conformanceWarnings -join '; ') + "]"
+    }
+    else {
+        ''
+    }
+
     if ($script:conformanceFailures.Count -gt 0) {
         return @{
             Outcome = 'FAIL'
-            Detail  = "$($script:conformanceFailures.Count) conformance failure(s): " + ($script:conformanceFailures -join '; ')
+            Detail  = "$($script:conformanceFailures.Count) conformance failure(s): " + ($script:conformanceFailures -join '; ') + $warningDetail
         }
     }
 
     return @{
         Outcome = 'PASS'
-        Detail  = "attributes, datatypes, retained flags, /set round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce all conform"
+        Detail  = "attributes, datatypes, retained flags, /set round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce all conform" + $warningDetail
     }
 }
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -623,8 +623,11 @@ function Get-MosquittoTool {
 # choose. Two attempts at shortening it both broke the conformance check, and the
 # measurements are worth keeping so nobody repeats them:
 #
-#   - Ending the wait after 250ms of quiet output: 7 failures. The output is buffered and
-#     lands in chunks, so "quiet" does not mean "finished".
+#   - Ending the wait after 250ms of quiet output: 7 failures. Retained replay and live
+#     traffic arrive with gaps in them, so "quiet" does not mean "finished". (This used
+#     to blame stdio buffering. It is not that -- see Stop-HomieCapture, where the
+#     buffering was measured and found not to exist. The 7 failures stand; the
+#     explanation for them was wrong.)
 #   - A flat 1s: 3 failures, 54 topics where a healthy run sees ~64.
 #   - mosquitto_sub -W 1, waiting for it to exit rather than killing it: complete, but
 #     6.3s -- slower than what it replaced.
@@ -766,11 +769,30 @@ function Stop-HomieCapture {
     $script:snapshotsTaken++
 
     Start-Sleep -Seconds $SettleSeconds
-    # See #36: taskkill /F does not wait for mosquitto_sub to flush. Its stdout is
-    # redirected to a file, so the CRT buffers fully (~4KB) rather than by line, and
-    # whatever is still in that buffer dies with the process. Only the refused-transition
-    # step depends on the TAIL of a window -- every other caller needs the bulk retained
-    # replay, which is far past the buffer boundary by the time the window closes.
+    # taskkill /F loses nothing here, and that is measured rather than assumed.
+    #
+    # #36 item 2 argued the opposite: stdout is redirected to a file, so the MSVC CRT
+    # buffers fully (~4KB) rather than by line, and a tail still sitting in that buffer
+    # would die with the process -- making the callers that read the END of a window
+    # (the refused-transition step, the out-of-format step) work only by accident of how
+    # much retained replay happened to precede it. That was a plausible mechanism and it
+    # is not what mosquitto_sub does.
+    #
+    # Measured on this machine against Mosquitto 2.0.22, no hardware involved:
+    #
+    #   - With the subscriber still RUNNING, the redirected file grows by exactly one
+    #     line per message (50, 100, 150 bytes for three publishes). A full buffer would
+    #     hold all three; there is nothing to lose because nothing is retained in it.
+    #   - taskkill /F immediately after the publish (0ms, 50ms, 250ms, 3s) keeps the tail
+    #     every time, in a file of 377 bytes -- a tenth of the supposed 4KB boundary.
+    #   - Repeated across retained-store sizes of 0, 5, 53 and 120 topics: the tail is
+    #     present at every size, including an EMPTY store, which is the case the buffer
+    #     theory says must fail.
+    #
+    # So mosquitto_sub flushes stdout per message and the window's tail is as reliable as
+    # its bulk. Do not reintroduce -W to "fix" this: it was measured at 15.2s for a 3s
+    # window here (and 6.3s for a 1s one, see $SnapshotSettleSeconds), which would cost
+    # minutes across a run to solve a problem that does not exist.
     Stop-SmartHomeProcessTree -ProcessId $Capture.ProcessId
 
     return @(Get-Content -Path $Capture.Path -ErrorAction SilentlyContinue)
@@ -1416,29 +1438,53 @@ function Invoke-HomieConformanceCheck {
 
             $refused = ConvertTo-HomieSnapshot -Lines $lines
 
+            # What this step asserts is THE DEVICE'S BEHAVIOUR, read from the wire. It is
+            # deliberately not an assertion about the retained store's final contents, and
+            # #36 item 1 is the decision to make that explicit rather than leave the two
+            # claims tangled together.
+            #
+            # They came apart because a settled per-topic read can be flipped by a QoS-1
+            # retransmission. ConvertTo-HomieSnapshot only merges on an EQUAL payload, so a
+            # DUP of the reflected 'sleeping' arriving after the correction replaces it:
+            # wire order [sleeping, alert, sleeping-dup] settles on 'sleeping' while every
+            # ordered assertion passes. And the store really does end up holding it --
+            # MQTT 3.1.1 3.3.1.1 says a receiver "cannot assume that it has seen an earlier
+            # copy" of a DUP packet, and QoS 1 has no dedup, so the broker re-processes it.
+            #
+            # That is a true statement about the store and a false one about the device: it
+            # reflected and corrected exactly as required, and the retransmission is the
+            # transport's, not its. Worse, the runner cannot tell that sequence apart from a
+            # device that genuinely republished the refused value after correcting it -- the
+            # subscriber sees a broker-forwarded DUP as an ordinary message. Asserting on it
+            # therefore names a defect this window cannot distinguish, which is the same
+            # call 2af2b12 already made for the "corrected too early" branch.
+            #
+            # So the settled reads below are used for two things only: presence (was
+            # anything measured at all) and evidence in the messages. The verdicts come from
+            # the ordered reads.
             $stateAfter = if ($refused.Contains("$root/`$state")) { $refused["$root/`$state"].Payload } else { $null }
-            # See #36: this settled read can be flipped by a QoS-1 retransmission. The
-            # per-topic collapse only merges on an equal payload, so a duplicate of the
-            # reflected 'sleeping' arriving after the correction replaces it -- wire order
-            # [sleeping, alert, sleeping-dup] leaves 'sleeping' here while the three wire
-            # assertions below all pass. Left as is deliberately: a broker re-processes a
-            # DUP PUBLISH, so the retained store really would hold the contradiction.
             $lifecycleAfter = if ($refused.Contains("$node/lifecycle")) { $refused["$node/lifecycle"].Payload } else { $null }
 
             # Absent, not merely wrong: neither topic being in the window means nothing
             # was measured -- a subscriber that never came up, not a device that took the
             # forbidden transition. Reported as such rather than as a device defect, the
             # way the wire assertions below already do for a lost command.
+            #
+            # Presence is the one thing the collapse answers soundly whatever arrives: a
+            # duplicate can change WHICH payload a topic settles on, never whether the
+            # topic was seen.
             if ($null -eq $stateAfter -or $null -eq $lifecycleAfter) {
                 $script:conformanceFailures += "refused '$($step.Command)': the capture window caught no `$state or $nodeId/lifecycle at all, so nothing about the refusal was measured"
             }
             else {
-                if ($stateAfter -ne $step.Expect) {
-                    $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state is '$stateAfter')"
-                }
-
-                if ($lifecycleAfter -ne $step.Expect) {
-                    $script:conformanceFailures += "refused '$($step.Command)' left $nodeId/lifecycle advertising '$lifecycleAfter' while `$state is '$stateAfter'"
+                # Named value, not last value. A device that took the forbidden transition
+                # must have published $state=sleeping, and it can only ever have published
+                # that by taking it -- so looking for the command itself is both stronger
+                # and immune to the flip above, where an older retransmitted 'ready' would
+                # settle here and be reported as a transition nobody asked for.
+                $statePayloads = Get-HomieLivePayloads -Lines $lines -Topic "$root/`$state"
+                if ([array]::IndexOf($statePayloads, $step.Command) -ge 0) {
+                    $script:conformanceFailures += "forbidden $($step.Expect) -> $($step.Command) transition was applied (`$state went to '$($step.Command)'; saw: $($statePayloads -join ', '))"
                 }
             }
 
@@ -1478,6 +1524,19 @@ function Invoke-HomieConformanceCheck {
             }
             elseif ($corrected -lt 0) {
                 $script:conformanceFailures += "device left the reflected '$($step.Command)' on $nodeId/lifecycle and never published '$($step.Expect)' over it (saw: $($lifecyclePayloads -join ', '))"
+            }
+            elseif ($lifecycleAfter -ne $step.Expect) {
+                # The device corrected, and the topic still settled somewhere else. By the
+                # reasoning at the settled reads above that is the store disagreeing with
+                # the device, not the device misbehaving -- so it is reported and not
+                # counted, which is the whole of #36 item 1.
+                #
+                # Not swallowed, because it is a real contradiction in the retained store
+                # while it lasts: a controller connecting before the next lifecycle publish
+                # reads the refused value beside a $state that never took it. It is
+                # transient (the next command overwrites it) and outside this device's
+                # control, but a run that hits it should say so rather than look clean.
+                Write-Warning ("refused '{0}': {1}/lifecycle settled on '{2}' beside `$state='{3}' even though the correction to '{4}' is on the wire -- a retransmitted duplicate re-processed by the broker, not a device defect (saw: {5})" -f $step.Command, $nodeId, $lifecycleAfter, $stateAfter, $step.Expect, ($lifecyclePayloads -join ', '))
             }
 
             continue

--- a/src/integrationTests/HomieClientCheck/Program.cs
+++ b/src/integrationTests/HomieClientCheck/Program.cs
@@ -169,11 +169,26 @@ namespace SmartHome.IntegrationTests.HomieClientCheck
             // Actuators copying this device should do the same: reflect the outcome, not
             // the command.
             //
-            // Unconditional, so an accepted command publishes the same payload twice --
-            // the library's reflection, then an identical correction. See #36: guarding
-            // on _lifecycle.Value would suppress the second publish, but Value is already
-            // updated even when the reflection's own publish threw, and the guard would
-            // then suppress the only publish the broker would have seen.
+            // Unconditional, and that is the decision rather than an oversight (#36 item
+            // 3, closed on this reasoning; the remaining half is #61).
+            //
+            // It costs a duplicate: an ACCEPTED command publishes the same payload twice,
+            // the library's reflection and then an identical correction. Every guard that
+            // would save that publish is content-based, and every content-based guard is
+            // wrong in the one case that matters. PropertyBase.Set applies the value
+            // before publishing it and EnumProperty.Update assigns Value before raising
+            // OnUpdate, so by the time this handler runs Value already holds the commanded
+            // value whether or not the reflection reached the broker -- and
+            // HomieClient.HandleIncomingMessage catches a throw from that publish and
+            // raises OnCommand anyway. So 'if (_lifecycle.Value != actual)' suppresses the
+            // correction precisely when the correction is the only publish the broker
+            // would ever have seen, and the store is left with no value at all. Comparing
+            // against the command payload instead fails the same way.
+            //
+            // A duplicate publish is cheap and self-correcting; a silently missing one is
+            // neither. #61 is what would make the guard safe -- the library telling the
+            // handler whether its reflection actually landed -- and until then
+            // unconditional is the side of the trade to be on.
             _lifecycle.Update(_homieClient.State.GetString());
         }
 


### PR DESCRIPTION
Closes #36 — its three known gaps, settled. Two are decisions with the reasoning written down
next to the code; one turned out to rest on a premise that does not hold.

## 1. A retransmitted duplicate can flip the settled lifecycle read — decided

The issue asked for a decision about which claim the refused-transition step makes: the retained
store's final contents, or the device's behaviour. **It is the device's behaviour, read from the
wire.**

The step read `$stateAfter` and `$lifecycleAfter` from `ConvertTo-HomieSnapshot`, whose per-topic
collapse only merges on an equal payload — so a DUP of the reflected `sleeping` arriving after the
correction replaces it, and wire order `[sleeping, alert, sleeping-dup]` settles on `sleeping`
while every ordered assertion passes.

The issue is right that the store really does end up holding that. [MQTT 3.1.1
§3.3.1.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038): a
receiver "cannot assume that it has seen an earlier copy" of a DUP packet, and QoS 1 has no
dedup, so the broker re-processes it. That makes the settled read a **true statement about the
store and a false one about the device**, which reflected and corrected exactly as the convention
requires. The retransmission is the transport's, not the device's.

What settles it is that the two are indistinguishable here. A broker-forwarded DUP reaches the
subscriber as an ordinary message, so this window cannot tell it from a device that genuinely
republished the refused value after correcting it. That is the same situation `2af2b12` already
ruled on for the "corrected too early" branch, and it is resolved the same way:

- The **verdict** comes from the ordered payloads — the reflection, then the correction over it.
  Those already cover both real device defects: `$reflected < 0` is a lost command, `$corrected <
  0` is a device that never corrected. The settled read added nothing except the case it gets
  wrong, and in the "never corrected" case it was reporting the same defect twice.
- The settled reads are kept for **presence** (was anything measured at all — a duplicate can
  change which payload a topic settles on, never whether the topic was seen) and as **evidence**
  in the messages.
- A store that disagrees with a corrected wire sequence is **not swallowed**. It is a real
  contradiction for as long as it lasts, so it warns, carrying the observed sequence. That is the
  half of the rejected fix the issue was right to refuse: suppressing it outright would have
  hidden it.

The `$state` assertion changes shape with it, because it had the identical exposure — an older
retransmitted `ready` settling there would be reported as a transition nobody asked for. It now
looks for the forbidden value **by name** rather than for whatever settled last: a device that
took the transition must have published `$state=sleeping`, and nothing else can produce that
payload. Strictly stronger, and immune to the flip.

## 2. The capture tail depends on a stdio flush `taskkill /F` does not wait for — retracted

**The premise does not hold. `mosquitto_sub` flushes stdout after every message.**

Measured on this machine against Mosquitto 2.0.22, no hardware involved, three ways:

- **The decisive one.** With the subscriber still *running*, the redirected file grows by exactly
  one line per message — 50, 100, 150 bytes for three publishes. A ~4KB full buffer would hold
  all three. There is nothing in the buffer for `taskkill` to lose because nothing is being held
  there.
- `taskkill /PID .. /T /F` at 0ms, 50ms, 250ms and 3s after the publish keeps the tail every
  time, in a file of **377 bytes** — a tenth of the supposed boundary. Reproduced twice,
  byte-identical.
- Repeated across retained stores of 0, 5, 53 and 120 topics, using the real
  `Get-SmartHomeSubscriberArguments` layout and the same `cmd.exe` redirect shape: the tail is
  present at every size, **including an empty store**, which is exactly the case the buffer theory
  says must fail.

So the callers that read the end of a window — the refused-transition step, and the out-of-format
step, which the issue did not list — are not working by accident of how much retained replay
happened to precede them. The comment asserting otherwise is replaced by the measurement.

Two consequences beyond the comment:

- The neighbouring claim at `$SnapshotSettleSeconds` that blamed stdio buffering for chunked
  output is corrected too. Its 7 failures stand; its explanation did not. Retained replay and live
  traffic simply arrive with gaps in them.
- The `-W` option is recorded as a non-remedy rather than a candidate: measured here at **15.2s
  for a 3s window** (matching the 6.3s already recorded for a 1s one), which across a run costs
  minutes to solve a problem that does not exist.

**This also retracts the hypothesis I posted on #35**, which offered this mechanism as an
explanation for the lost `/set` commands. It cannot be the cause. Retracted in a comment there.

## 3. Every accepted lifecycle command publishes the property twice — unchanged, and now says why

The rejection stands, and the reasoning checks out against the source. `PropertyBase.Set` applies
the value before publishing it, `EnumProperty.Update` assigns `Value` before raising `OnUpdate`,
and `HomieClient.HandleIncomingMessage` catches a throw from that publish and raises `OnCommand`
anyway (`accepted` keeps its initialised `true`). So by the time the handler runs, `Value` holds
the commanded value whether or not the reflection reached the broker — and `if (_lifecycle.Value
!= actual)` suppresses the correction precisely when the correction is the only publish the
broker would ever have seen. Comparing against the command payload instead fails the same way.
Every guard available to the app is content-based, and every content-based guard is wrong here.

The comment now carries that argument in full instead of pointing at an issue to be read
alongside it. What would make a guard safe is the library telling the handler whether its
reflection actually landed — `HomieCommandEventArgs` exposes only `Property` and `Payload`, and
its XML doc currently claims the value "has been reflected back", which is not guaranteed. Filed
as #61. That is not a re-run of #33: #33 asked the library to *defer* the reflection and was
closed as working-as-intended; #61 takes that answer as settled and asks only for a signal about
a publish the library has already attempted.

## Second commit: three findings from reviewing the first

`7db2459` fixes three things the review found in the code the first commit added. Two are places
where the change gave up more coverage than its own reasoning called for:

- **The `$state` read was narrowed too far.** Testing for the commanded value alone made it immune
  to the flip, and also stopped catching a refused command that moves `$state` somewhere else
  entirely — a `CanChangeState` regression leaving it at `init` or `lost` would have passed. It now
  fails on any live `$state` payload that is not `$step.Expect`. Tolerating exactly that one keeps
  the immunity for the only reason it was needed: `$step.Expect` is the value `$state` already
  holds and the one the preceding step republishes every poll round, so a fresh copy can
  legitimately still be arriving, while every older value was published outside M2Mqtt's retry
  budget — `MaximumAttemptsRetry` (3) × `DelayOnRetry` (1000ms), read from the sibling checkout,
  against a preceding step that polls in 3s snapshots.
- **The warning demoted every disagreement, not just the duplicate.** A DUP can only repeat a
  payload the device already published, so a settled value equal to the reflected command is the
  case #36 describes — but `[sleeping, alert, ready]` settling on `ready` is a genuine new publish
  onto the property after the correction, which is the defect this step exists for. The warning is
  now conditional on the settled value being `$step.Command`; anything else is a failure again.
- **The warning was console-only.** It reached neither the per-test `Detail`, the summary line, nor
  the run's log directory, so a run that observed the contradiction reported a clean PASS to
  anyone reading it afterwards — the "left no evidence" gap #35 is about. Warnings now go through
  `Add-ConformanceWarning`, which writes to the console *and* collects them, and the verdict's
  detail carries them on PASS and FAIL alike. Still not a conformance failure: a PASS with a note
  is a PASS.

## Verified on hardware

Full integration suite, ESP32 on COM3 with local Mosquitto, run on both commits:
**5/5 PASS** — 172s on `cb45180`, 183s on `7db2459`. The conformance phase snapshot counts are
identical to the pre-change baseline in both runs (announce 3, /set 1, out-of-format 1, lifecycle
5, re-announce 2), so neither the new `$state` read nor the warning accumulator costs a snapshot.
No warning fired on either run, which is the expected shape of a healthy one. The preserved
`homie/#` log carries exactly what the changed assertions read:

```
homie/homie-client-check/$state 0 alert
homie/homie-client-check/matrix/lifecycle 0 alert
homie/homie-client-check/matrix/lifecycle 0 sleeping     <- the reflection
homie/homie-client-check/matrix/lifecycle 0 alert        <- the correction over it
homie/homie-client-check/matrix/lifecycle 0 ready
homie/homie-client-check/$state 0 ready
```

Between `$state 0 alert` and `$state 0 ready` the device publishes nothing at all on `$state`, so
the stricter read sees an empty `$moved` and does not false-positive; and the correction follows
the reflection, which is the unchanged ordered assertion. The duplicate pairs from item 3 are in
the same log (`alert` twice, `ready` twice, `sleeping` twice), unchanged as decided. RoomSensor was
redeployed after each run, so the device is back to its own job. Solution builds clean in Debug;
`Run-IntegrationTests.ps1` parses.

A healthy run cannot reach three of the branches — the duplicate flip, a third value after the
correction, and `$state` moving elsewhere all need the device or the transport to misbehave. Those
were covered instead by transcribing the edited branch chain condition for condition and running
it over nine cases (healthy; healthy with no live `$state`; the DUP flip; never corrected; lost
command; a third value after the correction; the transition actually taken; `$state` moved
elsewhere; a tolerated `alert` retransmission). All nine land where intended. It is a simulation of
the conditions, not of the script — `Run-IntegrationTests.ps1` runs a suite on load, so it cannot
be dot-sourced — and it is stated as that rather than as an on-device result.

## Conflicts with #60

#60 rewrites the same `Stop-HomieCapture` block this corrects — it keeps the buffering comment as
context and adds the record-based stop below it. The two changes are independent and both wanted;
resolving is "this comment, their code". Flagged there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
