### PR TITLE
feat(scripts): give the host-side script logic a test home

### DIFF
--- a/.claude/skills/smarthome-script-tests/SKILL.md
+++ b/.claude/skills/smarthome-script-tests/SKILL.md
@@ -56,11 +56,26 @@ dot-source defines the catalog and the functions and runs nothing. Do not go bac
 functions out of it with the PowerShell AST — a test that reads its subject through a parser can
 drift from what actually runs, which is what issue #74 was about.
 
-The vocabulary is in `scripts\tests\TestRunner.ps1`: `Describe`, `It`, `Assert-Equal`
-(case-sensitive; pass `-IgnoreCase` where case is not part of the claim), `Assert-ArrayEqual`,
-`Assert-True`/`Assert-False`, `Assert-Null`/`Assert-NotNull`, `Assert-Match`, `Assert-Contains`,
-`Assert-Throws`, plus `New-TestDirectory` and `Set-TestFileContent` for fixtures. Every assertion
-takes `-Because`, which is what the failure message leads with.
+The vocabulary is in `scripts\tests\TestRunner.ps1`: `Describe`, `It`, `Assert-Equal`,
+`Assert-ArrayEqual`, `Assert-True`/`Assert-False`, `Assert-Null`/`Assert-NotNull`,
+`Assert-Match`, `Assert-Contains`, `Assert-Throws`, plus `New-TestDirectory` and
+`Set-TestFileContent` for fixtures. Every assertion takes `-Because`, which is what the failure
+message leads with.
+
+Two things about them worth knowing before writing a case:
+
+- **Comparisons are case-sensitive** (`Assert-Equal`, `Assert-ArrayEqual`, `Assert-Contains`);
+  the first and last take `-IgnoreCase`. `Assert-Match` is a regex and keeps `-match`'s own
+  case-insensitive default.
+- **`Assert-Equal` and `Assert-Match` refuse a collection** rather than comparing one, and say
+  so. PowerShell's `-eq` and `-match` *filter* a collection instead of returning a boolean, so
+  `@('a','b') -ceq 'a'` is `@('a')` — truthy — and an assertion built on that would pass
+  whenever the expected collection merely *contained* the actual value. Use `Assert-ArrayEqual`
+  for collections, and join at the call site for `Assert-Match`.
+
+A test file may stub a function the subject calls (`Get-SmartHomeDevEnvPath`, say) by defining
+it after the dot-source; command lookup walks the calling scope chain, so the stub wins inside
+that file or that `Describe` and nowhere else.
 
 ## Why not Pester
 

--- a/.claude/skills/smarthome-script-tests/SKILL.md
+++ b/.claude/skills/smarthome-script-tests/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: smarthome-script-tests
+description: Run the host-side script tests — the desk-provable half of scripts\, covering Common.ps1's helpers and the integration runner's verdict logic. Use before and after any change under scripts\, or when a host-side function needs proving without a device. For the on-device suite use smarthome-integration-tests instead.
+---
+
+# Run the host-side script tests
+
+```powershell
+.\scripts\Run-ScriptTests.ps1
+```
+
+No device, no broker, no network, no `local.env.ps1`, no restored `packages\`. About 6 seconds
+for ~100 cases. Exit 0 if everything passed, 1 otherwise — including when *nothing ran*, which is
+a failure on purpose: this repo already shipped three commits on a green `vstest` run that
+executed nothing.
+
+Useful switches:
+
+```powershell
+.\scripts\Run-ScriptTests.ps1 -File Common          # one subject
+.\scripts\Run-ScriptTests.ps1 -Name '*retained*'    # one claim, across files
+.\scripts\Run-ScriptTests.ps1 -Detailed             # every case, not just group counts
+```
+
+## What it covers, and what it deliberately does not
+
+`scripts\` decides what the integration suite reports, and it is the half of the suite a desk can
+exercise: `Get-CatalogValidationError`, `ConvertFrom-HomieCaptureLine`, `ConvertTo-HomieSnapshot`,
+`Get-HomieLivePayloads`, `Wait-ForAnnounceWitnessed`, `Get-SubscriberLogLineCount`, plus
+`Common.ps1`'s path globs, dev-environment state and the deploy-padding record.
+
+It does **not** cover anything that needs a broker, a subscriber process or the device —
+`Start-HomieCapture`'s connect wait, `Invoke-BrokerOutageCheck`, `Invoke-HomieConformanceCheck`.
+Those still need `Run-IntegrationTests.ps1` on real hardware. Running this suite is not a
+substitute for saying what was verified on hardware in a pull request.
+
+## Adding a test
+
+One file per subject, `scripts\tests\<Subject>.Tests.ps1`, dot-sourcing the subject at the top:
+
+```powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'Common.ps1')
+
+Describe 'Get-Something' {
+    It 'does the thing' {
+        Assert-Equal -Expected 'x' -Actual (Get-Something)
+    }
+}
+```
+
+`Run-IntegrationTests.ps1` can be dot-sourced the same way: a guard near the bottom of it means a
+dot-source defines the catalog and the functions and runs nothing. Do not go back to lifting
+functions out of it with the PowerShell AST — a test that reads its subject through a parser can
+drift from what actually runs, which is what issue #74 was about.
+
+The vocabulary is in `scripts\tests\TestRunner.ps1`: `Describe`, `It`, `Assert-Equal`
+(case-sensitive; pass `-IgnoreCase` where case is not part of the claim), `Assert-ArrayEqual`,
+`Assert-True`/`Assert-False`, `Assert-Null`/`Assert-NotNull`, `Assert-Match`, `Assert-Contains`,
+`Assert-Throws`, plus `New-TestDirectory` and `Set-TestFileContent` for fixtures. Every assertion
+takes `-Because`, which is what the failure message leads with.
+
+## Why not Pester
+
+Pester 5 does not ship with Windows. What ships, and what is on this machine, is Pester **3.4.0**,
+whose dialect (`Should Be`, not `Should -Be`) is incompatible with anything written for 5. Adopting
+Pester would mean `Install-Module` on every desk, a pinned install step in CI, a row in
+`Test-Setup.ps1`, and an explicit version guard at every import so PowerShell does not auto-load
+the in-box 3.4.0 instead. The point of this suite is that proving a host-side change costs nothing,
+and a prerequisite that has to be installed first is a reason not to run it.
+
+That trade is worth revisiting if mocking, fixtures across files, or JUnit output ever become
+load-bearing — not before.
+
+## CI
+
+The `Run host-side script tests` step is the first thing in `.github\workflows\ci.yml`, before the
+MSBuild and nanoFramework setup, because it needs none of it. It is the only automated coverage
+this repository has of the integration tooling itself; #22's unit tests run on the virtual device
+and cannot reach a PowerShell function.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # First, because it is the only step in this job that needs nothing installed --
+      # no MSBuild, no nanoclr, no packages\, no local.env.ps1 -- and it covers the
+      # host-side logic that decides what the integration suite reports. A broken
+      # scripts\ change fails here in seconds instead of after the nanoFramework setup.
+      #
+      # The runner is this repository's own (scripts\tests\TestRunner.ps1), deliberately
+      # not Pester: Pester 5 does not ship with Windows -- the in-box version is 3.4.0,
+      # whose dialect is incompatible -- so using it would mean an Install-Module step
+      # here and on every desk. See that file for the full reasoning.
+      - name: Run host-side script tests
+        run: .\scripts\Run-ScriptTests.ps1
+
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ have a script yet, that's a gap worth closing rather than working around.
 | `scripts\Stop-DevEnv.ps1 [-KeepLog] [-IncludeOrphans]` | Stops whatever `Start-DevEnv.ps1` recorded for the configured port, verifying pid+name+start-time first so a recycled pid is never killed. No-op + exit 0 if nothing is running, so it's safe to call unconditionally. `-IncludeOrphans` also clears brokers/subscribers this repo started that no state file covers | No | `smarthome-dev-env` |
 | `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug\|Release] [-FullPad]` | Always `/t:Rebuild`s (a plain incremental build silently drops the deployment `.bin`) then flashes via `nanoff`, padding the image with 0xFF far enough to erase the previous one (see Deploy padding below). `-FullPad` after a Visual Studio deploy | **Yes** | `smarthome-deploy` |
 | `scripts\Run-Tests.ps1` | Builds `SmartHome.UnitTests` and runs it via `vstest.console` + the nanoFramework test adapter | **Yes** | `smarthome-test` |
+| `scripts\Run-ScriptTests.ps1 [-File <names>] [-Name <wildcard>] [-Detailed]` | The host-side script tests: `scripts\tests\*.Tests.ps1`, run by this repo's own `TestRunner.ps1`. ~100 cases in ~6s, needing nothing installed — no device, no broker, no `local.env`, no `packages\`, no Pester. A run that executed zero tests fails | No | `smarthome-script-tests` |
 | `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` | The whole `src\integrationTests` suite in one call: broker up, deploy + capture + verdict per test, broker down, summary + exit code | **Yes** | `smarthome-integration-tests` |
 | `scripts\Sync-NanoFrameworkRepos.ps1 [-Force]` | Clones/updates the sibling nanoFramework repos beside `SmartHome` | No | `smarthome-sync-nanoframework` |
 | `scripts\Restore-Packages.ps1` | Restores classic `packages.config` NuGet packages from the local NuGet cache — `msbuild /t:Restore` is a no-op for this repo's project style. Only *this* checkout's configs: worktrees live inside the main checkout, and `Get-SmartHomePackagesConfig` in `Common.ps1` is the one glob that says so, shared with `Test-Setup.ps1` | No | `smarthome-restore-packages` |
@@ -263,6 +264,9 @@ tools/
   DeviceDebugMonitor/     Host-side .NET console app (NOT nanoFramework) -- CLI device debugger,
                           see scripts\Watch-DeviceDebugOutput.ps1
 scripts/                  Dev-environment and agent helper scripts (see table above)
+  tests/                  Host-side tests for those scripts. TestRunner.ps1 is the
+                          Describe/It/Assert-* vocabulary (this repo's own, not Pester);
+                          <Subject>.Tests.ps1 is one file per subject
 SmartHome.sln
 ```
 
@@ -368,15 +372,28 @@ Anything that needs WiFi calls `NetworkHelper.ConnectToConfiguredNetwork()` from
 2026-08-20 and would not join the network on a clean boot; `WifiNetworkHelper.Reconnect()` waits
 for the interface instead of racing it.
 
-### Three kinds of test, deliberately kept apart
+### Four kinds of test, deliberately kept apart
 
 - **`src/tests`** — unit tests (`SmartHome.UnitTests`) driven by `vstest.console` and the nanoFramework
   test adapter. They run *on* hardware but test logic, not the physical environment.
 - **`src/integrationTests`** — one app per external dependency (WiFi, broker, sensor). Each is a
   full device app that boots, exercises exactly one concern, and reports a verdict. Run them via
   `scripts\Run-IntegrationTests.ps1`, not by deploying them by hand.
+- **`scripts/tests`** — the host-side half: the PowerShell that decides what the integration
+  suite reports. No device, no broker, no network, nothing installed. Run them via
+  `scripts\Run-ScriptTests.ps1`, which CI runs too — the only automated coverage this repository
+  has of the integration tooling itself, since the nanoFramework unit tests cannot reach a
+  PowerShell function. **Any change under `scripts\` should come with a case here** unless it
+  genuinely needs a device to exercise; before this existed, proving one meant a throwaway
+  harness that was deleted afterwards, four times in a week (issue #74).
 - **`src/devices`** — real applications. Nothing here should exist only to prove a dependency
   works; that's what `integrationTests` is for.
+
+`Run-IntegrationTests.ps1` is dot-sourceable for that reason: a guard near the bottom means a
+dot-source defines `$testCatalog` and the functions and runs nothing, so a test file reaches the
+shipped source directly. Keep everything above that guard a declaration — a `Test-Path` or an
+`Import-SmartHomeLocalEnv` drifting back to the top would run on every dot-source, and
+`RunIntegrationTests.Tests.ps1` asserts against exactly that.
 
 Those tests differ in which dependency they exercise, as above, and separately in *who decides
 the verdict*. The latter is declared per entry in `$testCatalog` in `Run-IntegrationTests.ps1`,
@@ -385,7 +402,7 @@ the outcome, and `OwnsBroker` says that function stops and starts the broker its
 what `-NoBroker` refuses. An entry that names no `Verdict` is device-decided. The run loop reads
 both generically (one invoke by name, one shared epilogue), so a fourth kind of check is a new
 function plus its catalog entry, with no branch or guard elsewhere to keep in step. The three
-that exist are still worth naming (not the same three as the locations above):
+that exist are still worth naming (a different axis from the locations above):
 
 - **`DeviceMarker`** — the device decides. The runner captures managed debug output and reads
   the test's own `[ITEST]` marker. WifiCheck, MqttCheck and Bmp280Check work this way, and
@@ -620,10 +637,15 @@ truth for process, so change both or neither.
 branching off a protected `main`, Conventional Commits enforced on PR titles only, and what CI
 can and cannot verify.
 
-The part worth knowing before you touch anything: **CI builds every project and runs the unit
-tests on the nanoclr virtual device, but it cannot run the integration suite** — that needs a
-real ESP32, a real network and a real broker. Hardware verification is a manual step, and the
-pull request should say what was run on hardware, or say plainly that nothing was.
+The part worth knowing before you touch anything: **CI runs the host-side script tests, builds
+every project and runs the unit tests on the nanoclr virtual device, but it cannot run the
+integration suite** — that needs a real ESP32, a real network and a real broker. Hardware
+verification is a manual step, and the pull request should say what was run on hardware, or say
+plainly that nothing was.
+
+A green CI is therefore not the same claim for every change. For a change under `scripts\`,
+`Run-ScriptTests.ps1` covers the desk-provable half and nothing else: the capture, the broker
+outage and the conformance verdicts are still only proved by a run on the device.
 
 ## Project skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,16 +46,25 @@ Link the issue with `Closes #123` so it closes on merge.
 
 ## Testing, and what CI can and cannot do
 
-There are three kinds of test, kept deliberately apart (see `CLAUDE.md`):
+There are four kinds of test, kept deliberately apart (see `CLAUDE.md`):
 
 | | What it is | Runs in CI? |
 |---|---|---|
+| `scripts/tests` | Host-side PowerShell — the logic that decides what the integration suite reports | **Yes**, first, and it needs nothing installed |
 | `src/tests` | Unit tests — logic, no environment | **Yes**, on the nanoclr virtual device |
 | `src/integrationTests` | One app per external dependency: WiFi, broker, sensor | **No** — needs real hardware |
 | `src/devices` | The applications themselves | n/a |
 
-CI restores, builds all projects, and runs the unit tests against the **virtual device**
-(`nano.ci.runsettings`, `IsRealHardware=False`). Same IL, same CLR, no board.
+CI runs the host-side script tests, then restores, builds all projects, and runs the unit
+tests against the **virtual device** (`nano.ci.runsettings`, `IsRealHardware=False`). Same
+IL, same CLR, no board.
+
+A change under `scripts\` should come with a case in `scripts\tests` unless it genuinely
+needs a device to exercise:
+
+```powershell
+.\scripts\Run-ScriptTests.ps1
+```
 
 CI **cannot** run the integration suite. Those tests need a real ESP32 on a COM port, a
 real WiFi network and a real Mosquitto broker. Until a guarded self-hosted runner exists

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1378,6 +1378,26 @@ function Write-ConformancePhaseBreakdown {
     }
 }
 
+# The lifecycle states the conformance check drives the device through: ready -> alert ->
+# ready -> sleeping -> ready, with the one transition the convention's own state machine
+# forbids asked for in the middle. alert may only return to ready (or disconnect), so
+# alert -> sleeping must be refused -- and a device that advertises it as done anyway is
+# the defect the Refused step measures.
+#
+# At file scope because two things need to agree about it and used not to:
+# Measure-HomieConformance walks it, and Get-ConformanceCaptureSeconds sizes the debug
+# capture from how many steps there are. The count was written as a literal 5 about 420
+# lines from the table, so adding a step left the capture short by one
+# CommandTimeoutSeconds -- 30s on the current catalog entry -- and took the device-side
+# log away on exactly the slow run worth reading (issue #83).
+$conformanceLifecycleSteps = @(
+    @{ Command = 'alert';    Expect = 'alert';    Refused = $false }
+    @{ Command = 'sleeping'; Expect = 'alert';    Refused = $true  }
+    @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
+    @{ Command = 'sleeping'; Expect = 'sleeping'; Refused = $false }
+    @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
+)
+
 function Get-ConformanceCaptureSeconds {
     # A ceiling for the debug capture that runs alongside the check, derived from the
     # check's own timeouts rather than guessed: the announce wait, the /set round trip,
@@ -1387,15 +1407,21 @@ function Get-ConformanceCaptureSeconds {
     # Deliberately loose. A capture that ends early takes the device-side evidence with
     # it exactly when the run was slow enough to be worth reading, and nothing waits out
     # this window -- Stop-DeviceDebugCapture closes it as soon as the check returns.
-    param([hashtable]$Settings)
+    param(
+        [hashtable]$Settings,
 
-    $lifecycleSteps = 5
+        # Defaulted from the step table rather than restated, which is the whole point:
+        # the two used to be separate spellings of the same number. A parameter rather
+        # than a direct read so scripts\tests can prove the budget actually moves with the
+        # count -- a test that only recomputed the formula would pass on a literal too.
+        [int]$LifecycleStepCount = $conformanceLifecycleSteps.Count
+    )
 
     # +2 rather than +1: the /set round trip and the out-of-format phase each poll for up
     # to CommandTimeoutSeconds on top of the lifecycle steps.
     return $Settings.SettleSeconds +
            $Settings.RecoverySeconds +
-           (($lifecycleSteps + 2) * $Settings.CommandTimeoutSeconds) +
+           (($LifecycleStepCount + 2) * $Settings.CommandTimeoutSeconds) +
            60
 }
 
@@ -1806,19 +1832,10 @@ function Measure-HomieConformance {
     # ── the lifecycle states a device can be driven into ─────────────────────
     Start-ConformancePhase -Name 'lifecycle'
     Write-Host "  driving `$state through alert, sleeping and a refused transition..." -ForegroundColor DarkGray
-    # ready -> alert -> ready -> sleeping -> ready, with the one transition the
-    # convention's own state machine forbids asked for in the middle. alert may only
-    # return to ready (or disconnect), so alert -> sleeping must be refused -- and a
-    # device that advertises it as done anyway is the defect the Refused step measures.
-    $lifecycleSteps = @(
-        @{ Command = 'alert';    Expect = 'alert';    Refused = $false }
-        @{ Command = 'sleeping'; Expect = 'alert';    Refused = $true  }
-        @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
-        @{ Command = 'sleeping'; Expect = 'sleeping'; Refused = $false }
-        @{ Command = 'ready';    Expect = 'ready';    Refused = $false }
-    )
-
-    foreach ($step in $lifecycleSteps) {
+    # The table is at file scope ($conformanceLifecycleSteps, near
+    # Get-ConformanceCaptureSeconds), which sizes the debug capture from its length. It
+    # used to live here and the length was restated as a literal up there (issue #83).
+    foreach ($step in $conformanceLifecycleSteps) {
         if ($step.Refused) {
             # Nothing to wait for here -- the assertion is that nothing changed -- so one
             # capture window IS the measurement rather than a poll for it, and it carries

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -34,6 +34,11 @@
     *** HARDWARE: this flashes and runs code on the physical device on the configured
     COM port, once per test. Treat it exactly like Deploy-ToDevice.ps1. ***
 
+    Dot-sourcing this script does none of that: a guard below the function definitions
+    means `. .\scripts\Run-IntegrationTests.ps1` defines $testCatalog and the functions
+    and stops. That is what scripts\tests\RunIntegrationTests.Tests.ps1 uses to exercise
+    the host-side verdict logic at a desk (issue #74).
+
 .PARAMETER Tests
     Subset of tests to run, by name. Defaults to every entry of $testCatalog below,
     in dependency order -- WiFi first, since the MQTT checks can only fail
@@ -75,10 +80,17 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Common.ps1')
-Import-SmartHomeLocalEnv
 
-$repoRoot = Get-SmartHomeRepoRoot
-$mqttPort = Get-OptionalEnvValue -Name 'SMARTHOME_MQTT_PORT' -DefaultValue '1883'
+# Dot-sourcing this script defines the catalog and the functions and does nothing else:
+# the run itself -- reading local.env, the pre-flight, the broker, the deploy loop -- sits
+# below the guard near the bottom of the file. That is what lets scripts\tests exercise the
+# host-side half of the suite (the half that decides every verdict) without a device, a
+# broker or a network, instead of each test file re-extracting these functions through the
+# PowerShell AST. See the guard itself for why it reads $MyInvocation rather than a switch.
+#
+# Consequence for anything added here: file-scope statements between this line and the
+# guard run on a dot-source too, so keep them to declarations. Anything that reads the
+# environment, touches the disk or talks to the device belongs below the guard.
 
 # The catalog is the single source of truth for what the suite runs: the -Tests
 # default and its validation both come from here, and each project's path follows
@@ -139,16 +151,6 @@ $testCatalog = [ordered]@{
     }
 }
 
-if (-not $Tests) {
-    $Tests = @($testCatalog.Keys)
-}
-
-$unknown = @($Tests | Where-Object { -not $testCatalog.Contains($_) })
-if ($unknown.Count -gt 0) {
-    Write-Error ("Unknown test(s): {0}. Known tests: {1}." -f ($unknown -join ', '), (@($testCatalog.Keys) -join ', '))
-    exit 1
-}
-
 # Validate the catalog before anything is built or flashed. Under
 # Set-StrictMode -Version Latest a missing key read as $settings.Foo throws
 # PropertyNotFoundException -- which surfaces 90s into a run as Outcome 'ERROR' with a
@@ -166,46 +168,68 @@ $requiredCatalogKeys = @{
     'Invoke-HomieConformanceCheck' = @('DeviceId', 'NodeId', 'SettleSeconds', 'CommandTimeoutSeconds', 'RecoverySeconds')
     'Invoke-BrokerOutageCheck'     = @('HeartbeatTopic', 'SettleSeconds', 'OutageSeconds', 'RecoverySeconds', 'EchoCommandTopic', 'EchoTopic', 'CommandTimeoutSeconds')
 }
-$knownVerdicts = (@($requiredCatalogKeys.Keys) | Sort-Object) -join ', '
 
-foreach ($catalogTestName in $Tests) {
-    $catalogEntry = $testCatalog[$catalogTestName]
+function Get-CatalogValidationError {
+    # The rules described above, as a function that *returns* the first violation instead
+    # of writing it and exiting. Two callers want different things from them: the run wants
+    # a message and exit 1 before the first build, and scripts\tests wants to assert that a
+    # deliberately malformed entry is caught -- which a bare `exit 1` at file scope makes
+    # impossible to check without running the suite.
+    #
+    # First violation, not all of them, because that is what the run reported before this
+    # was a function and a longer report is not what a one-line configuration mistake
+    # needs. $null means every named test exists and is completely declared.
+    param(
+        [Parameter(Mandatory = $true)]
+        $Catalog,
 
-    # Required of every entry, device-decided ones included, because it is read as
-    # $settings.OwnsBroker on every path -- and because leaving it out would default to
-    # whichever answer is quietly wrong for the next check that owns the broker.
-    if (-not $catalogEntry.Contains('OwnsBroker')) {
-        Write-Error ("Catalog entry '{0}' declares no OwnsBroker. Say `$true if its verdict function stops and starts the broker itself, `$false otherwise." -f $catalogTestName)
-        exit 1
+        [string[]]$Tests,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$DeviceDecidedKeys,
+
+        # NOT $RequiredKeys: PowerShell variable names are case-insensitive, so that
+        # spelling and the local $requiredKeys below are the same variable, and assigning
+        # the local would write a string[] into a [hashtable]-typed parameter -- which
+        # fails as a type conversion at the assignment, several lines from the cause.
+        [Parameter(Mandatory = $true)]
+        [hashtable]$RequiredCatalogKeys
+    )
+
+    $unknown = @($Tests | Where-Object { -not $Catalog.Contains($_) })
+    if ($unknown.Count -gt 0) {
+        return ("Unknown test(s): {0}. Known tests: {1}." -f ($unknown -join ', '), (@($Catalog.Keys) -join ', '))
     }
 
-    $requiredKeys = $deviceDecidedKeys
-    if ($catalogEntry.Contains('Verdict')) {
-        if (-not $requiredCatalogKeys.Contains($catalogEntry.Verdict)) {
-            Write-Error ("Catalog entry '{0}' names an unknown Verdict function '{1}'. Known: {2}." -f $catalogTestName, $catalogEntry.Verdict, $knownVerdicts)
-            exit 1
+    $knownVerdicts = (@($RequiredCatalogKeys.Keys) | Sort-Object) -join ', '
+
+    foreach ($catalogTestName in $Tests) {
+        $catalogEntry = $Catalog[$catalogTestName]
+
+        # Required of every entry, device-decided ones included, because it is read as
+        # $settings.OwnsBroker on every path -- and because leaving it out would default to
+        # whichever answer is quietly wrong for the next check that owns the broker.
+        if (-not $catalogEntry.Contains('OwnsBroker')) {
+            return ("Catalog entry '{0}' declares no OwnsBroker. Say `$true if its verdict function stops and starts the broker itself, `$false otherwise." -f $catalogTestName)
         }
 
-        $requiredKeys = $requiredCatalogKeys[$catalogEntry.Verdict]
+        $requiredKeys = $DeviceDecidedKeys
+        if ($catalogEntry.Contains('Verdict')) {
+            if (-not $RequiredCatalogKeys.Contains($catalogEntry.Verdict)) {
+                return ("Catalog entry '{0}' names an unknown Verdict function '{1}'. Known: {2}." -f $catalogTestName, $catalogEntry.Verdict, $knownVerdicts)
+            }
+
+            $requiredKeys = $RequiredCatalogKeys[$catalogEntry.Verdict]
+        }
+
+        $missingKeys = @($requiredKeys | Where-Object { -not $catalogEntry.Contains($_) })
+        if ($missingKeys.Count -gt 0) {
+            return ("Catalog entry '{0}' is missing required setting(s): {1}." -f $catalogTestName, ($missingKeys -join ', '))
+        }
     }
 
-    $missingKeys = @($requiredKeys | Where-Object { -not $catalogEntry.Contains($_) })
-    if ($missingKeys.Count -gt 0) {
-        Write-Error ("Catalog entry '{0}' is missing required setting(s): {1}." -f $catalogTestName, ($missingKeys -join ', '))
-        exit 1
-    }
+    return $null
 }
-
-if (-not $LogDirectory) {
-    $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
-    $LogDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "smarthome-integration-$stamp"
-}
-New-Item -ItemType Directory -Force -Path $LogDirectory | Out-Null
-
-$deployScript   = Join-Path $PSScriptRoot 'Deploy-ToDevice.ps1'
-$watchScript    = Join-Path $PSScriptRoot 'Watch-DeviceDebugOutput.ps1'
-$startEnvScript = Join-Path $PSScriptRoot 'Start-DevEnv.ps1'
-$stopEnvScript  = Join-Path $PSScriptRoot 'Stop-DevEnv.ps1'
 
 function Get-TestProjectPath {
     param([string]$TestName)
@@ -2040,6 +2064,53 @@ function Measure-HomieConformance {
         Detail  = "attributes, datatypes, retained flags, /set round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce all conform" + $warningDetail
     }
 }
+
+# ── The run ───────────────────────────────────────────────────────────────────
+# Everything from here down happens only when this script is *run*. Dot-sourcing it
+# stops here with the catalog and the functions defined and nothing else done, which is
+# what scripts\tests needs: the functions below decide every verdict the suite reports,
+# they are the half of it a desk can exercise, and before this guard the only way to
+# reach them was to re-extract each one through the PowerShell AST -- a test reading its
+# subject through a parser, which can silently drift from what actually runs (issue #74).
+#
+# $MyInvocation.InvocationName is '.' for every spelling of a dot-source and the path or
+# '&' for every spelling of a run, so the safe answer is the default: a dot-source can
+# never start a suite that flashes the device. A -AsLibrary switch would invert that --
+# forget it and dot-sourcing deploys.
+#
+# `return`, not `exit`: at file scope `exit` in a dot-sourced script ends the *host*.
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+
+Import-SmartHomeLocalEnv
+
+$repoRoot = Get-SmartHomeRepoRoot
+$mqttPort = Get-OptionalEnvValue -Name 'SMARTHOME_MQTT_PORT' -DefaultValue '1883'
+
+if (-not $Tests) {
+    $Tests = @($testCatalog.Keys)
+}
+
+$catalogError = Get-CatalogValidationError -Catalog $testCatalog `
+                                           -Tests $Tests `
+                                           -DeviceDecidedKeys $deviceDecidedKeys `
+                                           -RequiredCatalogKeys $requiredCatalogKeys
+if ($catalogError) {
+    Write-Error $catalogError
+    exit 1
+}
+
+if (-not $LogDirectory) {
+    $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+    $LogDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "smarthome-integration-$stamp"
+}
+New-Item -ItemType Directory -Force -Path $LogDirectory | Out-Null
+
+$deployScript   = Join-Path $PSScriptRoot 'Deploy-ToDevice.ps1'
+$watchScript    = Join-Path $PSScriptRoot 'Watch-DeviceDebugOutput.ps1'
+$startEnvScript = Join-Path $PSScriptRoot 'Start-DevEnv.ps1'
+$stopEnvScript  = Join-Path $PSScriptRoot 'Stop-DevEnv.ps1'
 
 # ── Pre-flight ────────────────────────────────────────────────────────────────
 $expectedBroker = Get-OptionalEnvValue -Name 'SMARTHOME_MQTT_BROKER' -DefaultValue 'localhost'

--- a/scripts/Run-ScriptTests.ps1
+++ b/scripts/Run-ScriptTests.ps1
@@ -1,0 +1,164 @@
+<#
+.SYNOPSIS
+    Run the host-side script tests -- the desk-provable half of scripts\.
+
+.DESCRIPTION
+    scripts\ decides what the integration suite reports. Invoke-HomieConformanceCheck,
+    Invoke-BrokerOutageCheck, Wait-ForRetainedValue, Wait-ForAnnounceWitnessed,
+    Start-HomieCapture / Stop-HomieCapture, ConvertFrom-HomieCaptureLine and the catalog
+    validation are all pure host-side logic -- no device, no broker, no network -- and
+    until this entry point existed they had no test home at all. Proving a change to one
+    of them meant running the whole on-device suite, or building a throwaway harness that
+    was deleted afterwards. Four of those were written and thrown away in a week
+    (issue #74).
+
+    This runs every scripts\tests\*.Tests.ps1 file and reports one line per group plus
+    the detail of anything that failed.
+
+    It reads no machine configuration on purpose: no local.env.ps1, no COM port, no
+    Mosquitto, no restored packages\. A fresh clone can run it, and so can CI. If a test
+    ever needs one of those, it is testing the machine rather than the logic.
+
+    A run that executed zero tests fails. That is not defensive spelling: this repository
+    shipped three commits on a green vstest run that executed nothing, because the device
+    could not load the test assembly and every test was reported skipped. A filter with a
+    typo would do the same thing here.
+
+.PARAMETER File
+    Only run test files whose name matches one of these wildcards ('Common', 'Homie*').
+    The '.Tests.ps1' suffix is optional.
+
+.PARAMETER Name
+    Only run cases whose '<group> :: <case>' name matches this wildcard.
+
+.PARAMETER Detailed
+    Print every case, not just the per-group counts.
+
+.EXAMPLE
+    .\scripts\Run-ScriptTests.ps1
+    .\scripts\Run-ScriptTests.ps1 -File RunIntegrationTests -Detailed
+    .\scripts\Run-ScriptTests.ps1 -Name '*retained*'
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$File,
+
+    [string]$Name,
+
+    [switch]$Detailed
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'Common.ps1')
+. (Join-Path $PSScriptRoot 'tests\TestRunner.ps1')
+
+$testsDir = Join-Path $PSScriptRoot 'tests'
+
+# -LiteralPath, here and everywhere below: '[' and ']' are legal in a Windows directory
+# name and -Path reads them as character-class syntax, so a checkout at
+# 'C:\repos\SmartHome [wip]' finds nothing at all (issue #71). The tests in this
+# directory assert that same rule about Common.ps1; the runner should not break it.
+$testFiles = @(Get-ChildItem -LiteralPath $testsDir -Filter '*.Tests.ps1' -File | Sort-Object Name)
+
+if ($File) {
+    $testFiles = @($testFiles | Where-Object {
+        $candidate = $_.Name
+        $bare = $candidate -replace '\.Tests\.ps1$', ''
+        @($File | Where-Object { $candidate -like $_ -or $bare -like $_ }).Count -gt 0
+    })
+}
+
+if ($testFiles.Count -eq 0) {
+    Write-Error ("No test files to run under {0}{1}. Files there are named <Subject>.Tests.ps1." -f `
+        $testsDir, $(if ($File) { " matching: $($File -join ', ')" } else { '' }))
+    exit 1
+}
+
+$SmartHomeTestState.Filter = $Name
+$SmartHomeTestState.Detailed = [bool]$Detailed
+
+# One temp root per run, so New-TestDirectory fixtures cannot collide between files and a
+# single Remove-Item clears all of them. Under the process id, so two runs at once (a
+# desk and an editor) do not delete each other's fixtures.
+$SmartHomeTestState.TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("smarthome-script-tests-{0}" -f $PID)
+if (Test-Path -LiteralPath $SmartHomeTestState.TempRoot) {
+    Remove-Item -LiteralPath $SmartHomeTestState.TempRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $SmartHomeTestState.TempRoot | Out-Null
+
+$started = Get-Date
+
+Write-Host ""
+Write-Host "Host-side script tests" -ForegroundColor Cyan
+Write-Host ('=' * 78)
+
+try {
+    foreach ($testFile in $testFiles) {
+        Write-Host ""
+        Write-Host $testFile.Name -ForegroundColor White
+
+        # & rather than dot-source: each file gets its own scope, so the subject it
+        # dot-sources (Common.ps1, Run-IntegrationTests.ps1) and any stub it defines go
+        # away with it and cannot leak into the next file. The Describe/It/Assert-*
+        # functions are still reachable -- PowerShell resolves a command through the
+        # scope chain, and they live in this script's scope.
+        try {
+            & $testFile.FullName
+        }
+        catch {
+            # A file that fails outside a Describe (a bad dot-source, a syntax-level
+            # surprise) is one failure, not the end of the run.
+            $SmartHomeTestState.Total++
+            $SmartHomeTestState.Failed++
+            $SmartHomeTestState.Group = $testFile.Name
+            Add-TestFailure -Name '<file>' -Record $_
+            $SmartHomeTestState.Group = ''
+            Write-Host ("  {0,-62} {1}" -f '<file>', 'FAILED to load') -ForegroundColor Red
+        }
+    }
+}
+finally {
+    if ($SmartHomeTestState.TempRoot -and (Test-Path -LiteralPath $SmartHomeTestState.TempRoot)) {
+        Remove-Item -LiteralPath $SmartHomeTestState.TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$elapsed = ((Get-Date) - $started).TotalSeconds
+
+Write-Host ""
+Write-Host ('=' * 78)
+
+if ($SmartHomeTestState.Failures.Count -gt 0) {
+    Write-Host "Failures" -ForegroundColor Red
+    Write-Host ""
+    foreach ($failure in $SmartHomeTestState.Failures) {
+        Write-Host ("  {0}" -f $failure.Name) -ForegroundColor Red
+        Write-Host ("      {0}" -f $failure.Message)
+        Write-Host ("      at {0}" -f $failure.Where) -ForegroundColor DarkGray
+        Write-Host ""
+    }
+}
+
+$summary = "{0} passed, {1} failed" -f $SmartHomeTestState.Passed, $SmartHomeTestState.Failed
+if ($SmartHomeTestState.Skipped -gt 0) {
+    $summary += ", {0} skipped by -Name" -f $SmartHomeTestState.Skipped
+}
+$summary += " in {0:n1}s" -f $elapsed
+
+if ($SmartHomeTestState.Total -eq 0) {
+    Write-Host $summary -ForegroundColor Yellow
+    Write-Error ("No tests ran. {0} file(s) were loaded{1}, so this is a filter or a discovery problem, not a pass." -f `
+        $testFiles.Count, $(if ($Name) { " and -Name '$Name' matched nothing" } else { '' }))
+    exit 1
+}
+
+if ($SmartHomeTestState.Failed -gt 0) {
+    Write-Host $summary -ForegroundColor Red
+    exit 1
+}
+
+Write-Host $summary -ForegroundColor Green
+exit 0

--- a/scripts/tests/Common.Tests.ps1
+++ b/scripts/tests/Common.Tests.ps1
@@ -1,0 +1,437 @@
+# scripts\Common.ps1 -- the helpers every other script in this repository is built on.
+#
+# Dot-sourced into this file's own scope rather than relied on from the entry point's, so
+# the subject is unambiguous and anything defined here goes away with the file.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'Common.ps1')
+
+function New-PackagesConfigFixture {
+    # A synthetic checkout with every case Get-SmartHomePackagesConfig has to separate:
+    # a real reference, the build-time copies under bin\ and obj\, a linked worktree
+    # inside the checkout, and a sibling directory whose name merely starts the same way.
+    param([string]$Name = 'checkout')
+
+    $root = New-TestDirectory -Name $Name
+
+    $paths = @(
+        'src\common\Homie\packages.config'
+        'src\devices\RoomSensor\packages.config'
+        'src\devices\RoomSensor\bin\Debug\packages.config'
+        'src\devices\RoomSensor\obj\packages.config'
+        '.claude\worktrees\issue-99\src\common\Homie\packages.config'
+        '.claude\worktrees\issue-99\src\devices\RoomSensor\packages.config'
+        '.claude\worktrees-archive\issue-01\src\common\Homie\packages.config'
+    )
+
+    foreach ($relative in $paths) {
+        Set-TestFileContent -Path (Join-Path $root $relative) -Content @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<packages>'
+            '  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />'
+            '</packages>'
+        )
+    }
+
+    return $root
+}
+
+Describe 'Get-SmartHomePackagesConfig' {
+    It 'returns this checkout only: no bin\, no obj\, no linked worktree' {
+        $root = New-PackagesConfigFixture
+        $found = Get-SmartHomePackagesConfig -RepoRoot $root
+
+        Assert-Equal -Expected 3 -Actual $found.Count -Because 'two real references plus the worktrees-archive one'
+        Assert-Equal -Expected 0 -Actual @($found | Where-Object { $_.FullName -match '\\(bin|obj)\\' }).Count
+        Assert-Equal -Expected 0 -Actual @($found | Where-Object { $_.FullName -match '\\worktrees\\' }).Count
+    }
+
+    It 'keeps a sibling whose name merely starts with the excluded one' {
+        # The anchor carries a trailing separator on purpose: '.claude\worktrees-archive'
+        # is a different folder, and a bare name-prefix test would sweep it up (issue #68).
+        $root = New-PackagesConfigFixture
+        $found = Get-SmartHomePackagesConfig -RepoRoot $root
+
+        Assert-Equal -Expected 1 -Actual @($found | Where-Object { $_.FullName -match 'worktrees-archive' }).Count
+    }
+
+    It 'answers for the checkout it was asked about, not the one it lives in' {
+        # These scripts usually run *from* a worktree, whose own paths all contain
+        # '\.claude\worktrees\'. Anchoring at $RepoRoot rather than matching the substring
+        # anywhere is what keeps a worktree able to see its own files at all.
+        $root = New-PackagesConfigFixture
+        $worktree = Join-Path $root '.claude\worktrees\issue-99'
+
+        Assert-Equal -Expected 2 -Actual (Get-SmartHomePackagesConfig -RepoRoot $worktree).Count
+    }
+
+    It 'finds the same files under a checkout path containing brackets' {
+        # '[' and ']' are legal in a Windows directory name and -Path reads them as
+        # character-class syntax, so this returned nothing at all before issue #71.
+        $root = New-PackagesConfigFixture -Name 'SmartHome [wip]'
+
+        Assert-Equal -Expected 3 -Actual (Get-SmartHomePackagesConfig -RepoRoot $root).Count
+    }
+
+    It 'returns something whose .Count is readable when nothing matched' {
+        # The leading comma in the function's return is what makes this true: a plain
+        # `return @(...)` unrolls on the way out, no match reaches the caller as $null,
+        # and $null.Count throws under Set-StrictMode -- which is how Restore-Packages.ps1
+        # failed rather than reporting an empty checkout.
+        $empty = New-TestDirectory -Name 'no-configs'
+        $found = Get-SmartHomePackagesConfig -RepoRoot $empty
+
+        Assert-NotNull -Value $found
+        Assert-Equal -Expected 0 -Actual $found.Count
+    }
+
+    It 'propagates -ErrorAction to the enumeration' {
+        # Test-Setup.ps1 passes -ErrorAction SilentlyContinue because it would rather
+        # report a gap than abort on one; Restore-Packages.ps1 keeps the default and
+        # still stops loudly. Both behaviours come from this one pass-through.
+        $missing = Join-Path (New-TestDirectory -Name 'gone') 'not-a-directory'
+
+        Assert-Throws -Body { Get-SmartHomePackagesConfig -RepoRoot $missing } -Because 'the default must still abort'
+        Assert-Equal -Expected 0 -Actual (Get-SmartHomePackagesConfig -RepoRoot $missing -ErrorAction SilentlyContinue).Count
+    }
+}
+
+Describe 'Get-NanoFrameworkTestAdapterDir' {
+    function New-AdapterFixture {
+        param([string[]]$Versions, [string]$Name = 'adapter')
+
+        $root = New-TestDirectory -Name $Name
+        foreach ($version in $Versions) {
+            Set-TestFileContent -Path (Join-Path $root "packages\nanoFramework.TestFramework.$version\build\nanoFramework.TestAdapter.dll") -Content 'not a real dll'
+        }
+        return $root
+    }
+
+    It 'returns $null when packages\ has not been restored' {
+        Assert-Null -Value (Get-NanoFrameworkTestAdapterDir -RepoRoot (New-TestDirectory -Name 'unrestored'))
+    }
+
+    It 'returns the directory holding the adapter, not the file' {
+        $root = New-AdapterFixture -Versions @('3.0.80')
+        $dir = Get-NanoFrameworkTestAdapterDir -RepoRoot $root
+
+        Assert-NotNull -Value $dir
+        Assert-True -Condition (Test-Path -LiteralPath (Join-Path $dir 'nanoFramework.TestAdapter.dll'))
+    }
+
+    It 'finds the adapter under a checkout path containing brackets' {
+        $root = New-AdapterFixture -Versions @('3.0.80') -Name 'adapter [wip]'
+        Assert-NotNull -Value (Get-NanoFrameworkTestAdapterDir -RepoRoot $root)
+    }
+
+    It 'picks by descending path sort, which is not version order -- issue #79' {
+        # 3.0.9 wins over 3.0.80 because '9' sorts after '8' as text. This is the current
+        # behaviour, pinned here rather than endorsed: the adapter should be resolved from
+        # what the checkout's packages.config actually references, which is what #79 is
+        # for. When that lands, this case is the one that has to change with it.
+        $root = New-AdapterFixture -Versions @('3.0.9', '3.0.80')
+
+        Assert-Match -Pattern '3\.0\.9\\' -Actual (Get-NanoFrameworkTestAdapterDir -RepoRoot $root)
+    }
+}
+
+Describe 'Get-NfProjectAssemblyName' {
+    It 'reads <AssemblyName>, which since the SmartHome.* rename is not the file name' {
+        $project = Join-Path (New-TestDirectory -Name 'nfproj') 'RoomSensor.nfproj'
+        Set-TestFileContent -Path $project -Content @(
+            '<Project>'
+            '  <PropertyGroup>'
+            '    <AssemblyName>SmartHome.Devices.RoomSensor</AssemblyName>'
+            '  </PropertyGroup>'
+            '</Project>'
+        )
+
+        Assert-Equal -Expected 'SmartHome.Devices.RoomSensor' -Actual (Get-NfProjectAssemblyName -ProjectPath $project)
+    }
+
+    It 'tolerates whitespace inside the element' {
+        $project = Join-Path (New-TestDirectory -Name 'nfproj-spaced') 'A.nfproj'
+        Set-TestFileContent -Path $project -Content '<AssemblyName>  SmartHome.Devices.A  </AssemblyName>'
+
+        Assert-Equal -Expected 'SmartHome.Devices.A' -Actual (Get-NfProjectAssemblyName -ProjectPath $project)
+    }
+
+    It 'falls back to the file name when the element is absent' {
+        $project = Join-Path (New-TestDirectory -Name 'nfproj-bare') 'Legacy.nfproj'
+        Set-TestFileContent -Path $project -Content '<Project />'
+
+        Assert-Equal -Expected 'Legacy' -Actual (Get-NfProjectAssemblyName -ProjectPath $project)
+    }
+
+    It 'still fails on a project path containing brackets -- issue #80' {
+        # Not a claim that this is right. This function reads its project with
+        # Get-Content -Path, which is the same wildcard trap #71 fixed in the two globs
+        # above, on ~70 further call sites across the other scripts. Pinned so the fix for
+        # #80 has to come past this case rather than round it.
+        #
+        # No -Pattern, for two reasons. PowerShell's messages are localised on this
+        # machine the way MSBuild's are, so matching English text would pass here and fail
+        # nowhere useful. And the failure is not the ItemNotFound one might expect: -Raw
+        # is a FileSystem *dynamic* parameter, resolved from the provider of the resolved
+        # path, so a -Path whose wildcard matches nothing fails at parameter binding
+        # ("no parameter found matching Raw") before any file is opened.
+        $bracketed = Join-Path (New-TestDirectory -Name 'nfproj [wip]') 'A.nfproj'
+        Set-TestFileContent -Path $bracketed -Content '<AssemblyName>SmartHome.Devices.A</AssemblyName>'
+
+        Assert-Throws -Body { Get-NfProjectAssemblyName -ProjectPath $bracketed }
+
+        # Same content, same file name, no brackets: so the bracket is the whole
+        # difference, and this is not a fixture that was never written.
+        $plain = Join-Path (New-TestDirectory -Name 'nfproj-plain') 'A.nfproj'
+        Set-TestFileContent -Path $plain -Content '<AssemblyName>SmartHome.Devices.A</AssemblyName>'
+        Assert-Equal -Expected 'SmartHome.Devices.A' -Actual (Get-NfProjectAssemblyName -ProjectPath $plain)
+    }
+}
+
+Describe 'Get-SmartHomeDevEnvPath' {
+    It 'gives every kind its own file, all under temp and all prefixed' {
+        $kinds = @('State', 'Config', 'BrokerLog', 'SubscriberLog', 'SubscriberErrorLog', 'Snapshot')
+        $paths = @($kinds | ForEach-Object { Get-SmartHomeDevEnvPath -Port '1883' -Kind $_ })
+
+        Assert-Equal -Expected $kinds.Count -Actual @($paths | Sort-Object -Unique).Count -Because 'two kinds sharing a file would have them overwrite each other'
+        Assert-Equal -Expected 0 -Actual @($paths | Where-Object { (Split-Path -Leaf $_) -notlike 'smarthome-*' }).Count
+    }
+
+    It 'keys the files by port, so two ports can be up at once' {
+        Assert-True -Condition ((Get-SmartHomeDevEnvPath -Port '1883' -Kind State) -ne (Get-SmartHomeDevEnvPath -Port '1884' -Kind State))
+    }
+
+    It 'rejects a kind that is not in the vocabulary' {
+        # The orphan scan recognises leftovers by these same names, so a kind minted at a
+        # call site would be invisible to it.
+        Assert-Throws -Body { Get-SmartHomeDevEnvPath -Port '1883' -Kind 'Whatever' }
+    }
+}
+
+Describe 'Get-SmartHomeSubscriberArguments' {
+    It 'asks for the retain flag, which -v cannot print' {
+        $arguments = Get-SmartHomeSubscriberArguments -Port '1883'
+
+        Assert-Contains -Item '-F' -Collection $arguments
+        Assert-Contains -Item '%t %r %p' -Collection $arguments
+    }
+
+    It 'dials 127.0.0.1 rather than localhost' {
+        # Measured, not stylistic: localhost resolves to ::1 first, the broker binds
+        # 0.0.0.0, and every client then waits out an IPv6 connect timeout -- 2.03s
+        # against 0.02s on the first message.
+        Assert-Contains -Item '127.0.0.1' -Collection (Get-SmartHomeSubscriberArguments -Port '1883')
+        Assert-Equal -Expected 0 -Actual @(Get-SmartHomeSubscriberArguments -Port '1883' | Where-Object { $_ -eq 'localhost' }).Count
+    }
+
+    It 'passes the port through' {
+        Assert-Contains -Item '1884' -Collection (Get-SmartHomeSubscriberArguments -Port '1884')
+    }
+}
+
+Describe 'ConvertTo-SmartHomeHashtable' {
+    It 'turns a PSCustomObject into a hashtable whose missing keys read as $null' {
+        # The whole reason it exists: ConvertFrom-Json hands back PSCustomObjects, and
+        # under Set-StrictMode reading a property that is not there throws.
+        $converted = ConvertTo-SmartHomeHashtable -InputObject ('{"Label":"broker","Id":42}' | ConvertFrom-Json)
+
+        Assert-Equal -Expected 'broker' -Actual $converted['Label']
+        Assert-Equal -Expected 42 -Actual $converted['Id']
+        Assert-Null -Value $converted['NotThere']
+    }
+
+    It 'converts nested objects and arrays of them' {
+        $json = '{"Processes":[{"Label":"broker","Tree":true},{"Label":"subscriber","Tree":false}]}'
+        $converted = ConvertTo-SmartHomeHashtable -InputObject ($json | ConvertFrom-Json)
+
+        Assert-Equal -Expected 2 -Actual @($converted['Processes']).Count
+        Assert-Equal -Expected 'subscriber' -Actual $converted['Processes'][1]['Label']
+        Assert-Null -Value $converted['Processes'][0]['Missing']
+    }
+
+    It 'passes $null, scalars and an existing hashtable straight through' {
+        Assert-Null -Value (ConvertTo-SmartHomeHashtable -InputObject $null)
+        Assert-Equal -Expected 'x' -Actual (ConvertTo-SmartHomeHashtable -InputObject 'x')
+
+        $already = @{ Label = 'broker' }
+        Assert-Equal -Expected 'broker' -Actual (ConvertTo-SmartHomeHashtable -InputObject $already)['Label']
+    }
+}
+
+Describe 'Dev-env state' {
+    # A port no dev environment would ever be started on, so these cases cannot collide
+    # with a broker the developer has running. The files land in the real temp directory,
+    # because that is where the functions under test put them, and are cleared again here.
+    $statePort = '65999'
+
+    It 'reports nothing running when no state file exists' {
+        Clear-SmartHomeDevEnvState -Port $statePort
+        Assert-Null -Value (Get-SmartHomeDevEnvState -Port $statePort)
+    }
+
+    It 'round-trips a recorded process list' {
+        Save-SmartHomeDevEnvState -Port $statePort -State @{
+            Port      = $statePort
+            Processes = @(
+                @{ Label = 'broker'; Id = 111; Name = 'mosquitto'; StartTime = '2026-09-01T10:00:00.0000000Z'; Tree = $false }
+                @{ Label = 'subscriber'; Id = 222; Name = 'cmd'; StartTime = '2026-09-01T10:00:01.0000000Z'; Tree = $true }
+            )
+        }
+
+        try {
+            $state = Get-SmartHomeDevEnvState -Port $statePort
+
+            Assert-NotNull -Value $state
+            Assert-Equal -Expected 2 -Actual @($state['Processes']).Count
+            Assert-Equal -Expected 'mosquitto' -Actual $state['Processes'][0]['Name']
+            Assert-True -Condition $state['Processes'][1]['Tree']
+            Assert-Null -Value $state['NotRecorded'] -Because 'a missing key must read as $null, not throw'
+        }
+        finally {
+            Clear-SmartHomeDevEnvState -Port $statePort
+        }
+    }
+
+    It 'drops an unreadable state file rather than wedging the teardown' {
+        # Stop-DevEnv.ps1 has to stay callable unconditionally, so a truncated file
+        # (Ctrl+C mid-write, a reboot) reports "nothing running" and removes itself.
+        $stateFile = Get-SmartHomeDevEnvPath -Port $statePort -Kind State
+        Set-TestFileContent -Path $stateFile -Content '{"Processes":[{"Label":'
+
+        $WarningPreference = 'SilentlyContinue'
+        try {
+            Assert-Null -Value (Get-SmartHomeDevEnvState -Port $statePort)
+            Assert-False -Condition (Test-Path -LiteralPath $stateFile) -Because 'the corrupt file must not be read again on the next call'
+        }
+        finally {
+            Clear-SmartHomeDevEnvState -Port $statePort
+        }
+    }
+
+    It 'New-SmartHomeProcessRecord records name and start time next to the pid' {
+        # Windows recycles pids: a state file left by a crash can name a pid that now
+        # belongs to something else, and stopping that is worse than leaking.
+        $record = New-SmartHomeProcessRecord -Label 'broker' -Process (Get-Process -Id $PID) -Tree
+
+        Assert-Equal -Expected 'broker' -Actual $record['Label']
+        Assert-Equal -Expected $PID -Actual $record['Id']
+        Assert-NotNull -Value $record['Name']
+        Assert-Match -Pattern '^\d{4}-\d{2}-\d{2}T' -Actual $record['StartTime'] -Because 'round-trip format, so it compares exactly'
+        Assert-True -Condition $record['Tree']
+    }
+}
+
+Describe 'Deploy state' {
+    # The record Deploy-ToDevice.ps1 pads from. Its contract is "the number of bytes from
+    # the deploy address the next flash must overwrite", and every rejection below costs
+    # one full-size deploy -- the behaviour the script had before the record existed --
+    # so the safe direction is $null. A synthetic port, for the reason above.
+    $comPort = 'COM-TEST-74'
+
+    function Save-RawDeployState {
+        param([hashtable]$State)
+        $State | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath (Get-SmartHomeDeployStatePath -ComPort $comPort) -Encoding utf8
+    }
+
+    It 'builds a path that cannot escape the temp directory' {
+        # The port comes from local.env.ps1, so something like \\.\COM10 would otherwise
+        # point the record somewhere else entirely.
+        $path = Get-SmartHomeDeployStatePath -ComPort '\\.\COM10'
+
+        # '\\.\COM10' scrubs to '__._COM10': both backslashes and the leading one before
+        # COM10 become underscores, and the dot survives because it is legal in a name.
+        Assert-Equal -Expected ([System.IO.Path]::GetTempPath().TrimEnd('\')) -Actual (Split-Path -Parent $path)
+        Assert-Equal -Expected 'smarthome-deploy-__._COM10.json' -Actual (Split-Path -Leaf $path)
+    }
+
+    It 'keeps * unscrubbed, because the all-ports glob is built from this one rule' {
+        Assert-Match -Pattern '\*' -Actual (Get-SmartHomeDeployStatePath -ComPort '*')
+    }
+
+    It 'round-trips a saved record' {
+        Save-SmartHomeDeployState -ComPort $comPort -DeployAddress '0x1B000' -StaleBytes 409600 -Image 'RoomSensor.bin'
+
+        try {
+            $state = Get-SmartHomeDeployState -ComPort $comPort
+
+            Assert-NotNull -Value $state
+            Assert-Equal -Expected '0x1B000' -Actual $state['DeployAddress']
+            Assert-Equal -Expected 409600 -Actual $state['StaleBytes']
+            Assert-Equal -Expected 'RoomSensor.bin' -Actual $state['Image']
+        }
+        finally {
+            Clear-SmartHomeDeployState -ComPort $comPort
+        }
+    }
+
+    It 'returns $null when there is no record' {
+        Clear-SmartHomeDeployState -ComPort $comPort
+        Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort)
+    }
+
+    It 'rejects a record from another schema version' {
+        Save-RawDeployState -State @{ Version = 99; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = 4096 }
+        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
+        finally { Clear-SmartHomeDeployState -ComPort $comPort }
+    }
+
+    It 'rejects a record written for a different port' {
+        Save-RawDeployState -State @{ Version = 1; ComPort = 'COM9'; DeployAddress = '0x1B000'; StaleBytes = 4096 }
+        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
+        finally { Clear-SmartHomeDeployState -ComPort $comPort }
+    }
+
+    It 'rejects a record with no deploy address' {
+        # The record only vouches for a footprint at the address it was written for.
+        Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '   '; StaleBytes = 4096 }
+        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
+        finally { Clear-SmartHomeDeployState -ComPort $comPort }
+    }
+
+    It 'rejects a negative or unparseable StaleBytes' {
+        foreach ($bad in @(-1, 'lots')) {
+            Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = $bad }
+            try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) -Because "StaleBytes = $bad" }
+            finally { Clear-SmartHomeDeployState -ComPort $comPort }
+        }
+    }
+
+    It 'hands back StaleBytes as an int the caller can do arithmetic with' {
+        # ConvertFrom-Json returns Int32, Int64 or Double depending on the literal, and
+        # the padding decision multiplies and rounds this.
+        Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = 4096.0 }
+
+        try {
+            $state = Get-SmartHomeDeployState -ComPort $comPort
+
+            Assert-NotNull -Value $state
+            Assert-True -Condition ($state['StaleBytes'] -is [int])
+            Assert-Equal -Expected 8192 -Actual ($state['StaleBytes'] * 2)
+        }
+        finally {
+            Clear-SmartHomeDeployState -ComPort $comPort
+        }
+    }
+
+    It 'ignores an unreadable record instead of throwing' {
+        Set-TestFileContent -Path (Get-SmartHomeDeployStatePath -ComPort $comPort) -Content '{ not json'
+
+        $WarningPreference = 'SilentlyContinue'
+        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
+        finally { Clear-SmartHomeDeployState -ComPort $comPort }
+    }
+
+    It 'clearing a record that is not there is a no-op, not an error' {
+        Clear-SmartHomeDeployState -ComPort $comPort
+        Clear-SmartHomeDeployState -ComPort $comPort
+        Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort)
+    }
+
+    # Not covered here: Clear-SmartHomeDeployState with no -ComPort. It globs every
+    # record in the real temp directory, which on a developer's machine includes the one
+    # for the device actually attached -- clearing it would silently cost that machine's
+    # next deploy its tight pad. The directory is hardcoded inside the function, so there
+    # is no way to point that branch at a fixture without changing it.
+}

--- a/scripts/tests/RunIntegrationTests.Tests.ps1
+++ b/scripts/tests/RunIntegrationTests.Tests.ps1
@@ -1,0 +1,425 @@
+# scripts\Run-IntegrationTests.ps1 -- the host-side half of the integration suite.
+#
+# This is the half that decides every verdict the suite reports, and the half with no
+# coverage at all until issue #74. Dot-sourcing the script defines its functions and its
+# catalog and runs nothing (see the guard in that file), which is what lets these cases
+# exercise the real shipped source instead of a copy lifted out of it with the AST.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptsDir = Split-Path -Parent $PSScriptRoot
+$subject = Join-Path $scriptsDir 'Run-IntegrationTests.ps1'
+
+. $subject
+
+Describe 'The dot-source guard' {
+    It 'defines the functions and the catalog without reading the environment' {
+        # In a child process, because the interesting claim is about what a fresh
+        # dot-source does -- and this file has already done one.
+        $probe = Join-Path (New-TestDirectory -Name 'guard') 'probe.ps1'
+        Set-TestFileContent -Path $probe -Content @(
+            'Set-StrictMode -Version Latest'
+            '$ErrorActionPreference = ''Stop'''
+            ". '$subject'"
+            '$functions = @(Get-Command -CommandType Function | Where-Object { $_.ScriptBlock.File -eq ' + "'$subject'" + ' }).Count'
+            'Write-Output ("functions={0}" -f $functions)'
+            'Write-Output ("catalog={0}" -f @($testCatalog.Keys).Count)'
+            'Write-Output ("repoRootDefined={0}" -f [bool](Get-Variable -Name repoRoot -ErrorAction SilentlyContinue))'
+            'Write-Output ("logDirectory=[{0}]" -f $LogDirectory)'
+        )
+
+        $host_ = (Get-Process -Id $PID).Path
+        $output = & $host_ -NoProfile -ExecutionPolicy Bypass -File $probe
+        Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Because 'a dot-source must not fail'
+
+        $report = @{}
+        foreach ($line in $output) {
+            $parts = $line -split '=', 2
+            $report[$parts[0]] = $parts[1]
+        }
+
+        Assert-True -Condition ([int]$report['functions'] -ge 25) -Because "the verdict functions must be reachable, got $($report['functions'])"
+        Assert-Equal -Expected '5' -Actual $report['catalog']
+
+        # The two that prove nothing below the guard ran: $repoRoot is assigned there, and
+        # $LogDirectory is filled in and created there.
+        Assert-Equal -Expected 'False' -Actual $report['repoRootDefined']
+        Assert-Equal -Expected '[]' -Actual $report['logDirectory']
+    }
+
+    It 'has nothing but declarations above it' {
+        # The guard only holds while everything above it is a declaration. This is the
+        # case that stops an Import-SmartHomeLocalEnv, a New-Item or a Test-Path drifting
+        # back to the top of the file, where a dot-source would run it -- which is how
+        # this script came to be un-dot-sourceable in the first place.
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($subject, [ref]$null, [ref]$parseErrors)
+        Assert-Equal -Expected 0 -Actual @($parseErrors).Count
+
+        $statements = @($ast.EndBlock.Statements)
+        $guardIndex = -1
+        for ($i = 0; $i -lt $statements.Count; $i++) {
+            if ($statements[$i] -is [System.Management.Automation.Language.IfStatementAst] -and
+                $statements[$i].Extent.Text -match 'InvocationName') {
+                $guardIndex = $i
+                break
+            }
+        }
+
+        Assert-True -Condition ($guardIndex -ge 0) -Because 'the guard itself must still be there'
+
+        # The only two non-declarations allowed above the guard, both of which a
+        # dot-sourcing caller wants anyway: the strict-mode setting and the Common.ps1
+        # dot-source that brings in the helpers these functions are built on.
+        $allowedAbove = @(
+            "^Set-StrictMode -Version Latest$"
+            "^\.\s*\(Join-Path \`$PSScriptRoot 'Common\.ps1'\)$"
+        )
+
+        foreach ($statement in $statements[0..($guardIndex - 1)]) {
+            $text = $statement.Extent.Text
+            $isDeclaration =
+                $statement -is [System.Management.Automation.Language.FunctionDefinitionAst] -or
+                $statement -is [System.Management.Automation.Language.AssignmentStatementAst] -or
+                @($allowedAbove | Where-Object { $text -match $_ }).Count -gt 0
+
+            Assert-True -Condition $isDeclaration -Because ("line {0} runs on a dot-source: {1}" -f $statement.Extent.StartLineNumber, ($text -split "`n")[0])
+        }
+    }
+}
+
+Describe 'Get-CatalogValidationError' {
+    $deviceDecided = @('CaptureSeconds')
+    $required = @{
+        'Invoke-Something' = @('DeviceId', 'SettleSeconds')
+    }
+
+    It 'accepts the catalog this script actually ships' {
+        # The run's own pre-flight, run at a desk: every entry, not just the default set.
+        Assert-Null -Value (Get-CatalogValidationError -Catalog $testCatalog `
+                                                       -Tests @($testCatalog.Keys) `
+                                                       -DeviceDecidedKeys $deviceDecidedKeys `
+                                                       -RequiredCatalogKeys $requiredCatalogKeys)
+    }
+
+    It 'names an unknown test and lists the known ones' {
+        $error_ = Get-CatalogValidationError -Catalog $testCatalog `
+                                             -Tests @('WifiCheck', 'NoSuchCheck') `
+                                             -DeviceDecidedKeys $deviceDecidedKeys `
+                                             -RequiredCatalogKeys $requiredCatalogKeys
+
+        Assert-Match -Pattern 'NoSuchCheck' -Actual $error_
+        Assert-Match -Pattern 'WifiCheck' -Actual $error_ -Because 'the message has to say what the options were'
+    }
+
+    It 'rejects an entry that declares no OwnsBroker' {
+        # Required of every entry, device-decided ones included: it is read as
+        # $settings.OwnsBroker on every path, and leaving it out would default to
+        # whichever answer is quietly wrong for the next check that owns the broker.
+        $catalog = [ordered]@{ 'Thing' = @{ CaptureSeconds = 30 } }
+
+        Assert-Match -Pattern 'OwnsBroker' `
+                     -Actual (Get-CatalogValidationError -Catalog $catalog -Tests @('Thing') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required)
+    }
+
+    It 'rejects a Verdict function this script does not know' {
+        $catalog = [ordered]@{ 'Thing' = @{ OwnsBroker = $true; Verdict = 'Invoke-Whatever' } }
+        $error_ = Get-CatalogValidationError -Catalog $catalog -Tests @('Thing') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required
+
+        Assert-Match -Pattern 'Invoke-Whatever' -Actual $error_
+        Assert-Match -Pattern 'Invoke-Something' -Actual $error_ -Because 'and say which names are known'
+    }
+
+    It 'rejects a host-decided entry missing a setting its verdict function needs' {
+        $catalog = [ordered]@{ 'Thing' = @{ OwnsBroker = $true; Verdict = 'Invoke-Something'; DeviceId = 'x' } }
+
+        Assert-Match -Pattern 'SettleSeconds' `
+                     -Actual (Get-CatalogValidationError -Catalog $catalog -Tests @('Thing') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required)
+    }
+
+    It 'rejects a device-decided entry with no CaptureSeconds' {
+        # A forgotten CaptureSeconds would otherwise become a zero-length capture window
+        # -- a test that reports FAIL because nothing was captured.
+        $catalog = [ordered]@{ 'Thing' = @{ OwnsBroker = $false } }
+
+        Assert-Match -Pattern 'CaptureSeconds' `
+                     -Actual (Get-CatalogValidationError -Catalog $catalog -Tests @('Thing') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required)
+    }
+
+    It 'checks only the tests it was asked about' {
+        $catalog = [ordered]@{
+            'Good' = @{ OwnsBroker = $false; CaptureSeconds = 30 }
+            'Bad'  = @{ OwnsBroker = $false }
+        }
+
+        Assert-Null -Value (Get-CatalogValidationError -Catalog $catalog -Tests @('Good') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required)
+        Assert-NotNull -Value (Get-CatalogValidationError -Catalog $catalog -Tests @('Good', 'Bad') -DeviceDecidedKeys $deviceDecided -RequiredCatalogKeys $required)
+    }
+}
+
+Describe 'The shipped catalog' {
+    It 'names only Verdict functions this script defines' {
+        # The run checks this too, but only after the catalog validation and only for the
+        # tests being run -- and it can only run there, after the definitions. Here it
+        # covers every entry, before anything is built or flashed.
+        foreach ($testName in $testCatalog.Keys) {
+            $entry = $testCatalog[$testName]
+            if ($entry.Contains('Verdict')) {
+                Assert-NotNull -Value (Get-Command -Name $entry.Verdict -CommandType Function -ErrorAction SilentlyContinue) `
+                               -Because "$testName names Verdict $($entry.Verdict)"
+            }
+        }
+    }
+
+    It 'has a required-keys table whose every name is a function too' {
+        # The table doubles as the list of names an entry may point at, so a name in it
+        # that no longer exists would be accepted by validation and fail at the call.
+        foreach ($verdict in $requiredCatalogKeys.Keys) {
+            Assert-NotNull -Value (Get-Command -Name $verdict -CommandType Function -ErrorAction SilentlyContinue) -Because $verdict
+        }
+    }
+
+    It 'gives every broker-owning entry a recovery budget' {
+        foreach ($testName in $testCatalog.Keys) {
+            $entry = $testCatalog[$testName]
+            if ($entry.OwnsBroker) {
+                Assert-True -Condition ($entry.Contains('RecoverySeconds') -and $entry.RecoverySeconds -gt 0) -Because $testName
+            }
+        }
+    }
+}
+
+Describe 'ConvertFrom-HomieCaptureLine' {
+    It 'reads topic, retain flag and payload out of a -F "%t %r %p" line' {
+        $parsed = ConvertFrom-HomieCaptureLine -Line 'homie/room-sensor-office/$state 1 ready'
+
+        Assert-Equal -Expected 'homie/room-sensor-office/$state' -Actual $parsed.Topic
+        Assert-True -Condition $parsed.Retained
+        Assert-Equal -Expected 'ready' -Actual $parsed.Payload
+    }
+
+    It 'reads a live message as not retained' {
+        # MQTT only sets the retain flag when replaying from the store: a live retained
+        # publish arrives with the flag clear, which is why the conformance check reads
+        # retained-ness from a fresh subscriber.
+        Assert-False -Condition (ConvertFrom-HomieCaptureLine -Line 'homie/d/$state 0 init').Retained
+    }
+
+    It 'keeps a payload that contains spaces' {
+        Assert-Equal -Expected '12,34,56 and more' -Actual (ConvertFrom-HomieCaptureLine -Line 'homie/d/n/colour 0 12,34,56 and more').Payload
+    }
+
+    It 'reads an empty payload as an empty string, not as a non-message' {
+        # An empty retained publish is how a Homie attribute is cleared, so this line has
+        # to parse rather than be dropped as noise.
+        $parsed = ConvertFrom-HomieCaptureLine -Line 'homie/d/$state 1 '
+
+        Assert-NotNull -Value $parsed
+        Assert-Equal -Expected '' -Actual $parsed.Payload
+    }
+
+    It 'returns $null for a line that is not a message' {
+        # mosquitto_sub's stderr shares the capture file, so its diagnostics come through
+        # this function too.
+        Assert-Null -Value (ConvertFrom-HomieCaptureLine -Line 'Error: Connection refused')
+        Assert-Null -Value (ConvertFrom-HomieCaptureLine -Line '')
+        Assert-Null -Value (ConvertFrom-HomieCaptureLine -Line 'homie/d/$state 2 ready') -Because 'the retain flag is 0 or 1'
+    }
+
+    It 'parses a line built from the format Common.ps1 actually asks for' {
+        # The layout is chosen in Get-SmartHomeSubscriberArguments and read here. This is
+        # the case that fails if one of them is changed alone.
+        $format = @(Get-SmartHomeSubscriberArguments -Port '1883')[-1]
+        $line = $format -replace '%t', 'homie/d/$state' -replace '%r', '1' -replace '%p', 'ready'
+
+        $parsed = ConvertFrom-HomieCaptureLine -Line $line
+        Assert-NotNull -Value $parsed
+        Assert-Equal -Expected 'homie/d/$state' -Actual $parsed.Topic
+        Assert-True -Condition $parsed.Retained
+        Assert-Equal -Expected 'ready' -Actual $parsed.Payload
+    }
+}
+
+Describe 'ConvertTo-HomieSnapshot' {
+    It 'keeps the last value per topic' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @(
+            'homie/d/$state 1 init'
+            'homie/d/$state 0 ready'
+        )
+
+        Assert-Equal -Expected 'ready' -Actual $snapshot['homie/d/$state'].Payload
+    }
+
+    It 'lets a repeat of the same payload add the retain flag it proved' {
+        # A QoS-1 publish whose PUBACK is late is retransmitted with DupFlag set, so a
+        # live duplicate can arrive after the broker's replayed copy. Overwriting on
+        # payload equality threw away the retain flag replay had just proved, and the
+        # conformance check reported "not retained" for three attributes that plainly
+        # were.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @(
+            'homie/d/$name 1 Office'
+            'homie/d/$name 0 Office'
+        )
+
+        Assert-True -Condition $snapshot['homie/d/$name'].Retained
+    }
+
+    It 'lets a different payload replace both the value and the flag' {
+        # The other half of that rule: a value delivered only live must not inherit the
+        # retained-ness of the value it replaced.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @(
+            'homie/d/n/p 1 on'
+            'homie/d/n/p 0 off'
+        )
+
+        Assert-Equal -Expected 'off' -Actual $snapshot['homie/d/n/p'].Payload
+        Assert-False -Condition $snapshot['homie/d/n/p'].Retained
+    }
+
+    It 'treats payloads differing only in case as different' {
+        # -ceq, not -eq: a live 'TRUE' merging with a replayed 'true' would inherit a
+        # retain flag it never earned.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @(
+            'homie/d/n/p 1 true'
+            'homie/d/n/p 0 TRUE'
+        )
+
+        Assert-Equal -Expected 'TRUE' -Actual $snapshot['homie/d/n/p'].Payload
+        Assert-False -Condition $snapshot['homie/d/n/p'].Retained
+    }
+
+    It 'skips lines that are not messages' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @(
+            'Error: Connection refused'
+            'homie/d/$state 1 ready'
+        )
+
+        Assert-Equal -Expected 1 -Actual $snapshot.Keys.Count
+    }
+
+    It 'returns an empty snapshot rather than $null for no lines' {
+        Assert-Equal -Expected 0 -Actual (ConvertTo-HomieSnapshot -Lines @()).Keys.Count
+    }
+}
+
+Describe 'Get-HomieLivePayloads' {
+    $lines = @(
+        'homie/d/n/p 1 idle'
+        'homie/d/n/p 0 running'
+        'homie/d/n/other 0 ignored'
+        'homie/d/n/p 0 stopped'
+    )
+
+    It 'returns what went past the topic, in order' {
+        # This is what tells a command that was refused apart from one never delivered:
+        # both leave the retained store exactly as it was.
+        Assert-ArrayEqual -Expected @('running', 'stopped') -Actual (Get-HomieLivePayloads -Lines $lines -Topic 'homie/d/n/p')
+    }
+
+    It 'drops the retained replay, which is from before the window opened' {
+        Assert-Equal -Expected 0 -Actual @(Get-HomieLivePayloads -Lines $lines -Topic 'homie/d/n/p' |
+            Where-Object { $_ -eq 'idle' }).Count -Because 'the replayed value says nothing about what happened inside the window'
+    }
+
+    It 'returns an array even when nothing matched' {
+        # The leading comma in the function's return: a zero- or one-element result still
+        # has to arrive as an array, or the caller's .Count throws under Set-StrictMode.
+        $payloads = Get-HomieLivePayloads -Lines $lines -Topic 'homie/d/n/nothing'
+
+        Assert-NotNull -Value $payloads
+        Assert-Equal -Expected 0 -Actual $payloads.Count
+    }
+
+    It 'returns an array for a single match' {
+        $payloads = Get-HomieLivePayloads -Lines $lines -Topic 'homie/d/n/other'
+
+        Assert-Equal -Expected 1 -Actual $payloads.Count
+        Assert-Equal -Expected 'ignored' -Actual $payloads[0]
+    }
+}
+
+Describe 'The announce witness' {
+    # Both functions read the long-running homie/# log through Get-SmartHomeDevEnvPath.
+    # Stubbing it here -- in this file's scope, which is where the subject was
+    # dot-sourced -- points them at a fixture instead of the real dev environment.
+    $script:witnessLog = $null
+
+    function Get-SmartHomeDevEnvPath {
+        param([string]$Port, [string]$Kind)
+        return $script:witnessLog
+    }
+
+    function Set-WitnessLog {
+        param([string[]]$Lines)
+        $script:witnessLog = Join-Path (New-TestDirectory -Name 'witness') 'homie.log'
+        Set-TestFileContent -Path $script:witnessLog -Content $Lines
+    }
+
+    It 'Get-SubscriberLogLineCount reads a missing log as 0, not as an error' {
+        # -NoBroker skips the long-running subscriber, and a watermark of 0 then means
+        # "read the whole file", which is the right answer when there is no file.
+        $script:witnessLog = Join-Path (New-TestDirectory -Name 'no-log') 'absent.log'
+
+        Assert-Equal -Expected 0 -Actual (Get-SubscriberLogLineCount -Port '1883')
+    }
+
+    It 'Get-SubscriberLogLineCount counts lines, so the reader can -Skip it' {
+        Set-WitnessLog -Lines @('a', 'b', 'c')
+
+        Assert-Equal -Expected 3 -Actual (Get-SubscriberLogLineCount -Port '1883')
+    }
+
+    It 'witnesses this boot announcing' {
+        Set-WitnessLog -Lines @(
+            'homie/other/$state 0 ready'
+            'homie/d/$state 0 init'
+        )
+
+        Assert-True -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 2 -Watermark 1)
+    }
+
+    It 'is not satisfied by a previous boot''s init before the watermark' {
+        # The case the whole mechanism exists for. The watermark is read in the gap
+        # between the flash's hard reset and the new image's first publish, so a line
+        # before it cannot have come from the image that was just flashed -- and a
+        # retained $state=ready from the previous instance cannot say anything about this
+        # one either, which is what this replaced (issue #35).
+        Set-WitnessLog -Lines @(
+            'homie/d/$state 0 init'
+            'homie/d/$state 0 ready'
+        )
+
+        Assert-False -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 1 -Watermark 2)
+    }
+
+    It 'accepts a retained init as well as a live one' {
+        Set-WitnessLog -Lines @('homie/d/$state 1 init')
+
+        Assert-True -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 2 -Watermark 0)
+    }
+
+    It 'is not satisfied by init on another topic or another device' {
+        # Line-prefix match, not -like "*init*": a payload of 'init' on some other topic,
+        # or a device id that merely starts with this one, must not satisfy it.
+        Set-WitnessLog -Lines @(
+            'homie/d/n/mode 0 init'
+            'homie/device-two/$state 0 init'
+            'homie/d/$state 0 ready'
+        )
+
+        Assert-False -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 1 -Watermark 0)
+    }
+
+    It 'is not satisfied by a device id this one is a prefix of' {
+        Set-WitnessLog -Lines @('homie/d-two/$state 0 init')
+
+        Assert-False -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 1 -Watermark 0)
+    }
+
+    It 'returns false at the deadline rather than throwing on a missing log' {
+        $script:witnessLog = Join-Path (New-TestDirectory -Name 'no-log-2') 'absent.log'
+
+        Assert-False -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 1 -Watermark 0)
+    }
+}

--- a/scripts/tests/RunIntegrationTests.Tests.ps1
+++ b/scripts/tests/RunIntegrationTests.Tests.ps1
@@ -190,6 +190,44 @@ Describe 'The shipped catalog' {
     }
 }
 
+Describe 'The conformance lifecycle table' {
+    $settings = @{ SettleSeconds = 90; RecoverySeconds = 90; CommandTimeoutSeconds = 30 }
+
+    It 'drives ready -> alert -> ready -> sleeping -> ready with one refused transition' {
+        # alert may only return to ready (or disconnect), so alert -> sleeping is the one
+        # the convention's own state machine forbids. A device that advertises it as done
+        # anyway is the defect that step exists to measure.
+        Assert-Equal -Expected 5 -Actual $conformanceLifecycleSteps.Count
+
+        $refused = @($conformanceLifecycleSteps | Where-Object { $_.Refused })
+        Assert-Equal -Expected 1 -Actual $refused.Count
+        Assert-Equal -Expected 'sleeping' -Actual $refused[0].Command
+        Assert-Equal -Expected 'alert' -Actual $refused[0].Expect -Because 'a refused command must leave $state where it was'
+    }
+
+    It 'sizes the capture from the table, not from a second spelling of its length' {
+        # The defect this replaced: the count was a literal 5 about 420 lines from the
+        # table, so a sixth step left the capture one CommandTimeoutSeconds short and took
+        # the device-side log away on exactly the slow run worth reading (issue #83).
+        # Recomputing the formula would not catch that -- moving the count has to.
+        $atFive = Get-ConformanceCaptureSeconds -Settings $settings -LifecycleStepCount 5
+        $atSix = Get-ConformanceCaptureSeconds -Settings $settings -LifecycleStepCount 6
+
+        Assert-Equal -Expected $settings.CommandTimeoutSeconds -Actual ($atSix - $atFive)
+    }
+
+    It 'defaults to the shipped table' {
+        Assert-Equal -Expected (Get-ConformanceCaptureSeconds -Settings $settings -LifecycleStepCount $conformanceLifecycleSteps.Count) `
+                     -Actual (Get-ConformanceCaptureSeconds -Settings $settings)
+    }
+
+    It 'stays longer than the phases it has to outlive' {
+        # It is a ceiling, and a loose one on purpose: nothing waits this window out, and
+        # a capture that ends early loses the evidence.
+        Assert-True -Condition ((Get-ConformanceCaptureSeconds -Settings $settings) -gt ($settings.SettleSeconds + $settings.RecoverySeconds))
+    }
+}
+
 Describe 'ConvertFrom-HomieCaptureLine' {
     It 'reads topic, retain flag and payload out of a -F "%t %r %p" line' {
         $parsed = ConvertFrom-HomieCaptureLine -Line 'homie/room-sensor-office/$state 1 ready'

--- a/scripts/tests/TestRunner.Tests.ps1
+++ b/scripts/tests/TestRunner.Tests.ps1
@@ -63,6 +63,26 @@ Describe 'Assert-Equal' {
         $message = Test-AssertionFails { Assert-Equal -Expected 1 -Actual 2 -Because 'the count is wrong' }
         Assert-Match -Pattern 'the count is wrong' -Actual $message
     }
+
+    It 'refuses a collection instead of quietly passing on one that contains the value' {
+        # The reason this refusal exists rather than a comparison: PowerShell's -eq filters
+        # a collection on the left, so @('a','b') -ceq 'a' is @('a') -- truthy -- and this
+        # assertion used to PASS for that claim while still failing for
+        # -Expected @('a','b') -Actual 'z'. Selectively wrong is worse than wrong.
+        $message = Test-AssertionFails { Assert-Equal -Expected @('a', 'b') -Actual 'a' }
+
+        Assert-NotNull -Value $message -Because 'this is the case that used to pass'
+        Assert-Match -Pattern 'Assert-ArrayEqual' -Actual $message -Because 'and it has to name the right tool'
+    }
+
+    It 'refuses a collection on either side' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Equal -Expected 'a' -Actual @('a', 'b') })
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Equal -Expected @() -Actual @() })
+    }
+
+    It 'still compares strings, which are enumerable but not collections' {
+        Assert-Null -Value (Test-AssertionFails { Assert-Equal -Expected 'abc' -Actual 'abc' })
+    }
 }
 
 Describe 'Assert-ArrayEqual' {
@@ -129,6 +149,15 @@ Describe 'Assert-Match' {
     It 'fails on $null rather than treating it as an empty match' {
         Assert-NotNull -Value (Test-AssertionFails { Assert-Match -Pattern '.*' -Actual $null })
     }
+
+    It 'refuses a collection rather than reporting no match on one that matched' {
+        # -match filters a collection too, so @('cat','dog') -notmatch 'cat' is @('dog') --
+        # truthy -- and this used to report "no match" for output that plainly matched.
+        $message = Test-AssertionFails { Assert-Match -Pattern 'cat' -Actual @('cat', 'dog') }
+
+        Assert-NotNull -Value $message
+        Assert-Match -Pattern 'Join it' -Actual $message -Because 'the message has to say what to do instead'
+    }
 }
 
 Describe 'Assert-Contains' {
@@ -138,6 +167,17 @@ Describe 'Assert-Contains' {
 
     It 'passes when the item is present' {
         Assert-Null -Value (Test-AssertionFails { Assert-Contains -Item 'b' -Collection @('a', 'b') })
+    }
+
+    It 'is case-sensitive, like the rest of the runner' {
+        # -notcontains is case-insensitive, so this used to accept 'localhost' as present in
+        # @('LOCALHOST') -- and the claims this assertion carries in Common.Tests.ps1 are
+        # about exact tokens: '127.0.0.1', '%t %r %p', a topic name.
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Contains -Item 'localhost' -Collection @('LOCALHOST') })
+    }
+
+    It 'accepts a case difference under -IgnoreCase' {
+        Assert-Null -Value (Test-AssertionFails { Assert-Contains -Item 'localhost' -Collection @('LOCALHOST') -IgnoreCase })
     }
 }
 

--- a/scripts/tests/TestRunner.Tests.ps1
+++ b/scripts/tests/TestRunner.Tests.ps1
@@ -1,0 +1,197 @@
+# The runner testing itself.
+#
+# This is not ceremony. A test framework that cannot fail is the exact shape of the
+# failure this repository has already shipped: vstest exited 0 while every nanoFramework
+# test was silently skipped, and three commits went out on a green run that executed
+# nothing. Every assertion below is checked in the direction that matters -- that a false
+# claim actually fails -- because the direction that a true claim passes is proved by the
+# whole rest of the suite anyway.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-AssertionFails {
+    # Runs an assertion that is expected to fail, and returns its message. $null means it
+    # did NOT fail, which is what these cases are looking for. Anything that is not an
+    # assertion failure is re-thrown, so a genuine error in the runner still reads as one.
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Body
+    )
+
+    try {
+        & $Body | Out-Null
+        return $null
+    }
+    catch {
+        $target = $_.TargetObject
+        if ($target -is [System.Collections.IDictionary] -and $target.Contains('SmartHomeAssertion')) {
+            return $target['Message']
+        }
+        throw
+    }
+}
+
+Describe 'Assert-Equal' {
+    It 'fails when the values differ' {
+        $message = Test-AssertionFails { Assert-Equal -Expected 'a' -Actual 'b' }
+        Assert-NotNull -Value $message -Because 'a false claim must fail'
+        Assert-Match -Pattern "expected 'a', got 'b'" -Actual $message
+    }
+
+    It 'is case-sensitive by default' {
+        # The reason this default is worth a test: ConvertTo-HomieSnapshot merges two
+        # captured lines only on a byte-for-byte equal payload (-ceq), so a suite whose
+        # own comparison could not tell 'TRUE' from 'true' could not check that at all.
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Equal -Expected 'true' -Actual 'TRUE' })
+    }
+
+    It 'accepts a case difference under -IgnoreCase' {
+        Assert-Null -Value (Test-AssertionFails { Assert-Equal -Expected 'true' -Actual 'TRUE' -IgnoreCase })
+    }
+
+    It 'fails when only one side is null' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Equal -Expected 'a' -Actual $null })
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Equal -Expected $null -Actual 'a' })
+    }
+
+    It 'passes when both sides are null' {
+        Assert-Null -Value (Test-AssertionFails { Assert-Equal -Expected $null -Actual $null })
+    }
+
+    It 'prefixes the message with -Because' {
+        $message = Test-AssertionFails { Assert-Equal -Expected 1 -Actual 2 -Because 'the count is wrong' }
+        Assert-Match -Pattern 'the count is wrong' -Actual $message
+    }
+}
+
+Describe 'Assert-ArrayEqual' {
+    It 'fails on a length mismatch and says both lengths' {
+        $message = Test-AssertionFails { Assert-ArrayEqual -Expected @('a', 'b') -Actual @('a') }
+        Assert-Match -Pattern 'expected 2 item' -Actual $message
+        Assert-Match -Pattern 'got 1 item' -Actual $message
+    }
+
+    It 'fails on a content mismatch and says which index' {
+        $message = Test-AssertionFails { Assert-ArrayEqual -Expected @('a', 'b') -Actual @('a', 'c') }
+        Assert-Match -Pattern 'item 1' -Actual $message
+    }
+
+    It 'is case-sensitive' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-ArrayEqual -Expected @('a') -Actual @('A') })
+    }
+
+    It 'treats a scalar and a one-element array as equal' {
+        Assert-Null -Value (Test-AssertionFails { Assert-ArrayEqual -Expected 'a' -Actual @('a') })
+    }
+
+    It 'passes on two empty collections' {
+        Assert-Null -Value (Test-AssertionFails { Assert-ArrayEqual -Expected @() -Actual @() })
+    }
+}
+
+Describe 'Assert-True / Assert-False' {
+    It 'Assert-True fails on $false, 0 and an empty string' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-True -Condition $false })
+        Assert-NotNull -Value (Test-AssertionFails { Assert-True -Condition 0 })
+        Assert-NotNull -Value (Test-AssertionFails { Assert-True -Condition '' })
+    }
+
+    It 'Assert-False fails on $true and on a non-empty string' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-False -Condition $true })
+        Assert-NotNull -Value (Test-AssertionFails { Assert-False -Condition 'x' })
+    }
+}
+
+Describe 'Assert-Null / Assert-NotNull' {
+    It 'Assert-Null fails on an empty string, which is not null' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Null -Value '' })
+    }
+
+    It 'Assert-Null fails on an empty array, which is also not null' {
+        # Worth pinning rather than assuming: an empty array binds to an untyped
+        # parameter as an empty System.Object[], not as $null, so "no items" and "no
+        # value" are different claims here. A test that means "no items" wants
+        # Assert-ArrayEqual -Expected @(), not Assert-Null.
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Null -Value @() })
+    }
+
+    It 'Assert-NotNull fails on $null' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-NotNull -Value $null })
+    }
+}
+
+Describe 'Assert-Match' {
+    It 'fails when the pattern does not match' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Match -Pattern 'cat' -Actual 'dog' })
+    }
+
+    It 'fails on $null rather than treating it as an empty match' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Match -Pattern '.*' -Actual $null })
+    }
+}
+
+Describe 'Assert-Contains' {
+    It 'fails when the item is absent' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Contains -Item 'c' -Collection @('a', 'b') })
+    }
+
+    It 'passes when the item is present' {
+        Assert-Null -Value (Test-AssertionFails { Assert-Contains -Item 'b' -Collection @('a', 'b') })
+    }
+}
+
+Describe 'Assert-Throws' {
+    It 'fails when the body completes without throwing' {
+        $message = Test-AssertionFails { Assert-Throws -Body { 1 + 1 } }
+        Assert-Match -Pattern 'expected a terminating error' -Actual $message
+    }
+
+    It 'fails when the body throws something the pattern does not match' {
+        Assert-NotNull -Value (Test-AssertionFails { Assert-Throws -Body { throw 'boom' } -Pattern 'fizz' })
+    }
+
+    It 'returns the message when the body throws as expected' {
+        $thrown = Assert-Throws -Body { throw 'boom' } -Pattern 'boom'
+        Assert-Equal -Expected 'boom' -Actual $thrown
+    }
+}
+
+Describe 'Format-TestValue' {
+    It 'spells null, strings, booleans and arrays distinguishably' {
+        Assert-Equal -Expected '<null>' -Actual (Format-TestValue -Value $null)
+        Assert-Equal -Expected "'x'" -Actual (Format-TestValue -Value 'x')
+        Assert-Equal -Expected '$true' -Actual (Format-TestValue -Value $true)
+        Assert-Equal -Expected "@('a', 'b')" -Actual (Format-TestValue -Value @('a', 'b'))
+    }
+
+    It 'renders a hashtable with sorted keys, so two of them compare stably' {
+        Assert-Equal -Expected "@{Payload='on'; Retained=`$true}" `
+                     -Actual (Format-TestValue -Value @{ Retained = $true; Payload = 'on' })
+    }
+
+    It 'does not recurse without bound' {
+        $deep = @{ a = @{ b = @{ c = @{ d = 'too far' } } } }
+        Assert-Match -Pattern '\.\.\.' -Actual (Format-TestValue -Value $deep)
+    }
+}
+
+Describe 'New-TestDirectory' {
+    It 'creates a fresh empty directory' {
+        $dir = New-TestDirectory -Name 'runner'
+        Assert-True -Condition (Test-Path -LiteralPath $dir)
+        Assert-Equal -Expected 0 -Actual @(Get-ChildItem -LiteralPath $dir).Count
+    }
+
+    It 'creates a usable directory even when the name contains brackets' {
+        # The fixtures for issue #71 need exactly this, so the helper that builds them
+        # has to survive it too.
+        $dir = New-TestDirectory -Name 'brackets [wip]'
+        Set-TestFileContent -Path (Join-Path $dir 'probe.txt') -Content 'hello'
+        Assert-Equal -Expected 'hello' -Actual (Get-Content -LiteralPath (Join-Path $dir 'probe.txt') -Raw).Trim()
+    }
+
+    It 'hands out a different directory each time' {
+        Assert-True -Condition ((New-TestDirectory) -ne (New-TestDirectory))
+    }
+}

--- a/scripts/tests/TestRunner.ps1
+++ b/scripts/tests/TestRunner.ps1
@@ -26,10 +26,18 @@
     reconsider the trade above -- not before.
 
 .NOTES
-    Assert-Equal compares strings case-SENSITIVELY. That is the stricter default and it
-    is what the subjects want: ConvertTo-HomieSnapshot merges on -ceq, so a test that
-    could not tell 'TRUE' from 'true' could not check it. Pass -IgnoreCase where case is
-    genuinely not part of the claim.
+    Comparisons here are case-SENSITIVE (Assert-Equal, Assert-ArrayEqual, Assert-Contains).
+    That is the stricter default and it is what the subjects want: ConvertTo-HomieSnapshot
+    merges on -ceq, so a test that could not tell 'TRUE' from 'true' could not check it.
+    Assert-Equal and Assert-Contains take -IgnoreCase where case is genuinely not part of
+    the claim. Assert-Match is a regex and follows -match's own case-insensitive default;
+    write (?-i) into the pattern where that matters.
+
+    Assert-Equal and Assert-Match refuse a collection operand rather than comparing one.
+    PowerShell's -eq and -match FILTER a collection instead of returning a boolean, so
+    @('a','b') -ceq 'a' is @('a') -- truthy -- and an Assert-Equal built on it would pass
+    whenever the expected collection merely contains the actual value. Assert-ArrayEqual
+    is the tool for collections; for Assert-Match, join at the call site.
 #>
 
 Set-StrictMode -Version Latest
@@ -90,6 +98,21 @@ function Format-TestValue {
     return "$Value"
 }
 
+function Test-IsTestCollection {
+    # Everything PowerShell's comparison operators treat as a collection rather than as a
+    # single value -- which is the distinction that matters to the assertions below, and
+    # which excludes strings even though they are IEnumerable.
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Value
+    )
+
+    return ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string]))
+}
+
 function Assert-Fail {
     # Every assertion below ends here. The thrown payload is a hashtable rather than a
     # message string so It can tell an assertion apart from the subject blowing up, and
@@ -139,6 +162,18 @@ function Assert-Equal {
 
         [string]$Because
     )
+
+    # Refused rather than handled, because PowerShell's -eq FILTERS a collection on the
+    # left instead of comparing it: @('a','b') -ceq 'a' returns @('a'), which is truthy,
+    # so this assertion would silently pass whenever the expected collection merely
+    # *contains* the actual value -- and still fail when it does not, which is what makes
+    # it look like it works. Assert-ArrayEqual is the tool for collections.
+    foreach ($operand in @(@{ Name = 'Expected'; Value = $Expected }, @{ Name = 'Actual'; Value = $Actual })) {
+        if (Test-IsTestCollection -Value $operand['Value']) {
+            Assert-Fail -Message ("Assert-Equal compares single values, and -{0} is a {1}. Use Assert-ArrayEqual for collections." -f `
+                $operand['Name'], $operand['Value'].GetType().Name)
+        }
+    }
 
     if ($null -eq $Expected) {
         $same = ($null -eq $Actual)
@@ -278,6 +313,14 @@ function Assert-Match {
         [string]$Because
     )
 
+    # Same trap as Assert-Equal, in the other direction: -match on a collection filters it,
+    # so @('cat','dog') -notmatch 'cat' returns @('dog') -- truthy -- and this would report
+    # no match on output that plainly matched. Refused rather than joined, so the test says
+    # what it means: join the lines at the call site if the whole output is the claim.
+    if (Test-IsTestCollection -Value $Actual) {
+        Assert-Fail -Message ('Assert-Match compares one value, and -Actual is a {0}. Join it with -join, or pick the element the claim is about.' -f $Actual.GetType().Name)
+    }
+
     if ($null -eq $Actual -or $Actual -notmatch $Pattern) {
         $detail = "expected a match for /{0}/, got {1}" -f $Pattern, (Format-TestValue -Value $Actual)
         if ($Because) { $detail = "$Because -- $detail" }
@@ -297,10 +340,18 @@ function Assert-Contains {
         [AllowEmptyCollection()]
         $Collection,
 
+        [switch]$IgnoreCase,
+
         [string]$Because
     )
 
-    if (@($Collection) -notcontains $Item) {
+    # -cnotcontains, so this keeps the case-sensitive default the rest of the runner has.
+    # -notcontains would let 'localhost' be found in @('LOCALHOST'), which is exactly the
+    # kind of difference the claims using this assertion are about: topic names, payloads,
+    # and the '%t %r %p' format token.
+    $absent = if ($IgnoreCase) { @($Collection) -notcontains $Item } else { @($Collection) -cnotcontains $Item }
+
+    if ($absent) {
         $detail = "expected {0} among {1}" -f (Format-TestValue -Value $Item), (Format-TestValue -Value $Collection)
         if ($Because) { $detail = "$Because -- $detail" }
         Assert-Fail -Message $detail

--- a/scripts/tests/TestRunner.ps1
+++ b/scripts/tests/TestRunner.ps1
@@ -1,0 +1,491 @@
+<#
+.SYNOPSIS
+    The Describe/It/Assert-* vocabulary the files in this directory are written in.
+
+.DESCRIPTION
+    Dot-sourced by Run-ScriptTests.ps1, which is the only supported way to run it: the
+    functions here record into state that entry point owns, and a test file invoked on
+    its own has nowhere to record.
+
+    This is a runner this repository owns rather than Pester, and that is a deliberate
+    trade rather than an oversight. Pester 5 does *not* ship with Windows -- what ships,
+    and what is on this machine, is Pester 3.4.0, whose dialect ("Should Be", no
+    Should -Be) is incompatible with anything written for 5. Adopting Pester would mean
+    Install-Module on every desk, a pinned install step in CI, a row in Test-Setup.ps1
+    and an explicit version guard at every import so PowerShell does not auto-load the
+    in-box 3.4.0 instead. The whole point of this suite is that proving a host-side change
+    costs nothing, and a prerequisite that has to be installed before the first run is a
+    reason not to run it. Test-Setup.ps1 exists in this repository precisely because
+    every out-of-repo prerequisite reads as broken code the first time it is missing.
+
+    So: no modules, no network, no device. `.\scripts\Run-ScriptTests.ps1` works on a
+    fresh clone with nothing installed, and on the CI runner unchanged.
+
+    What is deliberately not here: mocking, test discovery by attribute, parallelism,
+    NUnit/JUnit output. If one of those becomes load-bearing, that is the moment to
+    reconsider the trade above -- not before.
+
+.NOTES
+    Assert-Equal compares strings case-SENSITIVELY. That is the stricter default and it
+    is what the subjects want: ConvertTo-HomieSnapshot merges on -ceq, so a test that
+    could not tell 'TRUE' from 'true' could not check it. Pass -IgnoreCase where case is
+    genuinely not part of the claim.
+#>
+
+Set-StrictMode -Version Latest
+
+# Read by Assert-Fail to skip its own frames when it works out which line failed. Set
+# here rather than passed around because every assertion needs it.
+$SmartHomeTestRunnerPath = $PSCommandPath
+
+# One object, mutated in place. Mutating a property works from any scope that can *read*
+# the variable, and reading walks the scope chain -- so a test file invoked with & from
+# the entry point records into the same state without any $script:/$global: ceremony.
+$SmartHomeTestState = @{
+    Total     = 0
+    Passed    = 0
+    Failed    = 0
+    Skipped   = 0
+    Group     = ''
+    Depth     = 0
+    Failures  = @()
+    Filter    = $null
+    Detailed  = $false
+    TempRoot  = $null
+    TempCount = 0
+}
+
+function Format-TestValue {
+    # How a value is spelled in a failure message. Values in this suite are strings,
+    # booleans, ints, string arrays and small hashtables; anything else falls through to
+    # its own ToString, which is enough to tell two of them apart.
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Value,
+
+        [int]$Depth = 0
+    )
+
+    if ($null -eq $Value) { return '<null>' }
+    if ($Value -is [string]) { return "'$Value'" }
+    if ($Value -is [bool]) { return ('$' + $Value.ToString().ToLowerInvariant()) }
+
+    if ($Depth -ge 3) { return '...' }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        $pairs = @($Value.Keys | Sort-Object | ForEach-Object {
+            "{0}={1}" -f $_, (Format-TestValue -Value $Value[$_] -Depth ($Depth + 1))
+        })
+        return '@{' + ($pairs -join '; ') + '}'
+    }
+
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $items = @(@($Value) | ForEach-Object { Format-TestValue -Value $_ -Depth ($Depth + 1) })
+        return '@(' + ($items -join ', ') + ')'
+    }
+
+    return "$Value"
+}
+
+function Assert-Fail {
+    # Every assertion below ends here. The thrown payload is a hashtable rather than a
+    # message string so It can tell an assertion apart from the subject blowing up, and
+    # so it can report the *test's* line: an ErrorRecord caught from a throw inside this
+    # file points at this file, which is never the interesting location.
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    # Found by skipping every frame belonging to this file rather than by a fixed depth,
+    # so an assertion built on another assertion still reports the test's own line.
+    $frame = @(Get-PSCallStack |
+        Where-Object { $_.ScriptName -and $_.ScriptName -ne $SmartHomeTestRunnerPath }) |
+        Select-Object -First 1
+
+    $scriptName = '<unknown>'
+    $line = 0
+    if ($frame) {
+        $scriptName = $frame.ScriptName
+        $line = $frame.ScriptLineNumber
+    }
+
+    throw @{
+        SmartHomeAssertion = $true
+        Message            = $Message
+        ScriptName         = $scriptName
+        Line               = $line
+    }
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Expected,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Actual,
+
+        [switch]$IgnoreCase,
+
+        [string]$Because
+    )
+
+    if ($null -eq $Expected) {
+        $same = ($null -eq $Actual)
+    }
+    elseif ($null -eq $Actual) {
+        $same = $false
+    }
+    elseif ($IgnoreCase) {
+        $same = ($Expected -eq $Actual)
+    }
+    else {
+        $same = ($Expected -ceq $Actual)
+    }
+
+    if (-not $same) {
+        $detail = "expected {0}, got {1}" -f (Format-TestValue -Value $Expected), (Format-TestValue -Value $Actual)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-ArrayEqual {
+    # Element-by-element, so a length mismatch and a content mismatch read differently.
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $Expected,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $Actual,
+
+        [string]$Because
+    )
+
+    $expectedItems = @($Expected)
+    $actualItems = @($Actual)
+
+    $prefix = ''
+    if ($Because) { $prefix = "$Because -- " }
+
+    if ($expectedItems.Count -ne $actualItems.Count) {
+        Assert-Fail -Message ("{0}expected {1} item(s) {2}, got {3} item(s) {4}" -f `
+            $prefix, $expectedItems.Count, (Format-TestValue -Value $expectedItems),
+            $actualItems.Count, (Format-TestValue -Value $actualItems))
+    }
+
+    for ($i = 0; $i -lt $expectedItems.Count; $i++) {
+        if ($expectedItems[$i] -cne $actualItems[$i]) {
+            Assert-Fail -Message ("{0}item {1}: expected {2}, got {3} (full: {4})" -f `
+                $prefix, $i, (Format-TestValue -Value $expectedItems[$i]),
+                (Format-TestValue -Value $actualItems[$i]), (Format-TestValue -Value $actualItems))
+        }
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $Condition,
+
+        [string]$Because
+    )
+
+    if (-not $Condition) {
+        $detail = "expected a true value, got {0}" -f (Format-TestValue -Value $Condition)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-False {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $Condition,
+
+        [string]$Because
+    )
+
+    if ($Condition) {
+        $detail = "expected a false value, got {0}" -f (Format-TestValue -Value $Condition)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-Null {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Value,
+
+        [string]$Because
+    )
+
+    if ($null -ne $Value) {
+        $detail = "expected <null>, got {0}" -f (Format-TestValue -Value $Value)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-NotNull {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Value,
+
+        [string]$Because
+    )
+
+    if ($null -eq $Value) {
+        $detail = 'expected a value, got <null>'
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-Match {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        $Actual,
+
+        [string]$Because
+    )
+
+    if ($null -eq $Actual -or $Actual -notmatch $Pattern) {
+        $detail = "expected a match for /{0}/, got {1}" -f $Pattern, (Format-TestValue -Value $Actual)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        $Item,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $Collection,
+
+        [string]$Because
+    )
+
+    if (@($Collection) -notcontains $Item) {
+        $detail = "expected {0} among {1}" -f (Format-TestValue -Value $Item), (Format-TestValue -Value $Collection)
+        if ($Because) { $detail = "$Because -- $detail" }
+        Assert-Fail -Message $detail
+    }
+}
+
+function Assert-Throws {
+    # Asserts the body raises a terminating error, optionally one whose message matches.
+    # Returns the message, so a caller can assert more about it than one pattern.
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Body,
+
+        [string]$Pattern,
+
+        [string]$Because
+    )
+
+    $prefix = ''
+    if ($Because) { $prefix = "$Because -- " }
+
+    try {
+        & $Body | Out-Null
+    }
+    catch {
+        $message = $_.Exception.Message
+        if ($Pattern -and $message -notmatch $Pattern) {
+            Assert-Fail -Message ("{0}threw, but the message did not match /{1}/: '{2}'" -f $prefix, $Pattern, $message)
+        }
+        return $message
+    }
+
+    Assert-Fail -Message ($prefix + 'expected a terminating error, but the body completed')
+}
+
+function Describe {
+    # A group. Nesting is allowed and shows as 'outer / inner'; an error escaping the body
+    # itself (rather than an It) is recorded as a failure of the group instead of ending
+    # the file, so one broken group does not hide every test after it.
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [scriptblock]$Body
+    )
+
+    $state = $SmartHomeTestState
+    $previousGroup = $state.Group
+    $state.Group = if ($previousGroup) { "$previousGroup / $Name" } else { $Name }
+    $state.Depth++
+
+    $passedBefore = $state.Passed
+    $failedBefore = $state.Failed
+
+    try {
+        & $Body | Out-Null
+    }
+    catch {
+        Add-TestFailure -Name '<group body>' -Record $_
+        $state.Failed++
+        $state.Total++
+    }
+    finally {
+        $passed = $state.Passed - $passedBefore
+        $failed = $state.Failed - $failedBefore
+        $indent = '  ' * ($state.Depth - 1)
+        $label = "{0}{1}" -f $indent, $Name
+        $counts = if ($failed -gt 0) { "{0} passed, {1} FAILED" -f $passed, $failed } else { "{0} passed" -f $passed }
+        $colour = if ($failed -gt 0) { 'Red' } else { 'DarkGray' }
+        Write-Host ("  {0,-62} {1}" -f $label, $counts) -ForegroundColor $colour
+
+        $state.Depth--
+        $state.Group = $previousGroup
+    }
+}
+
+function Add-TestFailure {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord]$Record
+    )
+
+    $state = $SmartHomeTestState
+    $full = if ($state.Group) { "{0} :: {1}" -f $state.Group, $Name } else { $Name }
+
+    $target = $Record.TargetObject
+    if ($target -is [System.Collections.IDictionary] -and $target.Contains('SmartHomeAssertion')) {
+        $message = $target['Message']
+        $where = "{0}:{1}" -f (Split-Path -Leaf $target['ScriptName']), $target['Line']
+    }
+    else {
+        # Not an assertion: the subject itself threw, which is a result too -- report the
+        # exception type as well, because "the string is null" and "expected 3, got 4"
+        # want different next steps.
+        $message = "{0}: {1}" -f $Record.Exception.GetType().Name, $Record.Exception.Message
+        $where = '<unknown>'
+        $info = $Record.InvocationInfo
+        if ($info -and $info.ScriptName) {
+            $where = "{0}:{1}" -f (Split-Path -Leaf $info.ScriptName), $info.ScriptLineNumber
+        }
+    }
+
+    $state.Failures += @{
+        Name    = $full
+        Message = $message
+        Where   = $where
+    }
+}
+
+function It {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [scriptblock]$Body
+    )
+
+    $state = $SmartHomeTestState
+    $full = if ($state.Group) { "{0} :: {1}" -f $state.Group, $Name } else { $Name }
+
+    if ($state.Filter -and ($full -notlike $state.Filter)) {
+        $state.Skipped++
+        return
+    }
+
+    $state.Total++
+
+    try {
+        & $Body | Out-Null
+        $state.Passed++
+        if ($state.Detailed) {
+            Write-Host ("      ok   {0}" -f $Name) -ForegroundColor DarkGray
+        }
+    }
+    catch {
+        $state.Failed++
+        Add-TestFailure -Name $Name -Record $_
+        if ($state.Detailed) {
+            Write-Host ("      FAIL {0}" -f $Name) -ForegroundColor Red
+        }
+    }
+}
+
+function New-TestDirectory {
+    # A fresh empty directory under this run's temp root, removed with it at the end.
+    # -Name is appended so a fixture can be recognised in a debugger; it may contain
+    # anything legal in a Windows directory name, brackets included -- which is the point
+    # for the tests that reproduce issue #71.
+    param(
+        [string]$Name = 'fixture'
+    )
+
+    $state = $SmartHomeTestState
+    if (-not $state.TempRoot) {
+        Assert-Fail -Message 'New-TestDirectory was called before the run had a temp root; run tests through Run-ScriptTests.ps1.'
+    }
+
+    $state.TempCount++
+    $path = Join-Path $state.TempRoot ("{0:d3}-{1}" -f $state.TempCount, $Name)
+    New-Item -ItemType Directory -Force -Path $path | Out-Null
+    return $path
+}
+
+function Set-TestFileContent {
+    # Write-a-file helper, on -LiteralPath throughout so a fixture under a bracketed
+    # directory can be built at all.
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        $Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+
+    Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8
+}


### PR DESCRIPTION
Closes #74. Also closes #83, which the backlog queue asked to fold in here if this landed first.

`scripts\` decides what the integration suite reports, and none of it had anywhere to be tested. Proving a change meant running the whole on-device suite or building a throwaway harness — four of those were written and deleted in a week (78 cases, none re-runnable), and each re-implemented the same trick: lift the functions out of `Run-IntegrationTests.ps1` with the PowerShell AST, because dot-sourcing it runs the suite.

## What is here

**The load-bearing part: the AST trick is no longer needed.** `Run-IntegrationTests.ps1` keeps its catalog and its functions at file scope and puts the run — reading `local.env`, the pre-flight, the broker, the deploy loop — behind a guard, so a dot-source defines everything and does nothing. The guard reads `$MyInvocation.InvocationName`, which is `.` for every spelling of a dot-source and the path or `&` for every spelling of a run, so the safe answer is the default: **a dot-source can never start a suite that flashes the device.** An `-AsLibrary` switch would have inverted that.

The catalog validation moved into `Get-CatalogValidationError`, which returns the first violation instead of writing it and exiting, so the rules can be asserted without a run.

**`scripts\Run-ScriptTests.ps1`** runs `scripts\tests\*.Tests.ps1`: **113 cases in ~6s**, needing nothing installed. A run that executed zero tests fails, on the same reasoning `Run-Tests.ps1` already carries.

**CI runs it first**, before the MSBuild and nanoFramework setup, because it needs none of it. It is the only automated coverage this repository has of the integration tooling itself — #22's unit tests run on the virtual device and cannot reach a PowerShell function.

## Two decisions worth reviewing

**Not Pester.** Pester 5 does not ship with Windows. What ships, and what is on this machine, is Pester **3.4.0**, whose dialect (`Should Be`, not `Should -Be`) is incompatible with anything written for 5. Adopting it would mean `Install-Module` on every desk, a pinned install step in CI, a row in `Test-Setup.ps1`, and a version guard at every import so PowerShell does not auto-load the in-box 3.4.0. The point of the suite is that proving a host-side change costs nothing, and a prerequisite that has to be installed first is a reason not to run it — which is why `Test-Setup.ps1` exists at all. The runner is ~200 lines of `Describe`/`It`/`Assert-*` this repository owns; `TestRunner.ps1` records the trade and what would make it worth revisiting.

**The guard, not hoisting helpers.** #74's point 2 offered either. The guard makes every one of the 32 functions reachable in one ~90-line move; hoisting would have grown `Common.ps1` past 1500 lines and mixed suite-specific logic into it. The duplication that hoisting would also have fixed is filed as #85 rather than folded in.

## What was verified

**Nothing ran on hardware. Nothing was deployed. The device was not touched** — it is still on `MqttReconnectCheck`, where the last suite run left it.

- `Run-ScriptTests.ps1`: **113 passed, 0 failed, exit 0**.
- **With both `local.env` files moved aside: 113 passed, exit 0.** That is the CI claim, checked rather than assumed.
- The failure paths, checked deliberately: a filter matching nothing exits 1 with "No tests ran"; a deliberately failing file exits 1 and reports the assertion and the exception with the right file and line.
- The dot-source guard, in a child process: 32 functions and the 5-entry catalog defined, `$repoRoot` undefined, `$LogDirectory` empty, no log directory created, in ~200ms. A second case walks the AST and asserts every top-level statement above the guard is a declaration, so an `Import-SmartHomeLocalEnv` or a `Test-Path` cannot drift back to the top of the file.
- `Run-IntegrationTests.ps1`'s two safe run paths still behave: `-Tests NoSuchTest` and `MqttReconnectCheck -NoBroker` report the same messages and exit 1, both before anything is built or flashed.
- `Test-Setup.ps1`: 16 checked, 0 failed.

**What a green run here does not claim.** `Start-HomieCapture`, `Wait-ForRetainedValue`, `Invoke-BrokerOutageCheck` and `Invoke-HomieConformanceCheck` are not covered — they own a process or a broker. Only `Run-IntegrationTests.ps1` on real hardware proves those, and this suite is not a substitute for saying so. That boundary is written into the skill and filed as #84.

## The review pass found real defects, in the runner itself

`/code-review high` over the first commit found three, all fixed in `d3ce4f4` with six regression cases:

- **`Assert-Equal` passed for a false claim.** PowerShell's comparison operators *filter* a collection rather than returning a boolean, so `@('a','b') -ceq 'a'` is `@('a')` — truthy — and `Assert-Equal -Expected @('a','b') -Actual 'a'` **passed**. It still failed for `-Actual 'z'`, which is what made it look like it worked: a test framework selectively unable to fail, which is the exact shape of the green-run-that-executed-nothing this repository has already shipped. Both operands are now refused with a message naming `Assert-ArrayEqual`.
- **`Assert-Match` had the same trap in the other direction** — `@('cat','dog') -notmatch 'cat'` is `@('dog')`, so it reported no match on output that plainly matched.
- **`Assert-Contains` was case-insensitive**, contradicting the case-sensitive default the rest of the runner keeps — and the claims already carried on it are about exact tokens (`127.0.0.1`, `%t %r %p`).

The suite also caught a bug in this branch while it was being written: `Get-CatalogValidationError`'s `$requiredKeys` local and its `$RequiredKeys` parameter are the same variable, because PowerShell names are case-insensitive, so the local assignment wrote a `string[]` into a `[hashtable]`-typed parameter. Renamed, with a comment.

## #83, folded in

`Get-ConformanceCaptureSeconds` sized the debug capture from a literal `$lifecycleSteps = 5`, about 420 lines from the five-element array `Measure-HomieConformance` walks. The table moved to file scope and both read it. `-LifecycleStepCount` is defaulted from it, which is what makes the fix provable: a test that recomputed the formula would pass against a literal too, so the case asserts that moving the count from 5 to 6 moves the budget by exactly one `CommandTimeoutSeconds`. Latent, not observed — every call today has five steps.

## Two known defects are pinned rather than endorsed

So their fixes have to come past a failing test: `Get-NanoFrameworkTestAdapterDir` picking `3.0.9` over `3.0.80` by text sort (#79 — the next queued item), and `Get-NfProjectAssemblyName` failing on a bracketed project path (#80).

The second turned out to fail differently from how #80 records it — at parameter binding, not as `ItemNotFound`, because `-Raw` is a FileSystem dynamic parameter resolved from the provider of the *resolved* path. [Corrected on #80](https://github.com/JojoEffect/SmartHome/issues/80#issuecomment-5498673479), since grepping for `ItemNotFound` would not find it.

## Filed, not fixed

- **#84** — the verdict functions that own a process or a broker are still uncovered, and `Test-Attribute` cannot be reached from a test at all (it is nested inside `Measure-HomieConformance` and closes over a `$snapshot` reassigned later in the same scope). That one decides whether the conformance assertions can be covered.
- **#85** — five duplications between `Run-IntegrationTests.ps1` and `Start-DevEnv.ps1` that a `/simplify` pass recorded on #74 on the assumption this change would absorb them. It did not, so they needed a home rather than closing with #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
