### PR TITLE
fix(scripts): wait for a message, not for a byte, before publishing into a capture

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -559,12 +559,21 @@ function Get-SmartHomeRecordedProcess {
         return $null
     }
 
-    if ($Record['Name'] -and $process.ProcessName -ne $Record['Name']) {
-        return $null
-    }
+    # Both comparisons inside the try, and that is not tidiness. Get-Process hands back an
+    # object whose name and start time are fetched lazily, so a process that exits in the
+    # gap between the lookup above and either read throws "Process has exited, so the
+    # requested information is not available" -- terminating under the callers'
+    # $ErrorActionPreference = 'Stop'. That gap is not hypothetical for a caller polling
+    # this in a loop precisely while the process is expected to die (Start-HomieCapture's
+    # connect wait), and a throw there escapes before that caller can hand back what it
+    # started, orphaning it. A process that vanished mid-check is exactly the "not running"
+    # this function reports; it must not be an error.
+    try {
+        if ($Record['Name'] -and $process.ProcessName -ne $Record['Name']) {
+            return $null
+        }
 
-    if ($Record['StartTime']) {
-        try {
+        if ($Record['StartTime']) {
             $recorded = [datetime]::Parse(
                 $Record['StartTime'],
                 [cultureinfo]::InvariantCulture,
@@ -574,9 +583,9 @@ function Get-SmartHomeRecordedProcess {
                 return $null
             }
         }
-        catch {
-            return $null
-        }
+    }
+    catch {
+        return $null
     }
 
     return $process

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -850,9 +850,17 @@ function Start-HomieCapture {
         # a healthy device.
         #
         # A subscriber to homie/# gets the whole retained store the moment it subscribes,
-        # so the first byte in the output file is the connection being live. Callers that
-        # only want the settled result do not need this: their 3s sleep starts before the
-        # connection and is a window, not a measurement of anything published inside it.
+        # so a delivered MESSAGE is the connection being live. Not a non-empty file: the
+        # subscriber's stderr is redirected into the same file (the '2>&1' below), so its
+        # first byte can be a diagnostic about a connection that never happened, and the
+        # wait would then report the very thing it exists to establish. Measured for #59:
+        # against a port with nothing listening this returned after 2.39s of a 5s budget,
+        # with 'Error: ... the target machine actively refused it' as the only content.
+        # So the wait below reads lines through ConvertFrom-HomieCaptureLine, which already
+        # tells a message from a diagnostic, and a diagnostic delays it rather than ending
+        # it. Callers that only want the settled result do not need this: their 3s sleep
+        # starts before the connection and is a window, not a measurement of anything
+        # published inside it.
         [int]$WaitForConnectSeconds = 0
     )
 
@@ -904,20 +912,72 @@ function Start-HomieCapture {
     # -- and Get-SmartHomeRecordedProcess skips its name comparison for a record that
     # carries no name. A record built after the wait would therefore fall back to the
     # start-time window alone, silently giving up the recycled-pid defence this record is
-    # here for. The wait really can outlive the launcher: against an unreachable broker it
-    # returns at ~2.4s, satisfied by the subscriber's own error rather than by a message
-    # (#59), and the launcher is gone by 3s.
+    # here for. The wait really can outlive the launcher: against an unreachable broker
+    # mosquitto_sub is gone by ~2.4s and no message ever arrives, so the wait runs to its
+    # own deadline unless it notices -- which is why it checks this record for liveness.
     $record = New-SmartHomeProcessRecord -Label 'homie snapshot subscriber' -Process $process -Tree
 
     if ($WaitForConnectSeconds -gt 0) {
         $connectDeadline = (Get-Date).AddSeconds($WaitForConnectSeconds)
-        while ((Get-Date) -lt $connectDeadline) {
-            $captured = Get-Item -Path $out -ErrorAction SilentlyContinue
-            if ($null -ne $captured -and $captured.Length -gt 0) {
+        $connected = $false
+        $diagnostics = @()
+        $subscriberGone = $false
+
+        while ($true) {
+            # A live read of a file another process is still writing, the same way
+            # Wait-ForAnnounceWitnessed reads the long-running subscriber log: cmd.exe's
+            # redirect shares the file for reading, and Get-Content takes a fresh view
+            # each pass rather than holding one open.
+            $captured = @(Get-Content -LiteralPath $out -ErrorAction SilentlyContinue)
+            $messages = @($captured | Where-Object { $null -ne (ConvertFrom-HomieCaptureLine -Line $_) })
+
+            if ($messages.Count -gt 0) {
+                $connected = $true
+                break
+            }
+
+            # Kept for the report below, not to end the wait: everything mosquitto_sub can
+            # write here before its subscription is live is a diagnostic, and none of them
+            # mean it is listening.
+            $diagnostics = @($captured | Where-Object { $_ -match '\S' })
+
+            # Nothing will arrive from a subscriber that has exited, and against an
+            # unreachable broker it exits at ~2.4s. Without this the wait would spend its
+            # whole budget on a process that is already gone -- which is what the old
+            # length test accidentally avoided, by breaking on that process's own error.
+            # Through the recorded process rather than the raw pid so a pid Windows has
+            # since reissued does not read as "still connecting".
+            if ($null -eq (Get-SmartHomeRecordedProcess -Record $record)) {
+                $subscriberGone = $true
+                break
+            }
+
+            if ((Get-Date) -ge $connectDeadline) {
                 break
             }
 
             Start-Sleep -Milliseconds 100
+        }
+
+        # Said here, where the difference is known. The caller is about to publish into
+        # this window and read the response out of it, so "no message arrived" has to be
+        # distinguishable afterwards from "the device did not answer" -- and it is not,
+        # from the captured lines alone. A warning rather than a throw, for the reason
+        # Stop-HomieCapture warns: the callers close their window in a finally, and a
+        # throw here would leave that window open.
+        if (-not $connected) {
+            $detail = if ($diagnostics.Count -gt 0) {
+                'it wrote only diagnostics: {0}' -f ($diagnostics -join ' / ')
+            }
+            elseif ($subscriberGone) {
+                'it exited without recording a reason'
+            }
+            else {
+                'it recorded nothing at all'
+            }
+
+            $ended = if ($subscriberGone) { 'exited first' } else { "did not within {0}s" -f $WaitForConnectSeconds }
+            Write-Warning ("The snapshot subscriber never delivered a message, so it may not have been subscribed when this window opened and anything published into it can be missed ({0}; {1}; capture file: {2})." -f $ended, $detail, $out)
         }
     }
 

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -949,6 +949,17 @@ function Start-HomieCapture {
             # since reissued does not read as "still connecting".
             if ($null -eq (Get-SmartHomeRecordedProcess -Record $record)) {
                 $subscriberGone = $true
+
+                # Read once more before believing the classification above. It came from a
+                # read taken BEFORE the liveness probe, and the subscriber's last write --
+                # its whole retained replay, or the error explaining why there was none --
+                # can land in that gap. Reporting from the stale view would claim nothing
+                # was delivered into a window that is in fact full, which is the same kind
+                # of false diagnostic this wait exists to stop making. The process is gone,
+                # so this read is final rather than another poll.
+                $captured = @(Get-Content -LiteralPath $out -ErrorAction SilentlyContinue)
+                $diagnostics = @($captured | Where-Object { $_ -match '\S' })
+                $connected = @($captured | Where-Object { $null -ne (ConvertFrom-HomieCaptureLine -Line $_) }).Count -gt 0
                 break
             }
 


### PR DESCRIPTION
Closes #59.

`Start-HomieCapture -WaitForConnectSeconds` exists so a caller that publishes *inside* the
window does not race the subscriber's subscription. It waited by polling the output file's
length and breaking on the first byte, on the invariant its own comment stated: a subscriber
to `homie/#` receives the whole retained store the moment it subscribes.

That invariant does not hold. The subscriber's stderr is redirected into the same file by the
`2>&1` in the `cmd.exe` wrapper — which `ConvertFrom-HomieCaptureLine`'s comment already
records ("mosquitto_sub's stderr shares the capture file"). So the first byte can be a
diagnostic about a connection that never happened, and the wait then reports the one thing it
exists to establish.

## The change

The wait reads lines through `ConvertFrom-HomieCaptureLine` — which already tells a message
from a diagnostic — and breaks only on a **message**, something only a live subscription can
produce. A diagnostic delays it rather than ending it.

Two consequences of testing for a message instead of a byte, both handled here:

- The wait no longer ends on the subscriber's own fatal error, so against an unreachable
  broker it would spend its whole budget on a process that exited at ~2.4s. It checks the
  recorded process for liveness instead — ending the wait for the same reason, but for an
  honest one, and keeping the recycled-pid defence `New-SmartHomeProcessRecord` carries.
- "No message arrived" is not distinguishable afterwards from "the device did not answer",
  and the caller is about to read a response out of this window. So the wait now says which
  of the three it saw: a diagnostic it quotes, an exit with no reason, or nothing at all. A
  warning rather than a throw, for the reason `Stop-HomieCapture` warns — both callers close
  their window in a `finally`.

Option 3 in the issue (splitting stderr into `SubscriberErrorLog`) was not taken: it would
force a matching change to `Stop-HomieCapture`'s "why did the subscriber quit" warning, which
reads its reasons out of that same shared file, and the cheaper option closes the invariant on
its own.

## The half of the issue that was not verified — refuted

The issue recorded a verified broken invariant and an unverified consequence: that
`mosquitto_sub -h -p -t -F` ever emits a **non-fatal** line before its subscription is live,
which would make the wait break early on a healthy run. That is refuted for this
configuration.

In mosquitto_sub 2.0.22 with these arguments and neither `-d` nor `-q`, every line that can
reach this file before the subscription is live is fatal:

- libmosquitto's own warnings (`Warning: Unable to set TCP_NODELAY.`, `Warning: Unable to open
  socket pair...`) go through `log__printf` to the `on_log` callback, and `client/sub_client.c`
  registers one only under `if(cfg.debug)`.
- `Connection error: <connack string>` and `Unable to connect (...)` are connect failures and
  disconnect.
- `All subscription requests were denied.` is post-SUBACK, and also disconnects.
- `Subscribed (mid: ...)` on stdout is gated on `cfg.debug && !cfg.quiet`.

So the wait's early return is reachable today only on a run that was already failing. What is
fixed is the invariant — and therefore what the wait can be trusted to mean — not a symptom
observed in a passing run. It is worth saying plainly that this does **not** retroactively
explain #35's lost `/set` commands.

## Two races a `/code-review high` pass found, fixed in `5460453`

Both are reachable exactly when the subscriber dies — which is the case the wait now polls for
on purpose, so the loop is what makes them worth closing.

- `Get-SmartHomeRecordedProcess` compared `$process.ProcessName` **outside** the try that
  guarded `$process.StartTime`. `Get-Process` returns an object that fetches both lazily, so a
  process exiting in the gap after the id lookup throws *"Process has exited, so the requested
  information is not available"* rather than reading back as not running. Under
  `$ErrorActionPreference = 'Stop'` that is terminating, and out of the wait it escapes
  **before** `Start-HomieCapture` returns the record — so the caller never gets a capture to
  close, its `try/finally` is never entered, and the `cmd.exe`/`mosquitto_sub` pair is
  orphaned, appending to the one fixed-path capture file for the rest of the run. Both
  comparisons now sit inside the try.
- The wait's exit branch reported from the read taken *before* its liveness probe, so the
  subscriber's last write — its whole retained replay, or the error explaining why there was
  none — could land in that gap and be missed, warning that nothing was delivered into a
  window that is in fact full. The branch re-reads once before classifying; the process is
  gone, so that read is final rather than another poll.

## Verification

**At a desk** (no broker, no device): 25/25 in a harness that extracts `Start-HomieCapture`
from *both* the pre-change source and the patched one via the PowerShell AST, so each side
runs the shipped source rather than a copy.

| Case | old | new |
|---|---|---|
| Real `mosquitto_sub`, port with nothing listening | returns 2.33s, silent, no message ever delivered | returns 2.25s **and says so**, quoting the connection error |
| Diagnostic first, real message at +2s | returns **0.14s**, nothing delivered | returns 2.17s, **with the message in hand** |
| Message straight away | — | 0.14s, silent |
| Subscriber alive but silent | — | spends the 2s budget, warns `recorded nothing at all` |
| `-WaitForConnectSeconds 0` (the `Get-HomieRetainedSnapshot` path) | — | 0.03s, no wait, no warning |
| Delivers a message, then exits | — | counts the message, warns about nothing |
| `Get-SmartHomeRecordedProcess` on an exited process | — | returns `$null` under `'Stop'`, does not throw |

Row 2 is the decisive one — it is the invariant, isolated.

**On hardware** — real ESP32 on COM3, real WiFi, real Mosquitto. Full suite,
`scripts\Run-IntegrationTests.ps1`, run twice: once on `cda4deb` and again on `5460453` after
the review fixes, since `Get-SmartHomeRecordedProcess` is also what `Stop-DevEnv.ps1` and every
capture teardown go through. **5/5 both times**, 169s and 166s:

```
                       cda4deb          5460453
  WifiCheck            PASS   20s       PASS   20s
  MqttCheck            PASS   19s       PASS   18s
  Bmp280Check          PASS   18s       PASS   18s
  HomieClientCheck     PASS   63s       PASS   64s
  MqttReconnectCheck   PASS   49s       PASS   46s
```

`HomieClientCheck` is the only caller of the changed wait (two call sites: the out-of-format
`/set` loop and the refused-transition step). It emitted **no** connect-wait warning in either
run, so every window it opened was satisfied by a real message, and its phase breakdown is
unchanged against the two runs recorded on #75 — announce 9.5s / 9.4s over 2 snapshots here
against 9.2s and 9.9s there, out-of-format `/set` 3.9s / 3.7s over a single snapshot with no
retry. `MqttReconnectCheck`'s two full broker teardown/restart cycles exercise the
`Common.ps1` change on the path `Stop-DevEnv.ps1` uses.

The device was deliberately **left on `MqttReconnectCheck`**, the last image the suite
flashed — redeploy RoomSensor when it should go back to its real job.

CI cannot run any of the above: the integration suite needs a real device, network and broker.
