### PR TITLE
fix(scripts): address the checkout by its literal path, brackets and all

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -32,11 +32,17 @@ function Import-SmartHomeLocalEnv {
     $localEnv = Join-Path $scriptsDir $FileName
     $template = Join-Path $scriptsDir ($FileName -replace '\.ps1$', '.template.ps1')
 
-    if (-not (Test-Path $localEnv)) {
+    # -LiteralPath: this is the gate every other script enters through, and -Path reads
+    # '[' and ']' as wildcard character-class syntax -- so on a checkout at
+    # 'C:\repos\SmartHome [wip]' the file on disk tested as absent and every script
+    # aborted claiming a config file that was right there was missing (issue #71).
+    # Test-Setup.ps1 makes the same test and would otherwise report the opposite of
+    # this one, which is the single thing a preflight must not do.
+    if (-not (Test-Path -LiteralPath $localEnv)) {
         Write-Error @"
 Missing: $localEnv
 Copy the template and fill in your machine settings:
-    Copy-Item "$template" "$localEnv"
+    Copy-Item -LiteralPath "$template" "$localEnv"
 "@
         exit 1
     }

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -173,6 +173,14 @@ function Get-SmartHomePackagesConfig {
     # A caller that would rather skip a subtree the enumerator cannot read than abort
     # on it passes -ErrorAction SilentlyContinue, which this advanced function
     # propagates to the Get-ChildItem below.
+    #
+    # -LiteralPath, not -Path: -Path reads '[' and ']' as wildcard character-class
+    # syntax, and both are legal in a Windows directory name, so a checkout at
+    # 'C:\repos\SmartHome [wip]' matched nothing at all -- and the two callers then
+    # failed differently, neither naming the cause: the restore threw on $null.Count,
+    # the preflight reported "no packages.config found" on a complete checkout
+    # (issue #71). $RepoRoot is always a concrete directory derived from $PSScriptRoot,
+    # so wildcard semantics are never wanted here.
     param(
         [Parameter(Mandatory = $true)]
         [string]$RepoRoot
@@ -182,7 +190,7 @@ function Get-SmartHomePackagesConfig {
     # a sibling '.claude\worktrees-something' is a different folder and stays in.
     $worktreesDir = (Join-Path $RepoRoot '.claude\worktrees') + [System.IO.Path]::DirectorySeparatorChar
 
-    return ,@(Get-ChildItem -Path $RepoRoot -Filter 'packages.config' -Recurse -File |
+    return ,@(Get-ChildItem -LiteralPath $RepoRoot -Filter 'packages.config' -Recurse -File |
         Where-Object {
             $_.FullName -notmatch '\\(bin|obj)\\' -and
             -not $_.FullName.StartsWith($worktreesDir, [StringComparison]::OrdinalIgnoreCase)
@@ -196,7 +204,10 @@ function Get-NanoFrameworkTestAdapterDir {
     )
 
     $packagesDir = Join-Path $RepoRoot 'packages'
-    $adapterDll = Get-ChildItem -Path $packagesDir -Recurse -Filter 'nanoFramework.TestAdapter.dll' -ErrorAction SilentlyContinue |
+    # -LiteralPath for the same reason as Get-SmartHomePackagesConfig above: a checkout
+    # path containing '[' or ']' finds nothing under -Path, and this one reports that as
+    # "adapter not restored".
+    $adapterDll = Get-ChildItem -LiteralPath $packagesDir -Recurse -Filter 'nanoFramework.TestAdapter.dll' -ErrorAction SilentlyContinue |
         Sort-Object FullName -Descending | Select-Object -First 1
 
     if (-not $adapterDll) {
@@ -279,7 +290,11 @@ function Get-SmartHomeMainWorktreeRoot {
         $commonDir = Join-Path $repoRoot $commonDir
     }
 
-    $resolved = Resolve-Path -Path $commonDir -ErrorAction SilentlyContinue
+    # -LiteralPath: git hands back this checkout's own path, brackets and all, and
+    # -Path would read them as wildcards and resolve nothing -- which this function
+    # reports as "git cannot answer for this checkout", so a linked worktree at a
+    # bracketed path would look like the main one.
+    $resolved = Resolve-Path -LiteralPath $commonDir -ErrorAction SilentlyContinue
     if (-not $resolved) {
         return $null
     }

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -368,7 +368,13 @@ function Invoke-GitCloneOrUpdate {
     $targetPath = Join-Path $targetRoot $name
     $repoUrl = "https://github.com/$Repository.git"
 
-    if ((Test-Path $targetPath) -and -not $Force) {
+    # -LiteralPath on every probe of $targetPath below: the sibling root is derived from
+    # the checkout, and -Path reads '[' and ']' as wildcard syntax. Under -Path a sibling
+    # repo that is cloned and current tests as absent, so the pin guard is skipped and
+    # `git clone` fails on a non-empty destination -- twice, because the cleanup probe is
+    # wrong the same way -- and the sync aborts on the first repository while
+    # Test-Setup.ps1 reports the same siblings present (issue #71).
+    if ((Test-Path -LiteralPath $targetPath) -and -not $Force) {
         $currentRef = git -C $targetPath rev-parse --abbrev-ref HEAD 2>$null
         if ($currentRef -eq 'HEAD') {
             $pinnedCommit = git -C $targetPath rev-parse --short HEAD 2>$null
@@ -378,13 +384,13 @@ function Invoke-GitCloneOrUpdate {
         }
     }
 
-    if (-not (Test-Path $targetPath)) {
+    if (-not (Test-Path -LiteralPath $targetPath)) {
         Write-Host "Cloning $Repository..." -ForegroundColor Cyan
         git clone --branch $Branch --single-branch $repoUrl $targetPath
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "Branch '$Branch' not found for $Repository. Falling back to default branch."
-            if (Test-Path $targetPath) {
-                Remove-Item $targetPath -Recurse -Force
+            if (Test-Path -LiteralPath $targetPath) {
+                Remove-Item -LiteralPath $targetPath -Recurse -Force
             }
             git clone $repoUrl $targetPath
         }

--- a/scripts/Initialize-Worktree.ps1
+++ b/scripts/Initialize-Worktree.ps1
@@ -153,7 +153,11 @@ if ($absent.Count -gt 0) {
     Write-Host ""
     $templateHints = ($absent | ForEach-Object {
         $template = $_ -replace '\.ps1$', '.template.ps1'
-        "    Copy-Item `"$(Join-Path $scriptsDir $template)`" `"$(Join-Path $scriptsDir $_)`""
+        # -LiteralPath in the printed command for the same reason as the copies above:
+        # on a bracketed checkout Copy-Item -Path matches nothing and exits 0 having
+        # copied nothing at all, so a user who runs exactly what this prints sees
+        # success and then this identical error again, with nothing naming the cause.
+        "    Copy-Item -LiteralPath `"$(Join-Path $scriptsDir $template)`" `"$(Join-Path $scriptsDir $_)`""
     }) -join "`n"
 
     Write-Error @"

--- a/scripts/Restore-Packages.ps1
+++ b/scripts/Restore-Packages.ps1
@@ -41,7 +41,13 @@ if ([string]::IsNullOrWhiteSpace($cacheRoot)) {
     $cacheRoot = Join-Path $env:USERPROFILE '.nuget\packages'
 }
 
-if (-not (Test-Path $packagesDir)) {
+# -LiteralPath throughout this script for every path derived from the checkout root or
+# from the NuGet cache root: -Path reads '[' and ']' as wildcard character-class syntax,
+# and both are legal in a Windows directory name, so on a checkout at
+# 'C:\repos\SmartHome [wip]' every one of these tests answered the opposite of the truth
+# (issue #71). New-Item is the exception below -- it has no -LiteralPath in Windows
+# PowerShell 5.1 and creates the literal name anyway.
+if (-not (Test-Path -LiteralPath $packagesDir)) {
     New-Item -ItemType Directory -Path $packagesDir | Out-Null
 }
 
@@ -56,21 +62,21 @@ $alreadyPresent = 0
 $missing = New-Object System.Collections.Generic.List[string]
 
 foreach ($config in $configs) {
-    [xml]$xml = Get-Content $config.FullName
+    [xml]$xml = Get-Content -LiteralPath $config.FullName
     foreach ($package in $xml.packages.package) {
         $id = $package.id
         $version = $package.version
         $destName = "$id.$version"
         $destPath = Join-Path $packagesDir $destName
 
-        if (Test-Path $destPath) {
+        if (Test-Path -LiteralPath $destPath) {
             $alreadyPresent++
             continue
         }
 
         $cachePath = Join-Path $cacheRoot "$($id.ToLowerInvariant())\$version"
-        if (Test-Path $cachePath) {
-            Copy-Item -Path $cachePath -Destination $destPath -Recurse
+        if (Test-Path -LiteralPath $cachePath) {
+            Copy-Item -LiteralPath $cachePath -Destination $destPath -Recurse
             Write-Host "  restored: $destName" -ForegroundColor Green
             $copied++
         }

--- a/scripts/Test-Setup.ps1
+++ b/scripts/Test-Setup.ps1
@@ -93,8 +93,14 @@ foreach ($config in $configFiles) {
     $path = Join-Path $scriptsDir $config.Name
     $template = Join-Path $scriptsDir ($config.Name -replace '\.ps1$', '.template.ps1')
 
-    if (-not (Test-Path $path)) {
-        $fix = "Copy-Item `"$template`" `"$path`"  (then fill it in)"
+    # -LiteralPath for every path this preflight derives from the checkout: -Path reads
+    # '[' and ']' as wildcard character-class syntax, and both are legal in a Windows
+    # directory name, so on a checkout at 'C:\repos\SmartHome [wip]' each of these tests
+    # answered the opposite of the truth -- a preflight reporting a complete checkout as
+    # a broken one, and (below) skipping the packages check it exists to perform
+    # (issue #71). The remediation it prints has to be literal for the same reason.
+    if (-not (Test-Path -LiteralPath $path)) {
+        $fix = "Copy-Item -LiteralPath `"$template`" `"$path`"  (then fill it in)"
         if ($mainCheckout) {
             $fix = ".\scripts\Initialize-Worktree.ps1  -- this is a worktree; the file is git-ignored, " +
                    "so it did not come along. That copies it from $mainCheckout and restores packages\ too"
@@ -236,14 +242,14 @@ $missingPackages = New-Object System.Collections.Generic.List[string]
 $configs = Get-SmartHomePackagesConfig -RepoRoot $repoRoot -ErrorAction SilentlyContinue
 
 foreach ($configFile in $configs) {
-    [xml]$xml = Get-Content $configFile.FullName
+    [xml]$xml = Get-Content -LiteralPath $configFile.FullName
 
     # XPath rather than $xml.packages.package: under Set-StrictMode -Version Latest the
     # property access throws on a packages.config with no <package> children, which
     # would abort the whole preflight. SelectNodes just returns an empty list.
     foreach ($package in $xml.SelectNodes('/packages/package')) {
         $name = "$($package.id).$($package.version)"
-        if (-not (Test-Path (Join-Path $packagesDir $name)) -and -not $missingPackages.Contains($name)) {
+        if (-not (Test-Path -LiteralPath (Join-Path $packagesDir $name)) -and -not $missingPackages.Contains($name)) {
             $missingPackages.Add($name)
         }
     }
@@ -289,7 +295,7 @@ else {
 
 $siblingRoot = Get-SiblingRoot
 $siblingProbe = @('nf-interpreter', 'nanoFramework.m2mqtt', 'Samples')
-$missingSiblings = @($siblingProbe | Where-Object { -not (Test-Path (Join-Path $siblingRoot $_)) })
+$missingSiblings = @($siblingProbe | Where-Object { -not (Test-Path -LiteralPath (Join-Path $siblingRoot $_)) })
 
 if ($missingSiblings.Count -eq 0) {
     Add-Result -Name 'companion nanoFramework repos' -Status 'OK' -Detail $siblingRoot


### PR DESCRIPTION
Closes #71.

## What was wrong

`-Path` reads `[` and `]` as wildcard character-class syntax. Both are legal in a Windows directory name, so on a checkout at `C:\repos\SmartHome [wip]` every path these scripts derive from the checkout root answered the opposite of the truth — and none of the resulting failures named the cause.

Measured in a probe worktree at `.claude\worktrees\zz-probe-base [x]`, on `origin/main` (286ca00):

| | before |
|---|---|
| `Get-ChildItem -Path <root> -Filter packages.config -Recurse` | **0** (`-LiteralPath`: 14) |
| `Initialize-Worktree.ps1` | copies both config files, then `Restoring packages referenced by 0 packages.config file(s)`, `All referenced packages are available`, **exit 0** |
| `Test-Setup.ps1` | both config files reported **`missing`** — they are on disk; `[WARN] packages\ no packages.config found`; test adapter `FAIL` |
| `msbuild SmartHome.sln` in that worktree | **exit 1, 238 × CS0518** |

The seeded worktree therefore claims success and restores nothing, and the preflight's remediation is to run the script that just succeeded.

Note this is *not* the crash the issue body describes: since #68 the shared helper returns `,@(...)`, so `$configs.Count` is `0` rather than throwing. The array wrap that issue also asked for came with #68 and is already in place — [said so on the issue](https://github.com/JojoEffect/SmartHome/issues/71#issuecomment-5492324741) before starting. The remaining defect is quieter than the one filed: a silent no-op instead of a loud abort.

## What changed

`-LiteralPath` on every checkout-derived path the restore and the preflight walk. Finding the 14 files is not enough for the run to work, so the substitution covers the whole path both scripts take, not only the glob the issue was filed against:

- **`Common.ps1`** — `Get-SmartHomePackagesConfig`'s glob (the issue's site, now shared by both callers since #68); `Get-NanoFrameworkTestAdapterDir`'s probe under `packages\`; the `Resolve-Path` in `Get-SmartHomeMainWorktreeRoot` that decides whether this is a linked worktree; and `Import-SmartHomeLocalEnv`'s config-file gate; and `Invoke-GitCloneOrUpdate`'s three probes of a sibling repository's directory.
- **`Restore-Packages.ps1`** — `packages\` probe, per-config `Get-Content`, per-package `Test-Path`, the cache `Test-Path` and the `Copy-Item`.
- **`Test-Setup.ps1`** — config-file probe (and the `Copy-Item` in the remediation it prints), per-config `Get-Content`, per-package `Test-Path`, sibling-repo probe.
- **`Initialize-Worktree.ps1`** — the `Copy-Item` in the first-time-setup remediation it prints.

`New-Item` is deliberately left on `-Path`: Windows PowerShell 5.1 has no `-LiteralPath` for it, and it creates the literal name anyway (verified).

The second commit is a `/code-review high` finding on the first, and is the reason `Import-SmartHomeLocalEnv` is in the list. Fixing `Test-Setup.ps1`'s config probe alone left the preflight reporting `[OK] scripts\local.env.ps1 present` while every script that enters through that gate — `Start-DevEnv`, `Deploy-ToDevice`, `Run-Tests`, `Run-IntegrationTests`, `Stop-DevEnv`, `Sync-NanoFrameworkRepos`, both `Watch-*` — still exited 1 claiming the same file was missing. Before the first commit both were wrong the same way; after it the preflight passed a check whose failure it exists to predict, which is worse than either. The two have to move together.

The third commit is a second `/code-review high` pass, on the branch as a whole, and closes the same split in the other direction. `Invoke-GitCloneOrUpdate` probes a sibling repository's directory three times; under `-Path`, a bracket anywhere in the sibling root (`C:epos [work]\SmartHome` is legal) reports a cloned, current sibling as absent, so the detached-HEAD pin guard is skipped and `git clone` fails on a non-empty destination — and the recovery probe is wrong the same way, so nothing is cleaned up and the second clone fails identically, aborting `Sync-NanoFrameworkRepos.ps1` on the first repository. The first commit had already made `Test-Setup.ps1`'s sibling probe literal, so the preflight was reporting those same siblings present while the one script that maintains them could not see them. The third file is `Initialize-Worktree.ps1`, whose printed first-time-setup remediation was the last of the three identical `Copy-Item` strings — and that one matters more than it reads, because `Copy-Item -Path` on a bracketed path is worse than an error: it exits 0, prints nothing, and copies nothing, so following the instruction looks like it worked and the next run fails the same way.

`Get-NfProjectAssemblyName` is the same defect and stays out on purpose: #80 names that exact line and plans the remaining sweep as grouped per-workflow pull requests.

## Verification

**On real hardware**, from a worktree on the final commit, ESP32 on COM3:

- `Run-Tests.ps1` — **55 of 55 passed**, exit 0
- `Run-IntegrationTests.ps1` — **5 of 5 passed**, exit 0: `WifiCheck`, `MqttCheck`, `Bmp280Check`, `HomieClientCheck`, and `MqttReconnectCheck` (republished and stayed subscribed across broker outages of 3s and 20s)

Nothing in this change is device code, so that run shows the branch does not break the deploy/test loop rather than exercising the fix itself — the fix's own evidence is the desk work below. `Deploy-ToDevice.ps1` was not run on its own, so the device is left holding `MqttReconnectCheck`; redeploy RoomSensor to put it back to work.

**End to end, in a bracketed probe worktree** at `.claude\worktrees\zz-final [x]`, on the final commit:

- `Initialize-Worktree.ps1` → 14 `packages.config`, **29 packages restored**, exit 0
- `Test-Setup.ps1` → **16 checked, 0 failed, 0 warned**, exit 0 (config files `present`, `packages\ all packages restored (14 packages.config)`, adapter found, `worktree of:` resolved)
- `Stop-DevEnv.ps1` (enters through the env gate; opens no port, touches no device) → `Nothing was running for port 1883.`, exit 0
- `msbuild SmartHome.sln /t:Build` in that worktree → **exit 0, 0 × CS0518**, all three assemblies produced — against 238 CS0518 and exit 1 for the same tree on `origin/main`

**No change on a normal path**, in this worktree on the final commit: `Test-Setup.ps1` 16/16 OK exit 0, `Restore-Packages.ps1` 130 already present exit 0, `Stop-DevEnv.ps1` exit 0.

**#68's exclusion still holds** under `-LiteralPath`: the patched `Get-SmartHomePackagesConfig` returns 14 from the main checkout, from this worktree, and from a bracketed worktree, with zero foreign-worktree paths in any of the three.

**Desk harness**, `Test-LiteralPath.ps1` (in `%TEMP%\claude\smarthome-handoff\`, beside `QUEUE.md`), **29/29**. It runs the patched `Common.ps1` and the `origin/main` one side by side in separate child processes — plain and bracketed synthetic checkouts — so each defect is shown as a difference rather than asserted: `Get-SmartHomePackagesConfig` 2/2/2/**0**, `Get-NanoFrameworkTestAdapterDir` FOUND/FOUND/FOUND/**NULL**, `Import-SmartHomeLocalEnv` IMPORTED vs **aborted-as-missing** on a config file that is on disk. It also pins all 15 changed call sites statically, so a later edit that reverts one is caught at a desk rather than on somebody's bracketed clone.

Both probe worktrees were removed.

## Not in this change

The issue suggested a wider sweep of `scripts\` for the same pattern on other concrete paths. That is ~90 further call sites across ten scripts — machine paths (`SMARTHOME_MOSQUITTO_DIR`, Program Files, the dev-env state and capture files under `%TEMP%`) rather than checkout-derived ones. It would not stay a reviewable diff next to this one, so it is filed as its own issue: #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

