### PR TITLE
feat(scripts): seed a fresh worktree automatically

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": [
+              "-NoProfile",
+              "-ExecutionPolicy",
+              "Bypass",
+              "-File",
+              "${CLAUDE_PROJECT_DIR}/scripts/Initialize-Worktree.ps1"
+            ],
+            "timeout": 120,
+            "statusMessage": "Seeding worktree (config files + packages)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,8 +12,8 @@
               "-NoProfile",
               "-ExecutionPolicy",
               "Bypass",
-              "-File",
-              "${CLAUDE_PROJECT_DIR}/scripts/Initialize-Worktree.ps1"
+              "-Command",
+              "$dir = $env:CLAUDE_PROJECT_DIR; if (-not $dir) { $dir = $PWD.Path }; $s = Join-Path $dir 'scripts\\Initialize-Worktree.ps1'; if (-not (Test-Path -LiteralPath $s)) { exit 0 }; & $s; exit $LASTEXITCODE"
             ],
             "timeout": 120,
             "statusMessage": "Seeding worktree (config files + packages)..."

--- a/.claude/skills/smarthome-init-worktree/SKILL.md
+++ b/.claude/skills/smarthome-init-worktree/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: smarthome-init-worktree
+description: Seed a fresh git worktree with the machine-local setup a clone never carries — both local.env files and a restored packages\ folder. Use as the first thing in any session running under .claude\worktrees\, or when a script in a worktree aborts with "Missing: ...\scripts\local.env.ps1" or a build fails with CS0518 everywhere.
+---
+
+# Seed a fresh SmartHome worktree
+
+```powershell
+.\scripts\Initialize-Worktree.ps1
+```
+
+Copies `scripts\local.env.ps1` and `scripts\nanoFramework.local.env.ps1` across from the main
+working tree, then restores `packages\`. Touches no hardware, opens no port, needs no
+confirmation.
+
+Idempotent and safe to call unconditionally — including in the main checkout, where it reports
+that and exits 0 without changing anything. Run it as the first command of a session in a
+worktree rather than waiting for something to fail.
+
+## Why a worktree needs seeding at all
+
+`git worktree add` brings tracked files and nothing else. All three of these are git-ignored, so
+none of them arrive:
+
+- `scripts\local.env.ps1`
+- `scripts\nanoFramework.local.env.ps1`
+- `packages\`
+
+The main checkout sitting right beside it is fully configured, which is what makes this
+confusing rather than obvious. `Get-SmartHomeScriptsDir` returns the *calling script's own*
+`$PSScriptRoot` — deliberately, so a worktree can carry different settings — so a worktree reads
+its own missing config, never the main checkout's.
+
+Both failures read like broken code:
+
+| What is missing | What you actually see |
+|---|---|
+| Either `local.env` file | Any script aborting at its first line with `Missing: ...\scripts\local.env.ps1` |
+| `packages\` | A wall of `error CS0518` — predefined type `System.Object` is not defined — in every project |
+
+MSBuild on this machine emits **German** diagnostics, so match on the error *code*, not the
+message text.
+
+## Switches
+
+| Switch | Effect |
+|---|---|
+| *(none)* | Copy both config files, then restore `packages\`. Measured at ~1.6s on a fresh worktree, ~0.5s when everything is already there |
+| `-NoRestore` | Config files only, ~0.03s. For an unattended cheap path, or when `packages\` is known good |
+| `-MainWorktree <path>` | Copy the config files from some other checkout instead of the main working tree |
+
+## What it will not do
+
+- **Never overwrites an existing config file.** A worktree may deliberately carry an edited copy
+  — a second device's COM port, a different broker port — and this script keeps it, reporting
+  `kept:` rather than `copied:`.
+- **Never invents config.** If the main checkout has no `local.env.ps1` either, this is
+  first-time setup on the machine, not a worktree that missed out; the script says so and prints
+  the `Copy-Item` for the *template* with both paths filled in. It does not seed from a template
+  itself — that would trade "file missing" for "file present, values empty", which fails later
+  and reads worse.
+- **Never hits the network.** The restore is `Restore-Packages.ps1`, which copies out of the
+  local NuGet cache only.
+
+## Finding the main checkout
+
+Via `git rev-parse --git-common-dir` — the main repository's `.git`, shared by every linked
+worktree; its parent is the main working tree. Shared as `Get-SmartHomeMainWorktreeRoot` in
+`Common.ps1`, with `Test-SmartHomeLinkedWorktree` beside it for the yes/no question.
+
+Deliberately not a relative hop like `..\..\..`: that is only correct for a worktree exactly
+three levels down, which `.claude\worktrees\<name>` happens to be and nothing guarantees.
+
+## Related
+
+`smarthome-check-setup` (`Test-Setup.ps1`) reports whether a worktree is seeded, along with
+every other prerequisite, and names this script as the fix. Run it after this one to confirm.
+`smarthome-restore-packages` is the `packages\` half on its own, for when the config files are
+already in place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` | The whole `src\integrationTests` suite in one call: broker up, deploy + capture + verdict per test, broker down, summary + exit code | **Yes** | `smarthome-integration-tests` |
 | `scripts\Sync-NanoFrameworkRepos.ps1 [-Force]` | Clones/updates the sibling nanoFramework repos beside `SmartHome` | No | `smarthome-sync-nanoframework` |
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
+| `scripts\Initialize-Worktree.ps1 [-NoRestore] [-MainWorktree <path>]` | Seeds a fresh linked worktree with the three git-ignored things `git worktree add` never brings: both `local.env` files, copied from the main working tree, and a restored `packages\`. Idempotent — never overwrites a config file the worktree already has, and no-ops with exit 0 in the main checkout, so it is safe to call unconditionally | No | `smarthome-init-worktree` |
 | `scripts\Clean-GitBranches.ps1 [-Worktrees] [-Delete] [-Scope Local\|Remote\|Both] [-Protect <names>]` | Classifies every worktree and every local and remote branch against `origin/main` and, with `-Delete`, removes the merged ones in one batch. Report-only without it. Keeps the base branch, anything with an open pull request, anything unmerged, and — unless `-Worktrees` frees them — the branches worktrees pin. A dirty worktree is never removed, and there is deliberately no flag that overrides that | No | `smarthome-clean-branches` |
 | `scripts\Test-Setup.ps1` | Reports everything the other scripts assume exists on this machine — both `local.env` files and their values, restored `packages\`, the test adapter, `gh` auth, MSBuild/vstest, Mosquitto, the COM port, the companion repos — all at once, rather than one abort at a time. Read-only; opens no port and touches no device | No | `smarthome-check-setup` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
@@ -175,9 +176,9 @@ them by name; the table is for when you meet one without having run it:
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| A script exits at once with `Missing: ...\scripts\local.env.ps1` | config file absent | copy the templates above, or the filled-in files from another checkout |
+| A script exits at once with `Missing: ...\scripts\local.env.ps1` | config file absent | in a worktree, `scripts\Initialize-Worktree.ps1`; otherwise copy the templates above, or the filled-in files from another checkout |
 | `Missing environment variable: SMARTHOME_...` | config file present but incomplete | fill the value in, comparing against the template |
-| A wall of `error CS0518` — predefined type `System.Object`/`System.Void` not defined — in every project | NuGet packages not restored: `packages\` is git-ignored (`.gitignore:200`) and comes with no clone | `scripts\Restore-Packages.ps1`. A plain `msbuild /t:Restore` is a no-op for this project style |
+| A wall of `error CS0518` — predefined type `System.Object`/`System.Void` not defined — in every project | NuGet packages not restored: `packages\` is git-ignored (`.gitignore:200`) and comes with no clone | `scripts\Restore-Packages.ps1` (or `scripts\Initialize-Worktree.ps1`, which also seeds the config files). A plain `msbuild /t:Restore` is a no-op for this project style |
 | `gh` fails with an authentication error | `gh auth login` never run, or the token expired | `gh auth login`. The backlog is unreadable until then |
 
 MSBuild on this machine emits **German** diagnostics, so match on the error *code* (`CS0518`)
@@ -189,16 +190,35 @@ rather than on English message text.
 `.claude\worktrees\<name>` reads *its own* `scripts\local.env.ps1`, never the main checkout's.
 Both config files and `packages\` are git-ignored, so a new worktree has neither, and the first
 script call fails there even though the main checkout is fully set up. Seed it once, from the
-worktree root (`..\..\..` being `<name>` → `worktrees` → `.claude` → the repo root):
+worktree root:
 
 ```powershell
-Copy-Item ..\..\..\scripts\local.env.ps1 scripts\
-Copy-Item ..\..\..\scripts\nanoFramework.local.env.ps1 scripts\
-.\scripts\Restore-Packages.ps1
+.\scripts\Initialize-Worktree.ps1
 ```
 
-`Test-Setup.ps1` detects the worktree and prints that first `Copy-Item` with both paths already
-filled in, so running it first is quicker than reading this.
+That copies both config files from the main working tree and restores `packages\` — about 1.6s
+on a fresh worktree. **Run it as the first command of any session in a worktree**, rather than
+waiting for a script to abort or a build to emit CS0518 everywhere. It is idempotent, never
+overwrites a config file the worktree already has, and no-ops with exit 0 in the main checkout,
+so calling it unconditionally is fine. `-NoRestore` does the config half only (~0.03s).
+
+It finds the main checkout via `git rev-parse --git-common-dir` — the main repository's `.git`,
+shared by every linked worktree, whose parent is the main working tree. Not by a relative hop:
+`..\..\..` is only correct for a worktree exactly three levels down. `Common.ps1` exposes that
+as `Get-SmartHomeMainWorktreeRoot`, with `Test-SmartHomeLinkedWorktree` for the yes/no question;
+`Get-SiblingRoot` and `Test-Setup.ps1` both read it rather than re-deriving it.
+
+`Test-Setup.ps1` detects the worktree and names this script as the fix for every row it would
+repair, so running it first is quicker than reading this.
+
+**A committed `SessionStart` hook already runs it**, so in practice a worktree seeds itself before
+the first prompt. [`.claude/settings.json`](.claude/settings.json) holds it — matcher `startup`,
+exec form (`powershell.exe` plus an argument list, no shell, so nothing depends on whether Git
+Bash is on PATH), script path via `${CLAUDE_PROJECT_DIR}`. It is the only thing in that file. The
+hook is a convenience, not the mechanism: it is the same script with no switches, so running it by
+hand stays correct, and a session that starts before the hook lands (or with hooks disabled) is
+one command away from the same state. Its stdout is injected into the session's context, which is
+the reason the script's normal-path output is a handful of lines rather than a log.
 
 ## Repository layout
 

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -203,19 +203,32 @@ function Get-SmartHomeMainWorktreeRoot {
 
     $repoRoot = Get-SmartHomeRepoRoot
 
+    $commonDir = $null
+    $gitExit = 1
     try {
         # --path-format=absolute would save the rooting dance below, but that flag is
         # git 2.31+. Plain --git-common-dir answers on every version, relatively.
         $commonDir = git -C $repoRoot rev-parse --git-common-dir 2>$null
+
+        # Read inside the try, not after it. Two different ways this line can throw,
+        # and both have to land in the catch for the function to keep its "$null when
+        # git can't answer" contract:
+        #   - git is not on PATH at all -- $ErrorActionPreference = 'Stop' makes the
+        #     CommandNotFoundException terminating;
+        #   - `git` resolves to a PowerShell function or alias rather than the
+        #     executable (profile wrappers, corporate shims), so no native command
+        #     ran and $LASTEXITCODE was never set -- which Set-StrictMode -Version
+        #     Latest turns into a terminating "variable cannot be retrieved" error.
+        # Read outside the try, that second one escapes the function and takes down
+        # Test-Setup.ps1, whose whole point is to report every gap rather than abort
+        # on the first.
+        $gitExit = $LASTEXITCODE
     }
     catch {
-        # git not on PATH at all. $ErrorActionPreference = 'Stop' turns the
-        # CommandNotFoundException terminating, so the exit-code check below would
-        # never be reached without this.
         return $null
     }
 
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commonDir)) {
+    if ($gitExit -ne 0 -or [string]::IsNullOrWhiteSpace($commonDir)) {
         return $null
     }
 

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 # propagates $WhatIfPreference into it. Without the override, a -WhatIf run reports
 # "WhatIf: Set variable SmartHomeMSBuildPath" as though it were an action the user
 # asked about, and skips the assignment -- noise in front of the real preview.
-foreach ($memo in 'SmartHomeMSBuildPath', 'SmartHomeVsTestPath', 'SmartHomeSiblingRoot') {
+foreach ($memo in 'SmartHomeMSBuildPath', 'SmartHomeVsTestPath', 'SmartHomeSiblingRoot', 'SmartHomeMainWorktreeRoot') {
     if (-not (Test-Path "variable:global:$memo")) {
         Set-Variable -Name $memo -Scope Global -Value $null -WhatIf:$false
     }
@@ -182,6 +182,69 @@ function Get-NfProjectAssemblyName {
     return [System.IO.Path]::GetFileNameWithoutExtension($ProjectPath)
 }
 
+function Get-SmartHomeMainWorktreeRoot {
+    # The root of the MAIN working tree, whether this checkout is that tree or a
+    # linked worktree under it. $null means only "git could not answer" -- no git on
+    # PATH, not a repository, an exported source tree -- never "this is the main
+    # one"; use Test-SmartHomeLinkedWorktree for that question.
+    #
+    # `git rev-parse --git-common-dir` reports the main repository's .git, which every
+    # linked worktree shares; its parent is the main working tree. That holds wherever
+    # the worktree sits, which a relative hop like ..\..\.. does not -- that one is
+    # correct only for a worktree exactly three levels down.
+    #
+    # Memoised in the global scope for the same reason as the tool lookups above: a
+    # suite run invokes sub-scripts in this one process, and each would otherwise pay
+    # for its own `git rev-parse`. A $null is deliberately not memoised -- it costs a
+    # re-probe per call in the one case where the answer is unusable anyway.
+    if ($global:SmartHomeMainWorktreeRoot) {
+        return $global:SmartHomeMainWorktreeRoot
+    }
+
+    $repoRoot = Get-SmartHomeRepoRoot
+
+    try {
+        # --path-format=absolute would save the rooting dance below, but that flag is
+        # git 2.31+. Plain --git-common-dir answers on every version, relatively.
+        $commonDir = git -C $repoRoot rev-parse --git-common-dir 2>$null
+    }
+    catch {
+        # git not on PATH at all. $ErrorActionPreference = 'Stop' turns the
+        # CommandNotFoundException terminating, so the exit-code check below would
+        # never be reached without this.
+        return $null
+    }
+
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commonDir)) {
+        return $null
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
+        $commonDir = Join-Path $repoRoot $commonDir
+    }
+
+    $resolved = Resolve-Path -Path $commonDir -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        return $null
+    }
+
+    # <main repo>\.git  ->  <main repo>
+    $global:SmartHomeMainWorktreeRoot = Split-Path $resolved.Path -Parent
+    return $global:SmartHomeMainWorktreeRoot
+}
+
+function Test-SmartHomeLinkedWorktree {
+    # True only when this checkout is provably a linked worktree. The main working
+    # tree is false, and so is a checkout git cannot answer for -- a caller that
+    # seeds a worktree from its main checkout must not act on a guess.
+    $mainRoot = Get-SmartHomeMainWorktreeRoot
+    if (-not $mainRoot) {
+        return $false
+    }
+
+    return ($mainRoot.TrimEnd('\', '/') -ne (Get-SmartHomeRepoRoot).TrimEnd('\', '/'))
+}
+
 function Get-SiblingRoot {
     $override = [Environment]::GetEnvironmentVariable('SMARTHOME_NANOFW_ROOT')
     if (-not [string]::IsNullOrWhiteSpace($override)) {
@@ -199,27 +262,14 @@ function Get-SiblingRoot {
     # whatever directory this script happens to run from. Inside a linked git
     # worktree (.claude\worktrees\<name>) the plain parent directory would be the
     # worktrees folder, which would clone 14 nanoFramework repos into it and hide
-    # the siblings the main checkout already has. Resolve the main working tree via
-    # git's common dir instead; fall back to the plain parent when git can't answer
-    # (no git on PATH, not a repo, an exported source tree).
-    $repoRoot = Get-SmartHomeRepoRoot
-
-    $commonDir = git -C $repoRoot rev-parse --git-common-dir 2>$null
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($commonDir)) {
-        if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
-            $commonDir = Join-Path $repoRoot $commonDir
-        }
-
-        $resolved = Resolve-Path -Path $commonDir -ErrorAction SilentlyContinue
-        if ($resolved) {
-            # <main repo>\.git  ->  <main repo>  ->  the directory holding it
-            $mainRepoRoot = Split-Path $resolved.Path -Parent
-            $global:SmartHomeSiblingRoot = Split-Path $mainRepoRoot -Parent
-            return $global:SmartHomeSiblingRoot
-        }
+    # the siblings the main checkout already has. Fall back to the plain parent only
+    # when git can't answer at all.
+    $mainRoot = Get-SmartHomeMainWorktreeRoot
+    if (-not $mainRoot) {
+        $mainRoot = Get-SmartHomeRepoRoot
     }
 
-    $global:SmartHomeSiblingRoot = Split-Path $repoRoot -Parent
+    $global:SmartHomeSiblingRoot = Split-Path $mainRoot -Parent
     return $global:SmartHomeSiblingRoot
 }
 

--- a/scripts/Initialize-Worktree.ps1
+++ b/scripts/Initialize-Worktree.ps1
@@ -25,11 +25,12 @@
     config file is missing, which is the very state this script exists to repair.
 
 .PARAMETER NoRestore
-    Skip the packages\ restore and copy the config files only. The restore is the slow
-    part of a first run (the copy is a few milliseconds; the restore has to copy every
-    referenced package folder out of the local NuGet cache), so this is the switch to
-    pass when something cheap needs to run unattended -- a SessionStart hook, say --
-    or when packages\ is known good.
+    Skip the packages\ restore and copy the config files only. The restore is the
+    larger half of the work, but not by as much as it sounds: a fresh worktree seeds
+    in about 1.6s all in, an already-seeded one re-runs in 0.5s, and the config copy
+    alone is 0.03s. So this switch is for when packages\ is known good, not a default
+    to reach for -- skipping the restore leaves the CS0518 wall in place for the first
+    build, which is the failure this script exists to prevent.
 
 .PARAMETER MainWorktree
     Root of the working tree to copy the config files from. Defaults to the main
@@ -42,7 +43,7 @@
 
 .EXAMPLE
     .\scripts\Initialize-Worktree.ps1 -NoRestore
-    Copy the config files only. Fast enough to run on every session start.
+    Copy the config files only, leaving packages\ alone.
 #>
 
 [CmdletBinding()]
@@ -63,12 +64,17 @@ $scriptsDir = Get-SmartHomeScriptsDir
 # ------------------------------------------------------------- which checkout? --
 
 if ($MainWorktree) {
-    if (-not (Test-Path $MainWorktree)) {
-        Write-Error "-MainWorktree does not exist: $MainWorktree"
+    # -LiteralPath throughout this script, never -Path. -Path interprets [ and ] as
+    # wildcards, and both are legal in a Windows directory name: with the repository
+    # at "C:\repos\SmartHome [wip]", Test-Path -Path reports False for a directory
+    # that exists, so a perfectly good -MainWorktree is rejected as missing and an
+    # already-present config file is copied over instead of kept.
+    if (-not (Test-Path -LiteralPath $MainWorktree -PathType Container)) {
+        Write-Error "-MainWorktree is not an existing directory: $MainWorktree"
         exit 1
     }
 
-    $sourceRoot = (Resolve-Path $MainWorktree).Path
+    $sourceRoot = (Resolve-Path -LiteralPath $MainWorktree).Path
 
     if ($sourceRoot.TrimEnd('\', '/') -eq $repoRoot.TrimEnd('\', '/')) {
         Write-Error @"
@@ -126,19 +132,19 @@ foreach ($name in $configFiles) {
     $destination = Join-Path $scriptsDir $name
     $source = Join-Path $sourceScripts $name
 
-    if (Test-Path $destination) {
+    if (Test-Path -LiteralPath $destination) {
         Write-Host "  kept:    scripts\$name (already present)" -ForegroundColor DarkGray
         $kept++
         continue
     }
 
-    if (-not (Test-Path $source)) {
+    if (-not (Test-Path -LiteralPath $source)) {
         Write-Host "  MISSING: scripts\$name -- not in $sourceScripts either" -ForegroundColor Red
         $absent.Add($name)
         continue
     }
 
-    Copy-Item -Path $source -Destination $destination
+    Copy-Item -LiteralPath $source -Destination $destination
     Write-Host "  copied:  scripts\$name" -ForegroundColor Green
     $copied++
 }

--- a/scripts/Initialize-Worktree.ps1
+++ b/scripts/Initialize-Worktree.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+    Seed a fresh linked git worktree with the machine-local setup a clone never carries.
+
+.DESCRIPTION
+    `git worktree add` copies tracked files and nothing else, so a new worktree under
+    .claude\worktrees\<name> starts without scripts\local.env.ps1, without
+    scripts\nanoFramework.local.env.ps1 and without packages\ -- all three are
+    git-ignored. The main checkout beside it is fully configured, which makes the
+    failure confusing rather than obvious: the first script call aborts at its own
+    first line with "Missing: ...\scripts\local.env.ps1", and the first build emits a
+    wall of CS0518 across every project, which reads like broken source.
+
+    This script copies both config files across from the main working tree and
+    restores packages\, so a worktree is usable immediately after `git worktree add`.
+
+    Idempotent and safe to call unconditionally:
+      - In the main working tree it reports that and exits 0, changing nothing.
+      - A config file that already exists is left alone, never overwritten -- a
+        worktree may deliberately carry an edited copy (a different COM port for a
+        second device, a different broker port).
+      - Restore-Packages.ps1 skips every package already present.
+
+    It deliberately does NOT use Import-SmartHomeLocalEnv: that helper exits when the
+    config file is missing, which is the very state this script exists to repair.
+
+.PARAMETER NoRestore
+    Skip the packages\ restore and copy the config files only. The restore is the slow
+    part of a first run (the copy is a few milliseconds; the restore has to copy every
+    referenced package folder out of the local NuGet cache), so this is the switch to
+    pass when something cheap needs to run unattended -- a SessionStart hook, say --
+    or when packages\ is known good.
+
+.PARAMETER MainWorktree
+    Root of the working tree to copy the config files from. Defaults to the main
+    working tree, resolved via `git rev-parse --git-common-dir`. Override it when the
+    machine-local config lives in some other checkout.
+
+.EXAMPLE
+    .\scripts\Initialize-Worktree.ps1
+    Seed this worktree: copy both config files, then restore packages\.
+
+.EXAMPLE
+    .\scripts\Initialize-Worktree.ps1 -NoRestore
+    Copy the config files only. Fast enough to run on every session start.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$NoRestore,
+
+    [string]$MainWorktree
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Common.ps1')
+
+$repoRoot = Get-SmartHomeRepoRoot
+$scriptsDir = Get-SmartHomeScriptsDir
+
+# ------------------------------------------------------------- which checkout? --
+
+if ($MainWorktree) {
+    if (-not (Test-Path $MainWorktree)) {
+        Write-Error "-MainWorktree does not exist: $MainWorktree"
+        exit 1
+    }
+
+    $sourceRoot = (Resolve-Path $MainWorktree).Path
+
+    if ($sourceRoot.TrimEnd('\', '/') -eq $repoRoot.TrimEnd('\', '/')) {
+        Write-Error @"
+-MainWorktree points at this checkout ($repoRoot), so there is nothing to copy from.
+Point it at the checkout that already has scripts\local.env.ps1.
+"@
+        exit 1
+    }
+}
+else {
+    # Not a linked worktree -- nothing to seed. Exit 0 rather than erroring: this
+    # script is meant to be called unconditionally (from a hook, from a skill, from
+    # the top of another script), and "you are in the main checkout" is a normal
+    # outcome, not a failure.
+    if (-not (Test-SmartHomeLinkedWorktree)) {
+        $mainRoot = Get-SmartHomeMainWorktreeRoot
+        if ($mainRoot) {
+            Write-Host "Not a linked worktree -- this is the main working tree ($repoRoot). Nothing to seed." -ForegroundColor DarkGray
+        }
+        else {
+            # Test-SmartHomeLinkedWorktree is false for "git could not answer" too,
+            # and that is a different situation worth naming: an exported source tree
+            # or a machine with no git still needs its config files, this script just
+            # cannot find where to copy them from.
+            Write-Host "Could not ask git which working tree this is -- assuming the main checkout. Nothing to seed." -ForegroundColor Yellow
+            Write-Host "  If this IS a worktree, pass -MainWorktree <path to the main checkout>." -ForegroundColor DarkGray
+        }
+
+        exit 0
+    }
+
+    $sourceRoot = Get-SmartHomeMainWorktreeRoot
+}
+
+$sourceScripts = Join-Path $sourceRoot 'scripts'
+
+Write-Host "Seeding worktree: $repoRoot" -ForegroundColor Cyan
+Write-Host "  from: $sourceRoot" -ForegroundColor DarkGray
+Write-Host ""
+
+# ------------------------------------------------------------------ config files --
+
+# Both are git-ignored, so neither ever arrives with a worktree. Named here rather
+# than derived, because the templates beside them are not the thing to copy: a
+# template has the machine's values blanked out, and seeding a worktree from one
+# would trade "missing file" for "file present, values empty" -- a later failure that
+# reads worse.
+$configFiles = @('local.env.ps1', 'nanoFramework.local.env.ps1')
+
+$copied = 0
+$kept = 0
+$absent = New-Object System.Collections.Generic.List[string]
+
+foreach ($name in $configFiles) {
+    $destination = Join-Path $scriptsDir $name
+    $source = Join-Path $sourceScripts $name
+
+    if (Test-Path $destination) {
+        Write-Host "  kept:    scripts\$name (already present)" -ForegroundColor DarkGray
+        $kept++
+        continue
+    }
+
+    if (-not (Test-Path $source)) {
+        Write-Host "  MISSING: scripts\$name -- not in $sourceScripts either" -ForegroundColor Red
+        $absent.Add($name)
+        continue
+    }
+
+    Copy-Item -Path $source -Destination $destination
+    Write-Host "  copied:  scripts\$name" -ForegroundColor Green
+    $copied++
+}
+
+if ($absent.Count -gt 0) {
+    Write-Host ""
+    $templateHints = ($absent | ForEach-Object {
+        $template = $_ -replace '\.ps1$', '.template.ps1'
+        "    Copy-Item `"$(Join-Path $scriptsDir $template)`" `"$(Join-Path $scriptsDir $_)`""
+    }) -join "`n"
+
+    Write-Error @"
+$($absent.Count) config file(s) could not be seeded: $($absent -join ', ')
+The source checkout does not have them either, so this is first-time setup on this
+machine rather than a worktree that missed out. Copy the templates and fill them in:
+
+$templateHints
+
+Then re-run this script, or see the "First-time setup" section of CLAUDE.md.
+"@
+    exit 1
+}
+
+# --------------------------------------------------------------------- packages\ --
+
+if ($NoRestore) {
+    Write-Host ""
+    Write-Host "Skipping the packages\ restore (-NoRestore). Run .\scripts\Restore-Packages.ps1 before building." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Worktree seeded: $copied copied, $kept already present." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ""
+
+# Reused rather than reimplemented: Restore-Packages.ps1 owns the cache layout, the
+# already-present check and the "not in the local cache either" message. Invoked as
+# this worktree's own copy, so it restores into this worktree's packages\.
+#
+# try/catch as well as the exit-code check: the restore can also fail by *throwing*
+# rather than exiting -- a Copy-Item that hits Windows' 260-character path limit does,
+# which a deep worktree path makes reachable. Without the catch that exception would
+# propagate as a raw stack trace, hiding the one thing worth saying here (the config
+# half is already seeded, so a re-run only has to redo the restore).
+$restoreExit = 0
+try {
+    & (Join-Path $scriptsDir 'Restore-Packages.ps1')
+    $restoreExit = $LASTEXITCODE
+}
+catch {
+    Write-Host ""
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    $restoreExit = 1
+}
+
+if ($restoreExit -ne 0) {
+    # Restore-Packages.ps1 has already said which packages and why. Don't restate it;
+    # do say that the config half of the seed did land, so a re-run is not needed for
+    # that part.
+    Write-Error @"
+Config files are seeded, but the packages\ restore failed (exit $restoreExit). See the
+message above. Re-run .\scripts\Restore-Packages.ps1 once it is addressed -- the config
+files are already in place and will not be copied again.
+"@
+    exit $restoreExit
+}
+
+Write-Host ""
+Write-Host "Worktree seeded: $copied config file(s) copied, $kept already present, packages\ restored." -ForegroundColor Green
+Write-Host "Check it with: .\scripts\Test-Setup.ps1" -ForegroundColor DarkGray
+
+# Explicit success code, same reason as Restore-Packages.ps1: callers read
+# $LASTEXITCODE, and without this it would carry whatever the last native command
+# happened to leave behind.
+exit 0

--- a/scripts/Test-Setup.ps1
+++ b/scripts/Test-Setup.ps1
@@ -64,29 +64,15 @@ function Test-OnPath {
     return $null
 }
 
-# The main working tree, when this is running inside a linked worktree. Used only to
-# make the remediation for a missing local.env concrete: the file is git-ignored, so
-# a fresh worktree never has one even though the main checkout is fully configured.
-function Get-MainCheckoutRoot {
-    try {
-        $commonDir = & git -C $repoRoot rev-parse --path-format=absolute --git-common-dir 2>$null
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commonDir)) {
-            return $null
-        }
-
-        $mainRoot = Split-Path $commonDir -Parent
-        if ($mainRoot -and ($mainRoot.TrimEnd('\') -ne $repoRoot.TrimEnd('\'))) {
-            return $mainRoot
-        }
-    }
-    catch {
-        # git absent, or not a repository. The template hint still applies.
-    }
-
-    return $null
+# The main working tree, when this is running inside a linked worktree; $null in the
+# main checkout and whenever git cannot answer. Used only to steer the remediation:
+# both config files and packages\ are git-ignored, so a fresh worktree has none of
+# them even though the main checkout is fully configured -- and Initialize-Worktree.ps1
+# fixes all three in one call, which is a better answer than three separate ones.
+$mainCheckout = $null
+if (Test-SmartHomeLinkedWorktree) {
+    $mainCheckout = Get-SmartHomeMainWorktreeRoot
 }
-
-$mainCheckout = Get-MainCheckoutRoot
 
 # ---------------------------------------------------------------- config files --
 
@@ -110,8 +96,8 @@ foreach ($config in $configFiles) {
     if (-not (Test-Path $path)) {
         $fix = "Copy-Item `"$template`" `"$path`"  (then fill it in)"
         if ($mainCheckout) {
-            $fix = "Copy-Item `"$(Join-Path $mainCheckout "scripts\$($config.Name)")`" `"$scriptsDir`"  " +
-                   "-- this is a worktree; the file is git-ignored, so it did not come along"
+            $fix = ".\scripts\Initialize-Worktree.ps1  -- this is a worktree; the file is git-ignored, " +
+                   "so it did not come along. That copies it from $mainCheckout and restores packages\ too"
         }
 
         Add-Result -Name "scripts\$($config.Name)" -Status 'FAIL' -Detail 'missing' -Fix $fix
@@ -279,8 +265,15 @@ elseif ($missingPackages.Count -eq 0) {
     Add-Result -Name 'packages\' -Status 'OK' -Detail "all packages restored ($($configs.Count) packages.config)"
 }
 else {
+    # In a worktree, name the one script that fixes this row and the config rows
+    # together -- a fresh worktree is normally missing all of them at once.
+    $packagesFix = '.\scripts\Restore-Packages.ps1 -- otherwise every project fails to compile with CS0518, which looks like broken source'
+    if ($mainCheckout) {
+        $packagesFix = '.\scripts\Initialize-Worktree.ps1 -- otherwise every project fails to compile with CS0518, which looks like broken source'
+    }
+
     Add-Result -Name 'packages\' -Status 'FAIL' -Detail "$($missingPackages.Count) package(s) not restored, e.g. $($missingPackages[0])" `
-               -Fix '.\scripts\Restore-Packages.ps1 -- otherwise every project fails to compile with CS0518, which looks like broken source'
+               -Fix $packagesFix
 }
 
 # The unit-test adapter lives inside packages\, so this only means anything once the
@@ -291,8 +284,13 @@ if ($adapterDir) {
     Add-Result -Name 'nanoFramework test adapter' -Status 'OK' -Detail $adapterDir
 }
 else {
+    $adapterFix = '.\scripts\Restore-Packages.ps1 -- Run-Tests.ps1 cannot run without it'
+    if ($mainCheckout) {
+        $adapterFix = '.\scripts\Initialize-Worktree.ps1 -- Run-Tests.ps1 cannot run without it'
+    }
+
     Add-Result -Name 'nanoFramework test adapter' -Status 'FAIL' -Detail 'nanoFramework.TestAdapter.dll not in packages\' `
-               -Fix '.\scripts\Restore-Packages.ps1 -- Run-Tests.ps1 cannot run without it'
+               -Fix $adapterFix
 }
 
 # -------------------------------------------------------------- sibling repos --


### PR DESCRIPTION
## The problem

`git worktree add` brings tracked files and nothing else. A worktree under `.claude\worktrees\<name>` therefore starts with none of the three things every script here needs — `scripts\local.env.ps1`, `scripts\nanoFramework.local.env.ps1`, `packages\` — because all three are git-ignored. The main checkout right beside it is fully configured, which is what makes the failure confusing rather than obvious: the first script call aborts at its own first line with `Missing: ...\scripts\local.env.ps1`, and the first build emits `CS0518` in every project, which reads like broken source.

`CLAUDE.md` documented the manual recipe and `Test-Setup.ps1` printed a filled-in `Copy-Item`, but nothing actually did it, so every session in a worktree started by repairing this by hand.

## What this adds

**`scripts\Initialize-Worktree.ps1`** — copies both config files from the main working tree, then restores `packages\` by invoking `Restore-Packages.ps1` rather than reimplementing it.

- Idempotent. An existing config file is **kept, never overwritten** — a worktree may deliberately carry an edited copy (a second device's COM port, a different broker port).
- The main checkout is a clean exit-0 no-op, so calling it unconditionally is safe.
- A source checkout that has no config files either is reported as *first-time machine setup*, with the template `Copy-Item` spelled out — it deliberately does not seed from a template, which would trade "file missing" for "file present, values empty", a later failure that reads worse.
- `-NoRestore` for the config half alone; `-MainWorktree <path>` to copy from somewhere else.

**A `SessionStart` hook**, so this is genuinely automatic rather than something a session must remember. New `.claude\settings.json` holds only this hook. Matcher `startup`; exec form (`powershell.exe` plus an argument list, no shell) so it does not depend on whether Git Bash is on PATH; script path via `${CLAUDE_PROJECT_DIR}`.

The full seed was chosen over the cheap config-only variant after measuring — the restore turned out not to be the slow part it was assumed to be:

| Run | Time |
|---|---|
| Fresh worktree, config files + restore | 1.61s |
| Re-run, everything already present | 0.54s |
| `-NoRestore` (config files only) | 0.03s |
| Main checkout (no-op) | one `git rev-parse` |

**`.claude\skills\smarthome-init-worktree\`** — the matching skill, following the shape of the other `smarthome-*` skills.

## Finding the main checkout

Via `git rev-parse --git-common-dir` — the main repository's `.git`, shared by every linked worktree, whose parent is the main working tree. Not by the relative `..\..\..` that `CLAUDE.md` used to document: that is only correct for a worktree exactly three levels down.

That lookup already existed **twice** — inline in `Get-SiblingRoot`, and again as `Test-Setup.ps1`'s own `Get-MainCheckoutRoot`. Both now call the shared `Get-SmartHomeMainWorktreeRoot` / `Test-SmartHomeLinkedWorktree` in `Common.ps1`.

One behaviour change came with that extraction, deliberately: the shared copy catches the `CommandNotFoundException` that `git` throws when it is not on PATH at all. `Get-SiblingRoot` documented that fallback ("fall back to the plain parent when git can't answer — no git on PATH...") but could not reach it, because `$ErrorActionPreference = 'Stop'` made the throw terminating before its exit-code check ran. The new script needs that path to actually work, so it now does.

## Docs

- `CLAUDE.md`: new row in the script table; "A fresh worktree starts with none of it" now points at the script instead of giving the manual recipe, and explains the hook; the prerequisite failure table names the script for the two rows it repairs.
- `Test-Setup.ps1` now names `Initialize-Worktree.ps1` as the fix for **every** row it would repair — both config files, `packages\`, and the test adapter — instead of a `Copy-Item` that covered only one of them.

## Verification

Desk work only. **Nothing here touches hardware** — no deploy, no unit suite, no integration suite, and per `CLAUDE.md` those are not run without asking.

Exercised in throwaway worktrees created with `git worktree add` and removed afterwards:

| Case | Result |
|---|---|
| Fresh worktree, first run | Both config files copied, 29 packages restored, exit 0 |
| Same worktree, second run | `kept:` both files, 0 restored, exit 0 |
| `-NoRestore` | Config half only, exit 0 |
| Main checkout | "Not a linked worktree ... Nothing to seed", exit 0, nothing written |
| `-MainWorktree` pointing at this checkout | Refused with a reason, exit 1 |
| `-MainWorktree` pointing at a checkout with no config files | Both reported MISSING, template `Copy-Item` printed for each, exit 1 |
| `Test-Setup.ps1` in the seeded worktree | 16 checked, 0 failed, 0 warned, exit 0 |
| `Test-Setup.ps1` in an unseeded worktree | 4 FAILs, all naming `Initialize-Worktree.ps1` as the fix, exit 1 |

The hook's exact command was dry-run in exec form with the placeholder resolved by hand, and seeded this worktree.

CI builds every project and runs the unit tests on the nanoclr virtual device; it cannot run the integration suite, and nothing in this change affects device code.

## Filed, not fixed

Two verified findings outside this diff, both in `Restore-Packages.ps1`:

- #68 — it recurses into `.claude\worktrees`, so running it from the main checkout restores every worktree's packages into the main checkout's `packages\` (127 `packages.config` found instead of 14). `Test-Setup.ps1` already guards against exactly this; `Restore-Packages.ps1` shares the glob and did not get the guard.
- #69 — a MAX_PATH failure is reported as "part of the path could not be found", which reads as a missing file rather than a path-length limit, and leaves a partial package folder that the next run counts as restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
