### PR TITLE
feat(scripts): rank by what verifying an issue needs, not where the edit is

### DIFF
--- a/.claude/skills/smarthome-prioritize/SKILL.md
+++ b/.claude/skills/smarthome-prioritize/SKILL.md
@@ -143,6 +143,11 @@ the ranking script.
 Any axis may be set. An overridden axis reports confidence `Override`, and the heuristic's own
 value stays in the JSON under `Heuristic` so the two can be compared.
 
+Setting `Where` alone raises a warning. It describes where the edit lands and carries no
+multiplier — `VerifyNeeds` is the axis that moves a row for a session with or without the
+device — so an override file written before the two were split corrects the report and not the
+ranking. Set `VerifyNeeds` when the intent was to move something.
+
 | Axis | Accepted values |
 |---|---|
 | `Trust`, `EvidenceDebt`, `Blocked` | JSON `true` / `false` — **unquoted** |
@@ -180,7 +185,9 @@ names ESP32 packages; a Homie library issue walks through the conformance check)
 body first put 33 of 37 issues in `Hardware`, which is an axis carrying no information. A
 body-derived call is therefore reported at confidence `Low` however many patterns fired: on the
 37 issues in this repository every title-derived call was right, and every wrong one came from
-the body. **`Low` on `VerifyNeeds` means read the issue before trusting the rank.**
+the body. The ranking table marks those rows `Hardware?`, `CI?`, `None?` — **a `?` on `Verify`
+means read the issue before trusting the rank.** Roughly half the backlog carries one, so this
+is not a rare corner; `-Json` carries the same thing as `VerifyFromBody`.
 
 ## The eight axes
 
@@ -223,7 +230,9 @@ hardware-gated, device available x1.25 ; large, deep session x1.3 ; theme Capabi
 ```
 
 Flags in the title column: `T` verification trust, `E` evidence debt, `U` unblocks another
-issue, `B` blocked.
+issue, `B` blocked. A `?` after the `Verify` value is separate from those: it means that axis
+was read from the issue body rather than its title, which is the least reliable call the script
+makes.
 
 ## What this does not decide
 

--- a/.claude/skills/smarthome-prioritize/SKILL.md
+++ b/.claude/skills/smarthome-prioritize/SKILL.md
@@ -7,7 +7,7 @@ description: Analyse the GitHub backlog, classify it into clusters, then ask a t
 
 The repository's labels (`type:`, `area:`, `status:`) classify an issue but never rank it —
 nothing in them decides between eleven `type: task` issues. `Get-BacklogPriorities.ps1` adds
-the seven axes that do, and this skill runs it in **two rounds with an interview between
+the eight axes that do, and this skill runs it in **two rounds with an interview between
 them**. The order matters: the interview asks the user to choose among clusters that are
 already on screen with real issue numbers in them, not among abstractions.
 
@@ -46,8 +46,15 @@ Two things to get right:
   and ranks nothing.
 
 The hardware question is the one that changes the answer most, because CI here cannot run the
-integration suite — roughly two thirds of this backlog is hardware-gated, and asking for it
-while the device is on someone's desk in another room wastes the session.
+integration suite — roughly three quarters of this backlog cannot be *verified* without the
+device, and asking for it while the device is on someone's desk in another room wastes the
+session.
+
+It keys off `VerifyNeeds`, not `Where`, and those two disagree for a whole class of issue here.
+Host-side tooling for the integration suite — `Run-IntegrationTests.ps1`, the capture helpers,
+the verdict functions — is edited at a desk and can be proved by nothing but a real suite run.
+Ranking it as desk work is what issue #57 was about, and it moved those issues further than any
+other single axis, because this multiplier is the largest one in the script.
 
 ## Round 3 — re-rank and commit to an order
 
@@ -72,7 +79,7 @@ many (3, 4 or 5 is the useful range) rather than picking a number — it is the 
 ```
 
 `-Handoff N` prints the selected issues with their url, axes, full scoring trail, any override
-note, and a marker on the hardware-gated ones. Three kinds of row are never handed out, however
+note, and a marker on the ones whose `VerifyNeeds` is `Hardware`. Three kinds of row are never handed out, however
 high they rank:
 
 - **blocked** — it names what it is waiting for, not work that can start
@@ -119,9 +126,15 @@ back so the ranking stays reproducible. Write a JSON file and re-run:
 ```json
 {
   "54": { "Effort": "S", "Note": "one guard around an already-exited subscriber" },
-  "26": { "Unblocks": [14, 35], "Risk": "Friction" }
+  "26": { "Unblocks": [14, 35], "Risk": "Friction" },
+  "57": { "VerifyNeeds": "None", "Note": "proved by re-running the ranking script, not the suite" }
 }
 ```
+
+The `57` row is the standing example of the `VerifyNeeds` blind spot: that issue's body quotes
+`Run-IntegrationTests.ps1` and `src/integrationTests` throughout, so the fallback reads it as
+hardware-verified, while the only thing that proves a change to the ranking script is running
+the ranking script.
 
 ```powershell
 .\scripts\Get-BacklogPriorities.ps1 -Overrides .\overrides.json -RankingOnly
@@ -134,6 +147,7 @@ value stays in the JSON under `Heuristic` so the two can be compared.
 |---|---|
 | `Trust`, `EvidenceDebt`, `Blocked` | JSON `true` / `false` — **unquoted** |
 | `Where` | `Hardware`, `Desk`, `Either`, `Unknown` |
+| `VerifyNeeds` | `Hardware`, `CI`, `None`, `Unknown` |
 | `Track` | `Capability`, `Velocity`, `Either`, `Unknown` |
 | `Risk` | `SilentWrong`, `LoudFailure`, `Friction`, `Cosmetic` |
 | `Effort` | `S`, `M`, `L` |
@@ -159,15 +173,25 @@ judgment, not a durable fact about the backlog.
 The `Needs a human call` cluster is the script naming its own blind spots: it lists every issue
 where at least one axis found no signal at all. Those are the first bodies worth reading.
 
-## The seven axes
+`VerifyNeeds` names a second blind spot through its confidence instead. It scores the **title
+and labels** first and falls back to the body only when those say nothing at all — the title
+says what an issue *is*, while every body in this repo mentions the device (the Dependabot issue
+names ESP32 packages; a Homie library issue walks through the conformance check). Scoring the
+body first put 33 of 37 issues in `Hardware`, which is an axis carrying no information. A
+body-derived call is therefore reported at confidence `Low` however many patterns fired: on the
+37 issues in this repository every title-derived call was right, and every wrong one came from
+the body. **`Low` on `VerifyNeeds` means read the issue before trusting the rank.**
 
-Four are specific to this repository, three are generic.
+## The eight axes
+
+Five are specific to this repository, three are generic.
 
 | Axis | Question | Weight |
 |---|---|---|
 | **Trust** | Can this make a check *lie* — pass silently, lose its evidence, mask a real failure? | +30, the heaviest single term |
 | **EvidenceDebt** | Does it name a constant, default or calibration asserted without measurement? | +15 |
-| **Where** | `Hardware` (needs the ESP32, probe or broker present) or `Desk` (CI can verify it) | session multiplier, ×0.15 to ×1.25 |
+| **Where** | Where the *edit* lands: `Hardware` (device-side code) or `Desk` (host-side source, scripts, docs) | none — descriptive only |
+| **VerifyNeeds** | What *proving* it takes: `Hardware` (a real device run), `CI` (the unit suite or a build), `None` (any desk) | session multiplier, ×0.15 to ×1.25 |
 | **Track** | `Capability` (ships device behaviour) or `Velocity` (speeds the dev loop) | theme multiplier only |
 | **Risk** | `SilentWrong` > `LoudFailure` > `Friction` > `Cosmetic` | 40 / 25 / 10 / 3 |
 | **Effort** | S / M / L | +8 / 0 / −6, then ×1.4 to ×0.5 by time budget |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style | No | `smarthome-restore-packages` |
 | `scripts\Initialize-Worktree.ps1 [-NoRestore] [-MainWorktree <path>]` | Seeds a fresh linked worktree with the three git-ignored things `git worktree add` never brings: both `local.env` files, copied from the main working tree, and a restored `packages\`. Idempotent — never overwrites a config file the worktree already has, and no-ops with exit 0 in the main checkout, so it is safe to call unconditionally | No | `smarthome-init-worktree` |
 | `scripts\Clean-GitBranches.ps1 [-Worktrees] [-Delete] [-Scope Local\|Remote\|Both] [-Protect <names>]` | Classifies every worktree and every local and remote branch against `origin/main` and, with `-Delete`, removes the merged ones in one batch. Report-only without it. Keeps the base branch, anything with an open pull request, anything unmerged, and — unless `-Worktrees` frees them — the branches worktrees pin. A dirty worktree is never removed, and there is deliberately no flag that overrides that | No | `smarthome-clean-branches` |
-| `scripts\Get-BacklogPriorities.ps1 [-Hardware ...] [-TimeBudget ...] [-Theme ...] [-Overrides <path>] [-Handoff <n>] [-RankingOnly] [-Top <n>] [-Json]` | Classifies every open issue on seven axes the labels don't cover — verification trust, evidence debt, hardware-gated vs desk, capability vs velocity, risk, effort, what it unblocks — then clusters and ranks them. Run plain first; the interview in the skill turns the answers into the weighting flags for a second run. Classification is a keyword heuristic that reports its own confidence and blind spots, and `-Overrides` is how a read of the actual bodies corrects it | No | `smarthome-prioritize` |
+| `scripts\Get-BacklogPriorities.ps1 [-Hardware ...] [-TimeBudget ...] [-Theme ...] [-Overrides <path>] [-Handoff <n>] [-RankingOnly] [-Top <n>] [-Json]` | Classifies every open issue on eight axes the labels don't cover — verification trust, evidence debt, where the edit lands, what verifying it needs, capability vs velocity, risk, effort, what it unblocks — then clusters and ranks them. Run plain first; the interview in the skill turns the answers into the weighting flags for a second run. Classification is a keyword heuristic that reports its own confidence and blind spots, and `-Overrides` is how a read of the actual bodies corrects it | No | `smarthome-prioritize` |
 | `scripts\Test-Setup.ps1` | Reports everything the other scripts assume exists on this machine — both `local.env` files and their values, restored `packages\`, the test adapter, `gh` auth, MSBuild/vstest, Mosquitto, the COM port, the companion repos — all at once, rather than one abort at a time. Read-only; opens no port and touches no device | No | `smarthome-check-setup` |
 | `scripts\Watch-DeviceSerial.ps1 [-DurationSeconds <n>] [-NoReset]` | Raw serial capture of the device's native boot log only — nanoCLR silences this at `app_main()` and switches to binary WireProtocol, so this can't see managed output | Resets only | `smarthome-watch-serial` |
 | `scripts\Watch-DeviceDebugOutput.ps1 [-DurationSeconds <n>] [-NoReboot] [-NoBuild] [-BuildOnly] [-Until <regex>] [-DumpConfig]` | Real managed-code debug output (`Debug.WriteLine`, exceptions) via `tools\DeviceDebugMonitor` — no VS needed, same library VS's debugger extension uses | Resets only | `smarthome-watch-debug-output` |
@@ -551,8 +551,17 @@ When the question is *what to work on next* rather than *what exists*, use
 `scripts\Get-BacklogPriorities.ps1` (skill: `smarthome-prioritize`), which scores the backlog
 on the axes the labels leave out and then re-weights for whether the device is reachable, how
 much time there is, and which cluster to work in. `-Handoff <n>` closes the loop by printing
-the top few as spin-off pointers — blocked and closed rows skipped, hardware-gated ones marked
-so the confirm-before-device-scripts rule reaches the session that picks them up.
+the top few as spin-off pointers — blocked and closed rows skipped, the ones needing hardware
+to verify marked so the confirm-before-device-scripts rule reaches the session that picks them
+up.
+
+Two of its axes look alike and are not. `Where` says where the *edit* lands; `VerifyNeeds` says
+what *proving* it takes, and the device-availability weighting — the largest multiplier in the
+script — keys off the second. They disagree for every host-side tool that only a real suite run
+can exercise: `Run-IntegrationTests.ps1` and the capture helpers are edited at a desk and
+verified on hardware. `VerifyNeeds` is read from the issue title first and from the body only
+as a fallback, because every body in this repo mentions the device; a body-derived call is
+reported at confidence `Low` and is the one to check before trusting a rank.
 
 ### File what you find
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,7 +561,9 @@ script — keys off the second. They disagree for every host-side tool that only
 can exercise: `Run-IntegrationTests.ps1` and the capture helpers are edited at a desk and
 verified on hardware. `VerifyNeeds` is read from the issue title first and from the body only
 as a fallback, because every body in this repo mentions the device; a body-derived call is
-reported at confidence `Low` and is the one to check before trusting a rank.
+reported at confidence `Low`, marked `?` in the ranking table, and is the one to check before
+trusting a rank. An `-Overrides` file that sets `Where` alone now warns, because before the
+split that key was how a row got moved and it no longer is.
 
 ### File what you find
 

--- a/scripts/Get-BacklogPriorities.ps1
+++ b/scripts/Get-BacklogPriorities.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Classify the open GitHub backlog on seven axes and rank it, optionally re-weighted
+    Classify the open GitHub backlog on eight axes and rank it, optionally re-weighted
     for the session you are actually about to have.
 
 .DESCRIPTION
@@ -25,16 +25,22 @@
     caller reads the issue bodies, decides, and hands the decisions back, so the ranking
     stays reproducible instead of living in a conversation.
 
-    The seven axes, and what each answers:
+    The eight axes, and what each answers:
 
       Trust        Can this issue make a check lie -- silently pass, lose its evidence,
                    or mask a real failure? Weighted hardest, because every other verdict
                    in this repo rests on the checks being honest.
       EvidenceDebt Does it name a constant, default or calibration asserted without
                    measurement? A latent wrong answer, not a cosmetic one.
-      Where        Hardware (needs the ESP32, probe or broker physically present) or Desk
-                   (doable anywhere, CI can verify it). Splits the backlog into two
-                   schedulable pools, because CI here cannot run the integration suite.
+      Where        Where the edit lands: Hardware (device-side code) or Desk (host-side
+                   source, scripts, docs). Descriptive only -- it carries no multiplier.
+      VerifyNeeds  What PROVING the change takes: Hardware (a real device run), CI (the
+                   unit suite or a build), or None (any desk). This is what splits the
+                   backlog into two schedulable pools, because CI here cannot run the
+                   integration suite -- and it is a different question from Where. Host-side
+                   tooling for the integration suite is edited at the desk and can only be
+                   proved on hardware; Where answered for both until it was split out, and
+                   reported Desk for exactly that class.
       Track        Capability (ships device behaviour) or Velocity (speeds the dev loop).
       Risk         What leaving it open costs: SilentWrong > LoudFailure > Friction >
                    Cosmetic. The worst band that fires wins; risks are not summed.
@@ -47,9 +53,9 @@
     authenticated `gh`.
 
 .PARAMETER Hardware
-    Session shape. Available raises hardware-gated issues, Unavailable pushes them down
-    to near-zero (they are still listed -- suppressed, not deleted). Unknown (default)
-    leaves them alone.
+    Session shape. Available raises issues that need hardware to verify, Unavailable
+    pushes them down to near-zero (they are still listed -- suppressed, not deleted).
+    Unknown (default) leaves them alone. It reads VerifyNeeds, not Where.
 
 .PARAMETER TimeBudget
     Quick favours small issues, Deep favours large ones, HalfDay (default) is neutral.
@@ -57,19 +63,21 @@
 .PARAMETER Theme
     Cluster to work in this session: Trust, EvidenceDebt, Capability, Velocity, Hardware,
     or Any (default). The matching cluster is raised and everything else damped; nothing
-    is filtered out.
+    is filtered out. Hardware here means VerifyNeeds Hardware -- what needs the device to
+    prove, not what is edited device-side.
 
 .PARAMETER Overrides
     Path to a JSON file of per-issue corrections, as produced after reading the bodies:
 
         { "35": { "Trust": true, "Effort": "S", "Note": "single Write-Host guard" },
-          "26": { "Where": "Hardware", "Risk": "Friction" } }
+          "26": { "VerifyNeeds": "Hardware", "Risk": "Friction" } }
 
     Must be a JSON object keyed by issue number; an array wrapper is rejected rather than
     silently ignored. Accepted axes and values:
 
       Trust, EvidenceDebt, Blocked  JSON true / false, unquoted
       Where                         Hardware | Desk | Either | Unknown
+      VerifyNeeds                   Hardware | CI | None | Unknown
       Track                         Capability | Velocity | Either | Unknown
       Risk                          SilentWrong | LoudFailure | Friction | Cosmetic
       Effort                        S | M | L
@@ -103,8 +111,8 @@
 
 .PARAMETER Handoff
     Print the top N as pointers for spinning each one off into its own session: url, axes,
-    the full scoring trail, any override note, and a marker on the hardware-gated ones so
-    the confirm-before-device-scripts rule reaches the new session.
+    the full scoring trail, any override note, and a marker on the ones that need hardware
+    to verify, so the confirm-before-device-scripts rule reaches the new session.
 
     Three kinds of row are never handed out, however high they rank: blocked (it names what
     it is waiting for, not work that can start), closed (settled), and in-progress (a
@@ -253,6 +261,28 @@ $rules = @(
     @{ Axis = 'Desk'; W = 2; P = 'refactor|dispatch|rename|README|CONTRIBUTING|CLAUDE\.md|documentation|\bdocs?\b'; Why = 'source or doc change only' }
     @{ Axis = 'Desk'; W = 1; P = 'script|\.ps1|helper|parse|regex'; Why = 'host-side tooling' }
 
+    # --- VerifyNeeds: Hardware ------------------------------------------------
+    # Deliberately a different vocabulary from the Where rules above, because the two axes
+    # ask different questions and the same words do not answer both. Host-side tooling for
+    # the integration suite is a desk *edit* whose only proof is a real suite run, so the
+    # suite's own nouns -- its runner, its projects, its verdict machinery -- weigh as
+    # hardware here while Where goes on reading the edit exactly as it did.
+    @{ Axis = 'VerifyHardware'; W = 3; P = 'ESP32|COM\s*port|flash(ed|ing)?|on-?device|device-?side|real\s+hardware|BMP280|ADS1115|I2C|solder|wiring'; Why = 'only the device can show it' }
+    @{ Axis = 'VerifyHardware'; W = 3; P = 'integration\s+(suite|test)|Run-IntegrationTests|integrationTests|conformance|broker\s+outage'; Why = 'proved only by an integration-suite run' }
+    @{ Axis = 'VerifyHardware'; W = 3; P = 'WifiCheck|MqttCheck|Bmp280Check|MqttReconnectCheck|HomieClientCheck'; Why = 'names an on-device check' }
+    @{ Axis = 'VerifyHardware'; W = 2; P = 'commission|probe|self-?hosted\s+runner|Deploy-ToDevice|nanoff|deploy(ment)?[-\s]?(partition|padding)|DeployPartition|retained[-\s]store|\[ITEST\]'; Why = 'needs the physical setup' }
+    @{ Axis = 'VerifyHardware'; W = 1; P = 'sensor|driver|firmware|relay|actuator'; Why = 'device-side behaviour' }
+
+    # --- VerifyNeeds: CI ------------------------------------------------------
+    @{ Axis = 'VerifyCI'; W = 3; P = 'unit\s+test|nanoclr|virtual\s+device|NFUnitTest|UnitTests?\b|HomieClientTests'; Why = 'the unit suite can prove it' }
+    @{ Axis = 'VerifyCI'; W = 2; P = '\bCI\b|GitHub\s+Actions?|workflow|Dependabot|MinVer|releases?\b'; Why = 'the pipeline can prove it' }
+    @{ Axis = 'VerifyCI'; W = 1; P = 'builds?\s+every|compil'; Why = 'a build proves it' }
+
+    # --- VerifyNeeds: None ----------------------------------------------------
+    @{ Axis = 'VerifyNone'; W = 3; P = 'README|CONTRIBUTING|CLAUDE\.md|documentation|documented|\bdocs?\b'; Why = 'prose only' }
+    @{ Axis = 'VerifyNone'; W = 2; P = 'wording|spelling|typo|rename'; Why = 'no behaviour to prove' }
+    @{ Axis = 'VerifyNone'; W = 1; P = 'script|\.ps1|helper|parse|regex'; Why = 'host-side, runs anywhere' }
+
     # --- Track: Capability ----------------------------------------------------
     @{ Axis = 'Capability'; W = 3; P = 'IrrigationControl|OvenControl|RoomSensor|RainwaterCistern|new\s+device'; Why = 'device application' }
     @{ Axis = 'Capability'; W = 2; P = 'stub|not\s+implemented|\bempty\b|Homie|actuator|relay|\bMCP\b|Skills\s+Discovery'; Why = 'shippable behaviour' }
@@ -326,6 +356,7 @@ $overrideSchema = [ordered]@{
     EvidenceDebt = 'Boolean'
     Blocked      = 'Boolean'
     Where        = @('Hardware', 'Desk', 'Either', 'Unknown')
+    VerifyNeeds  = @('Hardware', 'CI', 'None', 'Unknown')
     Track        = @('Capability', 'Velocity', 'Either', 'Unknown')
     Risk         = @('SilentWrong', 'LoudFailure', 'Friction', 'Cosmetic')
     Effort       = @('S', 'M', 'L')
@@ -499,6 +530,18 @@ foreach ($issue in $issues) {
     $debtHits = Get-AxisHits -Axis 'EvidenceDebt' -Text $text
     $hardwareHits = Get-AxisHits -Axis 'Hardware' -Text $text
     $deskHits = Get-AxisHits -Axis 'Desk' -Text $text
+    # VerifyNeeds reads the subject line first, not the whole issue. The title says what an
+    # issue IS; the body says what it MENTIONS, and in this repo every body mentions the
+    # device -- the Dependabot issue names ESP32 packages, a Homie library issue walks
+    # through the conformance check, this very issue quotes `Run-IntegrationTests.ps1`.
+    # Scoring the body first made 33 of 37 issues read as hardware-verified, which is an
+    # axis carrying no information at all. The body is the fallback for a title that says
+    # nothing, and what it produces is reported at Low confidence.
+    $verifySubject = "$($issue.title)`n$($labels -join ' ')"
+    $verifyScope = 'title'
+    $verifyHardwareHits = Get-AxisHits -Axis 'VerifyHardware' -Text $verifySubject
+    $verifyCiHits = Get-AxisHits -Axis 'VerifyCI' -Text $verifySubject
+    $verifyNoneHits = Get-AxisHits -Axis 'VerifyNone' -Text $verifySubject
     $capabilityHits = Get-AxisHits -Axis 'Capability' -Text $text
     $velocityHits = Get-AxisHits -Axis 'Velocity' -Text $text
 
@@ -506,11 +549,14 @@ foreach ($issue in $issues) {
     $debtScore = Get-HitScore $debtHits
     $hardwareScore = Get-HitScore $hardwareHits
     $deskScore = Get-HitScore $deskHits
+    $verifyHardwareScore = Get-HitScore $verifyHardwareHits
+    $verifyCiScore = Get-HitScore $verifyCiHits
+    $verifyNoneScore = Get-HitScore $verifyNoneHits
     $capabilityScore = Get-HitScore $capabilityHits
     $velocityScore = Get-HitScore $velocityHits
 
     # Labels are evidence too, and stronger than prose: someone chose them deliberately.
-    if ($labels -contains 'area: sensor') { $hardwareScore += 3; $capabilityScore += 2 }
+    if ($labels -contains 'area: sensor') { $hardwareScore += 3; $verifyHardwareScore += 3; $capabilityScore += 2 }
     if ($labels -contains 'area: homie') { $capabilityScore += 2 }
     if ($labels -contains 'area: infra') { $velocityScore += 3 }
     if ($labels -contains 'type: feature') { $capabilityScore += 3 }
@@ -522,6 +568,41 @@ foreach ($issue in $issues) {
     if ($hardwareScore -gt $deskScore) { $where = 'Hardware' }
     elseif ($deskScore -gt $hardwareScore) { $where = 'Desk' }
     elseif ($hardwareScore -gt 0) { $where = 'Either' }
+
+    # VerifyNeeds asks what *proving* the change takes, which is a different question from
+    # where the edit lands and answers differently for a whole class of issue here: host-side
+    # tooling for the integration suite reads as desk work because the prose is about scripts
+    # and parsing, while nothing but a real suite run can show the change works. Where used to
+    # answer for both and carried the session multiplier, so that disagreement moved an issue
+    # further than any other single axis (#57).
+    #
+    # Ties resolve to the stricter environment rather than to Unknown, because the two
+    # mistakes do not cost the same: calling hardware work desk work burns a session that
+    # cannot finish it, while the reverse only sorts a desk issue lower than it deserved in a
+    # session that has the device anyway.
+    if (($verifyHardwareScore + $verifyCiScore + $verifyNoneScore) -eq 0) {
+        $verifyScope = 'body'
+        $verifyHardwareHits = Get-AxisHits -Axis 'VerifyHardware' -Text $body
+        $verifyCiHits = Get-AxisHits -Axis 'VerifyCI' -Text $body
+        $verifyNoneHits = Get-AxisHits -Axis 'VerifyNone' -Text $body
+        $verifyHardwareScore = Get-HitScore $verifyHardwareHits
+        $verifyCiScore = Get-HitScore $verifyCiHits
+        $verifyNoneScore = Get-HitScore $verifyNoneHits
+    }
+
+    $verifyTop = [Math]::Max($verifyHardwareScore, [Math]::Max($verifyCiScore, $verifyNoneScore))
+    $verifyNeeds = 'Unknown'
+    if ($verifyTop -gt 0) {
+        if ($verifyHardwareScore -eq $verifyTop) { $verifyNeeds = 'Hardware' }
+        elseif ($verifyCiScore -eq $verifyTop) { $verifyNeeds = 'CI' }
+        else { $verifyNeeds = 'None' }
+    }
+
+    # A body-derived call is capped at Low however many patterns fired. On the 37 issues in
+    # this repository every title-derived call was right and every wrong one came from the
+    # body, so the score is not what separates them -- the scope is.
+    $verifyConfidence = Get-Confidence $verifyTop
+    if ($verifyScope -eq 'body' -and $verifyConfidence -ne 'None') { $verifyConfidence = 'Low' }
 
     $track = 'Unknown'
     if ($capabilityScore -gt $velocityScore) { $track = 'Capability' }
@@ -572,13 +653,14 @@ foreach ($issue in $issues) {
         Trust        = $trust
         EvidenceDebt = $debt
         Where        = $where
+        VerifyNeeds  = $verifyNeeds
         Track        = $track
         Risk         = $risk
         Effort       = $effort
         DependsOn    = $dependsOn
         Unblocks     = @()
         Heuristic    = [pscustomobject]@{
-            Trust = $trust; EvidenceDebt = $debt; Where = $where
+            Trust = $trust; EvidenceDebt = $debt; Where = $where; VerifyNeeds = $verifyNeeds
             Track = $track; Risk = $risk; Effort = $effort
         }
         Overridden   = @()
@@ -586,6 +668,7 @@ foreach ($issue in $issues) {
             Trust        = Get-Confidence $trustScore
             EvidenceDebt = Get-Confidence $debtScore
             Where        = Get-Confidence ([Math]::Max($hardwareScore, $deskScore))
+            VerifyNeeds  = $verifyConfidence
             Track        = Get-Confidence ([Math]::Max($capabilityScore, $velocityScore))
             Risk         = Get-Confidence (Get-HitScore $riskHits)
             Effort       = $effortConfidence
@@ -595,6 +678,10 @@ foreach ($issue in $issues) {
             EvidenceDebt = @($debtHits | ForEach-Object { $_.Why })
             Hardware     = @($hardwareHits | ForEach-Object { $_.Why })
             Desk         = @($deskHits | ForEach-Object { $_.Why })
+            VerifyScope  = $verifyScope
+            VerifyHardware = @($verifyHardwareHits | ForEach-Object { $_.Why })
+            VerifyCI     = @($verifyCiHits | ForEach-Object { $_.Why })
+            VerifyNone   = @($verifyNoneHits | ForEach-Object { $_.Why })
             Capability   = @($capabilityHits | ForEach-Object { $_.Why })
             Velocity     = @($velocityHits | ForEach-Object { $_.Why })
             Risk         = @($riskHits | ForEach-Object { $_.Why })
@@ -611,7 +698,7 @@ foreach ($issue in $issues) {
 
 # Blocked is overridable even though it comes from a label: an issue can be waiting on
 # something real without anyone having relabelled it, and the body is what says so.
-Set-OverriddenAxes -Records $records -Axes @('Trust', 'EvidenceDebt', 'Where', 'Track', 'Risk', 'Effort', 'Blocked', 'DependsOn', 'Note')
+Set-OverriddenAxes -Records $records -Axes @('Trust', 'EvidenceDebt', 'Where', 'VerifyNeeds', 'Track', 'Risk', 'Effort', 'Blocked', 'DependsOn', 'Note')
 
 # ---------------------------------------------------------- dependency edges ----
 
@@ -685,13 +772,17 @@ foreach ($record in $records) {
 
     # ---- session weighting: multiplicative, so the base score stays readable ----
 
-    if ($record.Where -eq 'Hardware') {
-        if ($Hardware -eq 'Unavailable') { $score *= 0.15; $why += 'hardware-gated, device unavailable x0.15' }
-        elseif ($Hardware -eq 'Available') { $score *= 1.25; $why += 'hardware-gated, device available x1.25' }
+    # Keyed on VerifyNeeds rather than Where: the question a session with or without the
+    # device needs answered is whether it can PROVE the change, not where the edit is typed.
+    # This is the largest multiplier in the script, so it belongs on the axis that actually
+    # answers it (#57).
+    if ($record.VerifyNeeds -eq 'Hardware') {
+        if ($Hardware -eq 'Unavailable') { $score *= 0.15; $why += 'needs hardware to verify, device unavailable x0.15' }
+        elseif ($Hardware -eq 'Available') { $score *= 1.25; $why += 'needs hardware to verify, device available x1.25' }
     }
-    elseif ($record.Where -eq 'Desk' -and $Hardware -eq 'Available') {
+    elseif (@('CI', 'None') -contains $record.VerifyNeeds -and $Hardware -eq 'Available') {
         $score *= 0.9
-        $why += 'desk work while the device is free x0.9'
+        $why += 'verifiable without the device while it is free x0.9'
     }
 
     if ($TimeBudget -eq 'Quick') {
@@ -710,7 +801,7 @@ foreach ($record in $records) {
             'EvidenceDebt' { $matchesTheme = $record.EvidenceDebt }
             'Capability' { $matchesTheme = ($record.Track -eq 'Capability') }
             'Velocity' { $matchesTheme = ($record.Track -eq 'Velocity') }
-            'Hardware' { $matchesTheme = ($record.Where -eq 'Hardware') }
+            'Hardware' { $matchesTheme = ($record.VerifyNeeds -eq 'Hardware') }
         }
         if ($matchesTheme) { $score *= 1.5; $why += "theme $Theme x1.5" }
         else { $score *= 0.7; $why += "off theme $Theme x0.7" }
@@ -843,12 +934,12 @@ Write-Cluster -Title 'Capability' -Color Green -Items @($ranked | Where-Object {
     -Meaning 'ships device behaviour'
 Write-Cluster -Title 'Velocity' -Color Blue -Items @($ranked | Where-Object { $_.Track -eq 'Velocity' }) `
     -Meaning 'speeds the dev loop'
-Write-Cluster -Title 'Hardware-gated' -Color Magenta -Items @($ranked | Where-Object { $_.Where -eq 'Hardware' }) `
-    -Meaning 'needs the ESP32, probe or broker present; CI cannot verify these'
+Write-Cluster -Title 'Hardware-gated' -Color Magenta -Items @($ranked | Where-Object { $_.VerifyNeeds -eq 'Hardware' }) `
+    -Meaning 'only a real device run can prove these; CI cannot, wherever the edit lands'
 Write-Cluster -Title 'Blocked' -Color DarkGray -Items @($ranked | Where-Object { $_.Blocked }) `
     -Meaning 'status: blocked - the body names what it is waiting for'
 
-$unclassified = @($ranked | Where-Object { $_.Where -eq 'Unknown' -or $_.Track -eq 'Unknown' -or $_.Confidence.Effort -eq 'None' })
+$unclassified = @($ranked | Where-Object { $_.Where -eq 'Unknown' -or $_.VerifyNeeds -eq 'Unknown' -or $_.Track -eq 'Unknown' -or $_.Confidence.Effort -eq 'None' })
 if ($unclassified.Count -gt 0) {
     Write-Cluster -Title 'Needs a human call' -Color DarkYellow -Items $unclassified `
         -Meaning 'no signal on at least one axis - read the body and correct it with -Overrides'
@@ -859,8 +950,8 @@ if ($unclassified.Count -gt 0) {
 Write-Host ''
 Write-Host 'RANKING' -ForegroundColor White
 Write-Host ''
-Write-Host ('  {0,-4} {1,-6} {2,-7} {3,-9} {4,-12} {5,-6} {6,-11} {7}' -f 'Rank', 'Issue', 'Prio', 'Where', 'Risk', 'Effort', 'Track', 'Title')
-Write-Host ('  ' + ('-' * 112)) -ForegroundColor DarkGray
+Write-Host ('  {0,-4} {1,-6} {2,-4} {3,-8} {4,-8} {5,-12} {6,-6} {7,-11} {8}' -f 'Rank', 'Issue', 'Prio', 'Where', 'Verify', 'Risk', 'Effort', 'Track', 'Title')
+Write-Host ('  ' + ('-' * 117)) -ForegroundColor DarkGray
 
 $shown = if ($Top -gt 0) { @($ranked | Select-Object -First $Top) } else { $ranked }
 $rank = 0
@@ -885,8 +976,8 @@ foreach ($record in $shown) {
     if ($record.Blocked) { $color = 'DarkGray' }
     if ($record.State -ne 'OPEN') { $color = 'DarkGray' }
 
-    Write-Host ('  {0,-4} #{1,-5} {2,-7} {3,-9} {4,-12} {5,-6} {6,-11} {7}' -f `
-            $rank, $record.Number, $record.Relative, $record.Where, $record.Risk, $record.Effort, $record.Track, $title) -ForegroundColor $color
+    Write-Host ('  {0,-4} #{1,-5} {2,-4} {3,-8} {4,-8} {5,-12} {6,-6} {7,-11} {8}' -f `
+            $rank, $record.Number, $record.Relative, $record.Where, $record.VerifyNeeds, $record.Risk, $record.Effort, $record.Track, $title) -ForegroundColor $color
 }
 
 if ($Top -gt 0 -and $ranked.Count -gt $Top) {
@@ -905,8 +996,8 @@ if ($Handoff -gt 0) {
         Write-Host ''
         Write-Host ("  #{0} - {1}" -f $record.Number, $record.Title) -ForegroundColor Cyan
         Write-Host ("    {0}" -f $record.Url) -ForegroundColor DarkGray
-        Write-Host ("    prio {0}  {1}  risk {2}  effort {3}  {4}" -f `
-                $record.Relative, $record.Where, $record.Risk, $record.Effort, $record.Track)
+        Write-Host ("    prio {0}  edit {1}  verify {2}  risk {3}  effort {4}  {5}" -f `
+                $record.Relative, $record.Where, $record.VerifyNeeds, $record.Risk, $record.Effort, $record.Track)
         Write-Host ("    why: {0}" -f (@($record.Why) -join ' ; ')) -ForegroundColor DarkGray
 
         if (@($record.Overridden).Count -gt 0) {
@@ -918,7 +1009,7 @@ if ($Handoff -gt 0) {
         if (@($record.Unblocks).Count -gt 0) {
             Write-Host ("    unblocks: {0}" -f ((@($record.Unblocks) | ForEach-Object { "#$_" }) -join ', ')) -ForegroundColor DarkGray
         }
-        if ($record.Where -eq 'Hardware') {
+        if ($record.VerifyNeeds -eq 'Hardware') {
             Write-Host '    HARDWARE: the handoff prompt must carry the confirm-before-device-scripts rule.' -ForegroundColor Yellow
         }
     }
@@ -933,6 +1024,8 @@ Write-Host ''
 $flagLegend = '  Flags: T verification trust, E evidence debt, U unblocks another issue, B blocked'
 if ($State -ne 'open') { $flagLegend += ', C closed' }
 Write-Host $flagLegend -ForegroundColor DarkGray
+Write-Host '  Where is where the edit lands; Verify is what proving it needs, and is the axis' -ForegroundColor DarkGray
+Write-Host '  the -Hardware session weighting keys off. They disagree, and that is the point.' -ForegroundColor DarkGray
 Write-Host '  Prio is 0-100 against the top of this run, so the two rounds share one scale.' -ForegroundColor DarkGray
 if ($weighted) {
     Write-Host '  It is session-weighted; the raw and unweighted values are Score and BaseScore in -Json.' -ForegroundColor DarkGray

--- a/scripts/Get-BacklogPriorities.ps1
+++ b/scripts/Get-BacklogPriorities.ps1
@@ -275,7 +275,7 @@ $rules = @(
 
     # --- VerifyNeeds: CI ------------------------------------------------------
     @{ Axis = 'VerifyCI'; W = 3; P = 'unit\s+test|nanoclr|virtual\s+device|NFUnitTest|UnitTests?\b|HomieClientTests'; Why = 'the unit suite can prove it' }
-    @{ Axis = 'VerifyCI'; W = 2; P = '\bCI\b|GitHub\s+Actions?|workflow|Dependabot|MinVer|releases?\b'; Why = 'the pipeline can prove it' }
+    @{ Axis = 'VerifyCI'; W = 2; P = '\bCI\b|GitHub\s+Actions?|workflow|Dependabot|MinVer|\breleases?\b'; Why = 'the pipeline can prove it' }
     @{ Axis = 'VerifyCI'; W = 1; P = 'builds?\s+every|compil'; Why = 'a build proves it' }
 
     # --- VerifyNeeds: None ----------------------------------------------------
@@ -654,6 +654,10 @@ foreach ($issue in $issues) {
         EvidenceDebt = $debt
         Where        = $where
         VerifyNeeds  = $verifyNeeds
+        # Not folded into Signals: every member of that object is a list of the Why strings
+        # that fired, and a bare scalar among them breaks anything walking it. This is also
+        # what the report marks with `?`, so it belongs where the axis it qualifies is.
+        VerifyFromBody = ($verifyScope -eq 'body')
         Track        = $track
         Risk         = $risk
         Effort       = $effort
@@ -678,7 +682,6 @@ foreach ($issue in $issues) {
             EvidenceDebt = @($debtHits | ForEach-Object { $_.Why })
             Hardware     = @($hardwareHits | ForEach-Object { $_.Why })
             Desk         = @($deskHits | ForEach-Object { $_.Why })
-            VerifyScope  = $verifyScope
             VerifyHardware = @($verifyHardwareHits | ForEach-Object { $_.Why })
             VerifyCI     = @($verifyCiHits | ForEach-Object { $_.Why })
             VerifyNone   = @($verifyNoneHits | ForEach-Object { $_.Why })
@@ -699,6 +702,27 @@ foreach ($issue in $issues) {
 # Blocked is overridable even though it comes from a label: an issue can be waiting on
 # something real without anyone having relabelled it, and the body is what says so.
 Set-OverriddenAxes -Records $records -Axes @('Trust', 'EvidenceDebt', 'Where', 'VerifyNeeds', 'Track', 'Risk', 'Effort', 'Blocked', 'DependsOn', 'Note')
+
+# A corrected VerifyNeeds is the caller's judgment, not a reading of the body, so the marker
+# that says "this came from the body" has to go with the value it described.
+foreach ($record in $records) {
+    if (@($record.Overridden) -contains 'VerifyNeeds') { $record.VerifyFromBody = $false }
+}
+
+# Where stopped carrying the session multiplier when VerifyNeeds took it over, so correcting
+# it now changes the report and not the ranking. Accepting that in silence is the same
+# failure the strict validation above exists to prevent -- and the pre-split help gave
+# { "26": { "Where": "Hardware", "Risk": "Friction" } } as its worked example, so an override
+# file written against the shipped docs is the likely case rather than the odd one. A warning
+# rather than an error: correcting Where is still legitimate, it just no longer moves a row.
+$inertWhere = @($overrideMap.Keys | Where-Object {
+        $overrideMap[$_].ContainsKey('Where') -and -not $overrideMap[$_].ContainsKey('VerifyNeeds')
+    } | Sort-Object { [int]$_ })
+if ($inertWhere.Count -gt 0) {
+    Write-Warning ("Overrides set Where without VerifyNeeds for #$($inertWhere -join ', #'). " +
+        'Where describes the edit and no longer weights the ranking; VerifyNeeds carries the ' +
+        'device-availability multiplier. Set VerifyNeeds too if the intent was to move these rows.')
+}
 
 # ---------------------------------------------------------- dependency edges ----
 
@@ -950,8 +974,8 @@ if ($unclassified.Count -gt 0) {
 Write-Host ''
 Write-Host 'RANKING' -ForegroundColor White
 Write-Host ''
-Write-Host ('  {0,-4} {1,-6} {2,-4} {3,-8} {4,-8} {5,-12} {6,-6} {7,-11} {8}' -f 'Rank', 'Issue', 'Prio', 'Where', 'Verify', 'Risk', 'Effort', 'Track', 'Title')
-Write-Host ('  ' + ('-' * 117)) -ForegroundColor DarkGray
+Write-Host ('  {0,-4} {1,-6} {2,-4} {3,-8} {4,-9} {5,-12} {6,-6} {7,-11} {8}' -f 'Rank', 'Issue', 'Prio', 'Where', 'Verify', 'Risk', 'Effort', 'Track', 'Title')
+Write-Host ('  ' + ('-' * 118)) -ForegroundColor DarkGray
 
 $shown = if ($Top -gt 0) { @($ranked | Select-Object -First $Top) } else { $ranked }
 $rank = 0
@@ -976,8 +1000,15 @@ foreach ($record in $shown) {
     if ($record.Blocked) { $color = 'DarkGray' }
     if ($record.State -ne 'OPEN') { $color = 'DarkGray' }
 
-    Write-Host ('  {0,-4} #{1,-5} {2,-4} {3,-8} {4,-8} {5,-12} {6,-6} {7,-11} {8}' -f `
-            $rank, $record.Number, $record.Relative, $record.Where, $record.VerifyNeeds, $record.Risk, $record.Effort, $record.Track, $title) -ForegroundColor $color
+    # `?` is the axis admitting where it read the answer. A body-derived call is right about
+    # three times in four against a hand-labelled reading of this backlog, where a
+    # title-derived one has not yet been wrong -- and the multiplier it feeds is the largest
+    # in the script, so the difference has to be on screen and not only in -Json.
+    $verifyCell = $record.VerifyNeeds
+    if ($record.VerifyFromBody) { $verifyCell += '?' }
+
+    Write-Host ('  {0,-4} #{1,-5} {2,-4} {3,-8} {4,-9} {5,-12} {6,-6} {7,-11} {8}' -f `
+            $rank, $record.Number, $record.Relative, $record.Where, $verifyCell, $record.Risk, $record.Effort, $record.Track, $title) -ForegroundColor $color
 }
 
 if ($Top -gt 0 -and $ranked.Count -gt $Top) {
@@ -996,8 +1027,10 @@ if ($Handoff -gt 0) {
         Write-Host ''
         Write-Host ("  #{0} - {1}" -f $record.Number, $record.Title) -ForegroundColor Cyan
         Write-Host ("    {0}" -f $record.Url) -ForegroundColor DarkGray
+        $verifyText = $record.VerifyNeeds
+        if ($record.VerifyFromBody) { $verifyText += ' (read from the body, low confidence)' }
         Write-Host ("    prio {0}  edit {1}  verify {2}  risk {3}  effort {4}  {5}" -f `
-                $record.Relative, $record.Where, $record.VerifyNeeds, $record.Risk, $record.Effort, $record.Track)
+                $record.Relative, $record.Where, $verifyText, $record.Risk, $record.Effort, $record.Track)
         Write-Host ("    why: {0}" -f (@($record.Why) -join ' ; ')) -ForegroundColor DarkGray
 
         if (@($record.Overridden).Count -gt 0) {
@@ -1026,6 +1059,8 @@ if ($State -ne 'open') { $flagLegend += ', C closed' }
 Write-Host $flagLegend -ForegroundColor DarkGray
 Write-Host '  Where is where the edit lands; Verify is what proving it needs, and is the axis' -ForegroundColor DarkGray
 Write-Host '  the -Hardware session weighting keys off. They disagree, and that is the point.' -ForegroundColor DarkGray
+Write-Host '  Verify marked ? was read from the issue body, not its title, and is the least' -ForegroundColor DarkGray
+Write-Host '  reliable call the script makes - read that body before trusting its rank.' -ForegroundColor DarkGray
 Write-Host '  Prio is 0-100 against the top of this run, so the two rounds share one scale.' -ForegroundColor DarkGray
 if ($weighted) {
     Write-Host '  It is session-weighted; the raw and unweighted values are Score and BaseScore in -Json.' -ForegroundColor DarkGray


### PR DESCRIPTION
Closes #57.

## What was wrong

`Get-BacklogPriorities.ps1` used one axis, `Where`, to answer two different questions: *where does the edit land* and *what does proving it require*. They differ for a whole class of issue in this repository — host-side tooling for the integration suite is edited at a desk and can be proved by nothing but a real suite run — and `Where` carried the largest multiplier in the script (×0.15 when the device is unavailable, ×1.25 when it is), so a misread there moved an issue further than any other single axis.

## What this does

Issue #57 offered two fixes and asked for one. This is the first: **split the axis.**

- `Where` keeps its rules and its meaning — where the edit lands — and now carries **no multiplier at all**. Its classification is byte-identical to before this change for all 37 issues in the backlog.
- A new `VerifyNeeds` axis answers `Hardware` / `CI` / `None`, with its own rule set.
- The device-availability weighting, the `-Theme Hardware` match, the *Hardware-gated* cluster and the `-Handoff` device-confirm marker all key off `VerifyNeeds` instead.
- `VerifyNeeds` is overridable like every other axis, and the schema rejects a value outside `Hardware | CI | None | Unknown` the same way the others do.

## The part worth reviewing: title-first scoring

The obvious implementation — score the whole issue the way every other axis does — is degenerate here. It put **33 of 37 issues in `Hardware`**, which is an axis carrying no information, and would have damped the entire backlog by ×0.15 in a desk session.

The reason is that the title says what an issue *is* while the body says what it *mentions*, and in this repository every body mentions the device. The Dependabot issue names ESP32 packages. A Homie library issue walks through the conformance check. Issue #57 itself quotes `Run-IntegrationTests.ps1` and `src/integrationTests` throughout.

So `VerifyNeeds` scores the **title and labels** first, and falls back to the body only when the subject line says nothing at all. Measured against a hand-labelled reading of all 37 issues (open and closed):

| scoring | correct |
|---|---|
| whole issue, body included | 27 / 37 (73%) |
| title and labels first, body as fallback | **33 / 37 (89%)** |

Every title-derived call was right. All four misses came from the body fallback — so a body-derived call is reported at confidence `Low` however many patterns fired, and the skill now says that `Low` on this axis means read the issue before trusting the rank.

The four residual misses are #57, #33, #13 and #10. All are documented as the axis's known blind spot, and `-Overrides` is the correction path the issue itself named. #57 is now the standing example in `SKILL.md`, since its body reads as hardware-verified while the only thing that proves a change to the ranking script is running the ranking script.

## Verification

No hardware involved — this script is read-only, opens no port and touches no device.

- Ran against the live backlog (`-State all`, 37 issues) before and after: `Where` unchanged for every issue.
- `-Overrides` with `"VerifyNeeds": "None"` applies and reports confidence `Override`; `"VerifyNeeds": "Desk"` is rejected with `expected one of: Hardware, CI, None, Unknown`.
- `-Handoff` marks the rows whose `VerifyNeeds` is `Hardware`, and prints `edit`/`verify` separately.
- Plain run, `-RankingOnly`, `-Top`, `-Json` and `-Theme` all exercised.
- The split visibly does its job: with `-Hardware Unavailable`, #68/#69/#71 (desk edits, desk proof) rise while #35/#20/#18 (desk edits, hardware proof) fall — the second group used to be ranked as desk work.

CI builds the solution and runs the unit tests; neither covers this script, and the repository has no PowerShell test harness.

## Docs

`CLAUDE.md` and the `smarthome-prioritize` skill both updated: eight axes rather than seven, the two axes named apart, the title-vs-body scope rule and what `Low` confidence means on this axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
