### PR TITLE
fix(deploy): ask the device what to erase instead of guessing

### DIFF
--- a/.claude/agents/device-ops.md
+++ b/.claude/agents/device-ops.md
@@ -20,16 +20,17 @@ Scripts you own (each has a matching `.claude/skills/smarthome-*` skill too):
 - Don't rewrite `Start-DevEnv.ps1`'s child launches to use `-RedirectStandardOutput`: that forces
   handle inheritance and makes piping the script's output hang forever. The ShellExecute +
   `log_dest file` + `cmd.exe` wrapper arrangement is deliberate and commented in the script.
-- `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug|Release] [-DeployAddress <hex>] [-FullPad]`
-  — build + flash. `-FullPad` pads the flat 400KB worst case instead of sizing the 0xFF pad
-  from the per-COM-port record of the last flash — use it on the first deploy after someone
-  has deployed from Visual Studio, which writes the deployment partition behind this script's
-  back. `-DeployAddress` defaults to this device's current real `deploy` partition
+- `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug|Release] [-DeployAddress <hex>]`
+  — build + flash. Before the flash it has the device erase anything past the new image's end,
+  over the debugger connection, so a Visual Studio deploy or a hardware unit-test run in between
+  needs no switch and nothing remembered. If it warns that it could not clear the deployment
+  area, Visual Studio is usually holding that connection; the flash still goes ahead, padded to
+  the whole partition. `-DeployAddress` defaults to this device's current real `deploy` partition
   offset (`0x1E0000`) — `nanoff`'s own hardcoded default (`0x1B0000`) landed inside the
-  **factory** partition instead and silently produced a deploy the CLR could never load. If a
-  deploy "succeeds" but the device never does anything afterward, verify with
-  `Watch-DeviceDebugOutput.ps1` before assuming it's an application bug — check for
-  `CLR_E_WRONG_TYPE` / zero-assembly resolution, which means this address is stale again.
+  **factory** partition instead and silently produced a deploy the CLR could never load. The
+  script now cross-checks that address against what the device reports and refuses to flash on a
+  mismatch, so a stale address surfaces as a refusal rather than as a device that boots and does
+  nothing.
 - `scripts\Run-Tests.ps1` — build + run the `SmartHome.UnitTests` unit suite on hardware.
 - `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` — the whole `src\integrationTests`
   suite in one call: starts a detached broker, then per test deploys, captures managed debug

--- a/.claude/skills/smarthome-deploy/SKILL.md
+++ b/.claude/skills/smarthome-deploy/SKILL.md
@@ -13,15 +13,24 @@ hard way), then flashes via `nanoff`.
 .\scripts\Deploy-ToDevice.ps1                                                    # RoomSensor, Debug
 .\scripts\Deploy-ToDevice.ps1 -Project src\devices\IrrigationControl\IrrigationControl.nfproj
 .\scripts\Deploy-ToDevice.ps1 -Configuration Release
-.\scripts\Deploy-ToDevice.ps1 -FullPad                                           # after a VS deploy
 ```
 
-The image is padded with 0xFF far enough to erase whatever the previous deploy left behind —
-sized from a per-COM-port record of the last flash, falling back to a flat 400KB whenever that
-record can't be trusted. **Pass `-FullPad` on the first deploy after anyone has deployed from
-Visual Studio**, since VS writes the deployment partition without going through this script and
-the record then describes an image that is no longer on the device. `Run-Tests.ps1` clears the
-record itself, so no `-FullPad` is needed after a unit-test run.
+`nanoff` erases only as much as it writes, so a smaller app flashed after a larger one would
+leave the larger one's tail where the CLR still finds and loads it. The script has the **device**
+erase anything past the new image's end, over the debugger connection, immediately before the
+flash — so a deploy from Visual Studio or a hardware unit-test run in between needs nothing
+remembered and no switch. There is no per-machine record any more, and no `-FullPad`.
+
+Two things it prints that are worth reading rather than scrolling past:
+
+- **"Could not clear the deployment area"** — the device would not talk, usually because Visual
+  Studio holds the debugger connection. Not a failure: the flash goes ahead with the image padded
+  to the whole partition, which is slower and equally safe. Closing VS's device window makes the
+  next deploy quick again.
+- **A refused flash naming a different deploy address** — the device reports its deploy partition
+  somewhere other than `-DeployAddress`. Take that seriously: flashing at the wrong address writes
+  into a partition the CLR never scans, `nanoff` reports success anyway, and the app silently never
+  runs. Pass the address the device reported.
 
 To deploy an integration test (`src\integrationTests\*`), prefer
 `smarthome-integration-tests` — it deploys, captures, and reads the verdict in one call instead

--- a/.claude/skills/smarthome-integration-tests/SKILL.md
+++ b/.claude/skills/smarthome-integration-tests/SKILL.md
@@ -69,9 +69,11 @@ Outcomes other than PASS/FAIL:
 - `ERROR` — deploy or capture itself failed; the message is the sub-script's own error.
 - `WRONG-TEST` — the device emitted a marker naming a different assembly than the one just
   flashed, so a previous test is still answering. Two causes, and they point opposite ways:
-  the flash failed (nanoff's own output says so), or it succeeded but under-padded and left the
-  old assembly in the deployment partition for the CLR to find (nanoff looks perfectly healthy —
-  see the Deploy padding notes, and issue #46). Both names come from one `<AssemblyName>` (the
+  the flash failed (nanoff's own output says so), or it succeeded onto a deployment area that
+  was never cleared, leaving the old assembly there for the CLR to find (nanoff looks perfectly
+  healthy — see the Clearing the deployment area notes, and issue #46). Since #46 the deploy has
+  the device erase that itself, and **warns** when it could not, so check the deploy output for
+  that warning before anything else. Both names come from one `<AssemblyName>` (the
   device reads its own at runtime, the runner reads the project's in the pre-flight), so this
   can no longer mean a naming slip — that was issue #20.
 - `RESTARTED` — BrokerOutage only. The device did publish again, but its heartbeat counter went

--- a/.claude/skills/smarthome-script-tests/SKILL.md
+++ b/.claude/skills/smarthome-script-tests/SKILL.md
@@ -27,7 +27,8 @@ Useful switches:
 `scripts\` decides what the integration suite reports, and it is the half of the suite a desk can
 exercise: `Get-CatalogValidationError`, `ConvertFrom-HomieCaptureLine`, `ConvertTo-HomieSnapshot`,
 `Get-HomieLivePayloads`, `Wait-ForAnnounceWitnessed`, `Get-SubscriberLogLineCount`, plus
-`Common.ps1`'s path globs, dev-environment state and the deploy-padding record.
+`Common.ps1`'s path globs, dev-environment state and the deployment-geometry parse the deploy
+cross-checks its flash address against.
 
 It does **not** cover anything that needs a broker, a subscriber process or the device —
 `Start-HomieCapture`'s connect wait, `Invoke-BrokerOutageCheck`, `Invoke-HomieConformanceCheck`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ have a script yet, that's a gap worth closing rather than working around.
 |---|---|---|---|
 | `scripts\Start-DevEnv.ps1 [-NoSync] [-Detached]` | Syncs the sibling repos (unless `-NoSync`), then starts local Mosquitto (explicit `0.0.0.0` listener — a bare `-p` binds localhost-only on Mosquitto 2.x and silently can't be reached from a real device) and subscribes to `homie/#`. `-Detached` backgrounds both and returns | No | `smarthome-dev-env` |
 | `scripts\Stop-DevEnv.ps1 [-KeepLog] [-IncludeOrphans]` | Stops whatever `Start-DevEnv.ps1` recorded for the configured port, verifying pid+name+start-time first so a recycled pid is never killed. No-op + exit 0 if nothing is running, so it's safe to call unconditionally. `-IncludeOrphans` also clears brokers/subscribers this repo started that no state file covers | No | `smarthome-dev-env` |
-| `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug\|Release] [-FullPad]` | Always `/t:Rebuild`s (a plain incremental build silently drops the deployment `.bin`) then flashes via `nanoff`, padding the image with 0xFF far enough to erase the previous one (see Deploy padding below). `-FullPad` after a Visual Studio deploy | **Yes** | `smarthome-deploy` |
+| `scripts\Deploy-ToDevice.ps1 [-Project <path>] [-Configuration Debug\|Release]` | Always `/t:Rebuild`s (a plain incremental build silently drops the deployment `.bin`), has the device erase whatever sits past the new image's end, then flashes via `nanoff` (see Clearing the deployment area below) | **Yes** | `smarthome-deploy` |
 | `scripts\Run-Tests.ps1` | Builds `SmartHome.UnitTests` and runs it via `vstest.console` + the nanoFramework test adapter | **Yes** | `smarthome-test` |
 | `scripts\Run-ScriptTests.ps1 [-File <names>] [-Name <wildcard>] [-Detailed]` | The host-side script tests: `scripts\tests\*.Tests.ps1`, run by this repo's own `TestRunner.ps1`. ~100 cases in ~6s, needing nothing installed — no device, no broker, no `local.env`, no `packages\`, no Pester. A run that executed zero tests fails | No | `smarthome-script-tests` |
 | `scripts\Run-IntegrationTests.ps1 [-Tests <names>] [-NoBroker]` | The whole `src\integrationTests` suite in one call: broker up, deploy + capture + verdict per test, broker down, summary + exit code | **Yes** | `smarthome-integration-tests` |
@@ -87,32 +87,57 @@ If a new recurring unit of work shows up that isn't covered by an existing scrip
 `Write-Error` remediation) and give it a matching skill — that's the standing expectation for
 this repo, not a one-time cleanup.
 
-### Deploy padding
+### Clearing the deployment area
 
 `nanoff` erases and writes only the image file's own byte length, so a smaller app flashed
 after a larger one leaves the larger one's tail unerased past the new image's end — and the
 CLR finds it. It walks the *whole* deployment partition looking for assembly headers and, on
 a header that doesn't check out, moves to the next candidate rather than stopping
 (`ContiguousBlockAssemblies` in `nf-interpreter`'s `src/CLR/Startup/CLRStartup.cpp`). No
-amount of trailing blank flash terminates that scan; only overwriting the stale bytes does.
-`Deploy-ToDevice.ps1` therefore pads every image with 0xFF, and the invariant it has to hold
-is exactly "cover the footprint of the previous image".
+amount of trailing blank flash terminates that scan; only erasing the stale bytes does. So
+every deploy has to hold exactly one invariant: **nothing but erased flash past the end of
+the image being written**.
 
-It used to pad every image to a flat 400KB, which held that invariant by brute force. It now
-records the last flashed size per COM port (in `%TEMP%\smarthome-deploy-<port>.json`, written
-pessimistically before the flash and tightened after it) and pads to `max(this image, that
-record)` rounded up to a 4KB sector — same guarantee, roughly half the erase-and-verify
-footprint across a suite run. Anything the record can't vouch for — missing, corrupt, a
-different `-DeployAddress`, `-FullPad` — falls back to the flat 400KB, never to the bare
-image size, and never below a larger footprint the record does vouch for at this address
-(`-FullPad` distrusts how *tight* the record is, not its floor). An image bigger than the
-400KB fallback deploys fine but warns, because the fallback stops being a worst case the
-moment one exists.
+`Deploy-ToDevice.ps1` asks the device to hold it, immediately before the flash. Nothing on
+this machine has to know what is already on the device, so nothing can be wrong about it.
+Three attempts at that question, of which only the third works, all checked against the
+pinned sibling checkouts rather than assumed:
 
-The record only describes what *this script* flashed. Visual Studio's F5 deploy and the
-nanoFramework test adapter both write the deployment partition themselves, and erase only
-their own footprint too. `Run-Tests.ps1` clears the record for that reason; Visual Studio
-can't, so pass `-FullPad` on the first deploy after one.
+- `Monitor_DeploymentMap`, the command whose name promises the used extent, is a **stub** in
+  the firmware — it replies with an empty payload (`Debugger.cpp`), so `nf-debugger`'s
+  `GetDeploymentMap()` always hands back an empty list.
+- `Debugging_Deployment_Status` reports the partition's **start and length** — its geometry,
+  not how much of it is in use.
+- `AccessMemory_Read` over the deploy partition is **refused**: `CheckPermission` lists no
+  `BLOCKTYPE_DEPLOYMENT` case for reads. (`Watch-DeviceDebugOutput.ps1 -DumpConfig` reads the
+  *config* partition, which is permitted — that is why that one works.)
+- `AccessMemory_Erase` **does** list it, and the firmware skips the erase when the region from
+  the given address to the end of the partition is already blank
+  (`Esp32FlashDriver_IsBlockErased`). Same command Visual Studio's own deploy issues before it
+  writes (`DeploymentExecute` in `nf-debugger`'s `WireProtocol/Engine.cs`).
+
+So the device is told to erase rather than asked what is there, through
+`DeviceDebugMonitor --erase-deployment <keep-bytes>` and `Clear-SmartHomeDeviceDeployment` in
+`Common.ps1`. On ESP32 an erase that *is* needed takes the whole partition with it
+(`Esp32FlashDriver_EraseBlock` ignores the address), so the device has no app between that
+call and the flash — which is why it runs immediately before, not as a tidy-up step.
+
+That call also returns the partition's real geometry, and the deploy **refuses to flash** when
+the device's start address disagrees with `-DeployAddress`. That mismatch is the failure that
+cost a whole debugging session: `nanoff`'s own default address landed in the *factory*
+partition on this device's layout, every deploy silently never ran, and `nanoff` reported
+success either way. A reported partition *length* that disagrees with `-DeployPartitionSize`
+is a warning, and the device's value wins.
+
+Until 2026-09-02 the script guessed instead, padding each image with 0xFF as far as a
+per-COM-port record of what *it* last flashed (issue #46). The record could only ever describe
+this script's own flashes — Visual Studio's F5 deploy and the nanoFramework test adapter write
+the same partition over the debugger connection and erase only their own footprint too — so
+`Run-Tests.ps1` had to invalidate it, Visual Studio could not, and a `-FullPad` switch existed
+for the case only a human could notice. Record, switch and `Run-Tests.ps1`'s call are all gone.
+The 0xFF pad survives as the fallback for one case: the device could not be reached at all (VS
+holding the debugger connection is the usual reason), where the image is padded to the whole
+partition and the flash goes ahead with a warning.
 
 ## First-time setup
 
@@ -463,8 +488,8 @@ per-project `TestName` const — a third independent spelling of one name that n
 build reconciled, and whose drift surfaced as a `WRONG-TEST` verdict 90 seconds into a hardware
 run, in the same shape as a stale deploy (issue #20). `WRONG-TEST` still exists and now means
 only that: the app answering is not the one just flashed — either because the flash failed, or
-because it succeeded but under-padded and left the old assembly where the CLR still finds it
-(Deploy padding above, and issue #46). The type has to come from the caller
+because it succeeded but left the old assembly where the CLR still finds it (Clearing the
+deployment area above, which is what #46 closed). The type has to come from the caller
 rather than `Assembly.GetExecutingAssembly()` because `IntegrationTest` ships both ways — as a
 `TestSupport` reference and as a linked source file — and would otherwise name `TestSupport`
 for some tests and the test itself for others.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,15 @@ pinned sibling checkouts rather than assumed:
 - `Monitor_DeploymentMap`, the command whose name promises the used extent, is a **stub** in
   the firmware — it replies with an empty payload (`Debugger.cpp`), so `nf-debugger`'s
   `GetDeploymentMap()` always hands back an empty list.
-- `Debugging_Deployment_Status` reports the partition's **start and length** — its geometry,
-  not how much of it is in use.
+- `Debugging_Deployment_Status` reads as the direct question and **does not work here**: on
+  this ESP32 it comes back with no usable geometry. Nothing in `nf-debugger`'s own ESP32 path
+  depends on it either — `DeploymentExecuteFull` is its only caller, and the ESP32 reports
+  `IncrementalDeployment`, so `DeploymentExecuteIncremental` is what actually runs. Measured on
+  the device on 2026-09-02, not reasoned about.
+- The **flash sector map** (`Monitor_FlashSectorMap`, a `Monitor_` command rather than a
+  `Debugging_` one) does answer, and its `c_MEMORY_USAGE_DEPLOYMENT` entry gives the partition's
+  start and size — its geometry, not how much of it is in use. `0x1E0000` / `1835008`, which
+  is exactly what `-DeployAddress` and `-DeployPartitionSize` had been carrying from a boot log.
 - `AccessMemory_Read` over the deploy partition is **refused**: `CheckPermission` lists no
   `BLOCKTYPE_DEPLOYMENT` case for reads. (`Watch-DeviceDebugOutput.ps1 -DumpConfig` reads the
   *config* partition, which is permitted — that is why that one works.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,11 @@ stops the run at its first line, ahead of any build, flash or broker start.
 ### Required local tools
 
 - [nanoFramework VS extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension)
+- [.NET SDK](https://dotnet.microsoft.com/download) — not just the runtime.
+  `tools\DeviceDebugMonitor` is a net8.0 project, and it is built by every debug capture
+  *and* by every deploy (which now has the device clear its deployment area first). A
+  machine that installed `nanoff` as a global tool has only the runtime, so this does not
+  come for free with the line below it
 - `nanoff` CLI: `dotnet tool install -g nanoff`
 - [Mosquitto](https://mosquitto.org/download/)
 - Git on PATH

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1056,6 +1056,7 @@ function Stop-SmartHomeDevEnv {
 #
 # So there is no state file here any more, and nothing to invalidate: a flash from any
 # source is handled by the erase immediately before the next one.
+
 # Case-insensitive about the rendering and strict about the shape: the number is
 # produced by a C# format string in another file, and this has no business failing a
 # deploy over how that file spells its hex prefix -- but it does have business refusing
@@ -1156,33 +1157,67 @@ function Clear-SmartHomeDeviceDeployment {
         return @{ Ok = $false; Detail = $_.Exception.Message }
     }
 
-    # Built every call rather than once per session. An up-to-date build is a ~2s no-op,
-    # and the alternative -- a switch the caller has to remember to pass -- is the shape
-    # of bookkeeping this whole change exists to delete. Issue #19 is the version worth
-    # having: resolve the built exe once and invoke it directly, for this and for the
-    # captures, rather than paying dotnet's project evaluation every time.
-    dotnet build $projectPath --nologo -v quiet | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        return @{ Ok = $false; Detail = "DeviceDebugMonitor failed to build (exit code $LASTEXITCODE)." }
+    # Both dotnet calls inside one try. Not defensive habit: the caller runs under
+    # $ErrorActionPreference = 'Stop', so a machine with no .NET SDK -- which is every
+    # machine that installed nanoff as a global tool and nothing else, since a global
+    # tool needs only the runtime -- would otherwise abort the deploy on a
+    # CommandNotFoundException instead of taking the padding fallback. A host that
+    # cannot run this is exactly the case the fallback exists for, same as a device that
+    # will not answer, and this function promises its caller a result rather than a throw.
+    $output = $null
+    $exitCode = 0
+    try {
+        # Built every call rather than once per session. An up-to-date build is a ~2s
+        # no-op, and the alternative -- a switch the caller has to remember to pass -- is
+        # the shape of bookkeeping this whole change exists to delete. Issue #19 is the
+        # version worth having: resolve the built exe once and invoke it directly, for
+        # this and for the captures, rather than paying dotnet's project evaluation
+        # every time.
+        dotnet build $projectPath --nologo -v quiet | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            return @{ Ok = $false; Detail = "DeviceDebugMonitor failed to build (exit code $LASTEXITCODE)." }
+        }
+
+        # stdout captured, stderr deliberately left to flow to the console: piping a
+        # native tool through 2>&1 in Windows PowerShell 5.1 wraps its ordinary stderr in
+        # a NativeCommandError and sets $? to false, which is how a healthy tool gets
+        # read as a failed one.
+        $output = dotnet run --project $projectPath --no-build -- $ComPort '--erase-deployment' $KeepBytes
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        return @{ Ok = $false; Detail = "Could not run DeviceDebugMonitor ($($_.Exception.Message))" }
     }
 
-    # stdout captured, stderr deliberately left to flow to the console: piping a native
-    # tool through 2>&1 in Windows PowerShell 5.1 wraps its ordinary stderr in a
-    # NativeCommandError and sets $? to false, which is how a healthy tool gets read as
-    # a failed one.
-    $output = dotnet run --project $projectPath --no-build -- $ComPort '--erase-deployment' $KeepBytes
-    $exitCode = $LASTEXITCODE
-
-    $result = @{ Ok = ($exitCode -eq 0) }
-
     $geometry = Read-SmartHomeDeploymentGeometry -Output $output
+
+    # Ok means the device confirmed the invariant, not merely that a process exited 0.
+    # The confirmation line is the one thing only the erase path prints -- every other
+    # mode of this binary also ends in exit 0, the ordinary capture included -- so
+    # requiring it is what stops a mis-dispatched run reading as a successful erase.
+    $confirmed = @($output) -contains "DEPLOYMENT blank-past=$KeepBytes"
+
+    $result = @{ Ok = ($exitCode -eq 0 -and $confirmed) }
+
     if ($null -ne $geometry) {
         $result['Start'] = $geometry['Start']
         $result['Length'] = $geometry['Length']
     }
+    elseif ($exitCode -eq 0) {
+        # Exit 0 with no geometry line means the output was readable enough to succeed
+        # and not readable enough to cross-check the flash address against. Said out
+        # loud: silently skipping that check is how a stale -DeployAddress gets back to
+        # being invisible, which is the failure it was added for.
+        Write-Warning "DeviceDebugMonitor reported no deployment geometry, so the flash address cannot be cross-checked against the device."
+    }
 
     if (-not $result['Ok']) {
-        $result['Detail'] = "DeviceDebugMonitor --erase-deployment exit code $exitCode"
+        $result['Detail'] = if ($exitCode -ne 0) {
+            "DeviceDebugMonitor --erase-deployment exit code $exitCode"
+        }
+        else {
+            'DeviceDebugMonitor exited 0 without confirming the deployment area is clear'
+        }
     }
 
     return $result

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1015,159 +1015,175 @@ function Stop-SmartHomeDevEnv {
     return $stoppedSomething
 }
 
-# ── Deploy state ──────────────────────────────────────────────────────────────
-# Deploy-ToDevice.ps1 pads every image with 0xFF before flashing it, because nanoff
-# erases and writes only the image file's own byte length -- so a smaller app
-# deployed after a larger one leaves the larger one's tail sitting unerased past
-# the new image's end. That tail is not ignored: the CLR walks the WHOLE deployment
+# ── Device deployment area ────────────────────────────────────────────────────
+# nanoff erases and writes only the image file's own byte length, so a smaller app
+# flashed after a larger one leaves the larger one's tail sitting unerased past the
+# new image's end. That tail is not ignored: the CLR walks the WHOLE deployment
 # partition looking for assembly headers, and on a header that doesn't check out it
 # `continue`s to the next candidate rather than stopping (ContiguousBlockAssemblies
 # in nf-interpreter's src\CLR\Startup\CLRStartup.cpp, whose stream Length is the
 # full block range). So no amount of trailing blank flash terminates the scan --
-# the only thing that keeps stale assemblies out is overwriting them.
+# the only thing that keeps stale assemblies out is erasing them.
 #
-# The invariant is therefore exactly "cover the footprint of the previous image",
-# and the previous image's size is the one fact needed to pad to less than a flat
-# worst case. It is recorded here, keyed by COM port.
+# Deploy-ToDevice.ps1 used to guess how far that reached, from a per-COM-port record
+# of what IT last flashed, and pad the image with 0xFF that far. The guess could only
+# ever describe this script's own flashes: Visual Studio's F5 deploy and the
+# nanoFramework test adapter write the same partition over the debugger's WireProtocol
+# connection and erase only their own footprint too, and nothing made the record notice
+# (issue #46). So the device is asked instead.
 #
-# Deliberately NOT another -Kind on Get-SmartHomeDevEnvPath: that function's -Port
-# is an MQTT port, and one parameter meaning two different kinds of port depending
-# on -Kind is exactly the ambiguity its callers should not have to hold. This
-# shares the temp directory and $SmartHomeTempFilePrefix, not the signature.
+# What the device will and will not answer, all of it checked against the pinned
+# sibling checkouts rather than assumed:
 #
-# StaleBytes is the contract: "the number of bytes from the deploy address that the
-# next flash must overwrite for no leftover assembly data to survive it". It is
-# written pessimistically -- the full padded length -- BEFORE a flash, so an
-# interrupted or failed write still leaves a record covering everything nanoff may
-# have put down, and tightened to the image's own length only once nanoff reports
-# success, at which point everything between the image's end and the padded length
-# is known to be 0xFF.
+#   - It will NOT report how much of the partition is in use. Monitor_DeploymentMap,
+#     the command whose name promises exactly that, is a stub in the firmware that
+#     replies with an empty payload (Debugger.cpp), so nf-debugger's GetDeploymentMap()
+#     always hands back an empty list. Debugging_Deployment_Status reports the
+#     partition's start and length -- its geometry, not its contents.
+#   - It will NOT let the region be read back. CheckPermission has no
+#     BLOCKTYPE_DEPLOYMENT case under AccessMemory_Read, so ReadMemory over the deploy
+#     partition comes back PermissionDenied. (Watch-DeviceDebugOutput.ps1 -DumpConfig
+#     reads the CONFIG partition, which is permitted -- that is why that one works.)
+#   - It WILL erase it. AccessMemory_Erase does list BLOCKTYPE_DEPLOYMENT, and the
+#     firmware skips the erase entirely when the region from the given address to the
+#     end of the partition is already blank (Esp32FlashDriver_IsBlockErased). That is
+#     the exact invariant the padding existed to hold, decided by the device rather
+#     than by a record on this machine, and it is the same command Visual Studio's own
+#     deploy issues before it writes (DeploymentExecute in nf-debugger's
+#     WireProtocol\Engine.cs).
 #
-# Anything that flashes the device WITHOUT going through Deploy-ToDevice.ps1 --
-# Visual Studio's F5 deploy, the nanoFramework test adapter -- invalidates the
-# record, because it writes assemblies this script never saw. Such a path must call
-# Clear-SmartHomeDeployState; the next deploy then falls back to the flat
-# worst-case pad, which is what the script did unconditionally before any of this.
-$SmartHomeDeployStateVersion = 1
+# So there is no state file here any more, and nothing to invalidate: a flash from any
+# source is handled by the erase immediately before the next one.
+# Case-insensitive about the rendering and strict about the shape: the number is
+# produced by a C# format string in another file, and this has no business failing a
+# deploy over how that file spells its hex prefix -- but it does have business refusing
+# a line that is missing half the answer.
+$SmartHomeDeploymentGeometryPattern = '^DEPLOYMENT\s+start=0[xX]([0-9A-Fa-f]+)\s+length=(\d+)\s*$'
 
-function Get-SmartHomeDeployStatePath {
+function Read-SmartHomeDeploymentGeometry {
+    <#
+        Pulls the deploy partition's start and length out of DeviceDebugMonitor's
+        --erase-deployment output. Split out from the invocation below so the parsing
+        is provable at a desk: everything around it needs a device.
+
+        Returns $null rather than throwing when the line is absent or malformed -- the
+        caller has an exit code that already says whether the erase worked, and a
+        geometry it could not read is a reason to skip the cross-check, not to fail a
+        deploy that the device reported as fine.
+    #>
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$ComPort
+        [string[]]$Output
     )
 
-    # 'COM3' needs no escaping, but the port comes from local.env.ps1 and something
-    # like \\.\COM10 would otherwise build a path pointing somewhere else entirely.
-    # '*' survives the scrub on purpose, so Clear-SmartHomeDeployState can build the
-    # all-ports glob from this one naming rule instead of restating it.
-    $safePort = ($ComPort -replace '[^A-Za-z0-9._*-]', '_')
-    return (Join-Path ([System.IO.Path]::GetTempPath()) "$SmartHomeTempFilePrefix-deploy-$safePort.json")
+    if ($null -eq $Output) {
+        return $null
+    }
+
+    foreach ($line in $Output) {
+        if ([string]::IsNullOrWhiteSpace([string]$line)) {
+            continue
+        }
+
+        $match = [regex]::Match([string]$line, $SmartHomeDeploymentGeometryPattern)
+        if (-not $match.Success) {
+            continue
+        }
+
+        # Parsed as UInt32 and handed back as [long]: a start address of 0x1E0000 fits
+        # an int, but the address space it comes from does not, and the caller compares
+        # this against a -DeployAddress string it parses the same way.
+        $start = 0
+        $length = 0
+        if (-not [uint32]::TryParse($match.Groups[1].Value, [System.Globalization.NumberStyles]::HexNumber, [cultureinfo]::InvariantCulture, [ref]$start)) {
+            continue
+        }
+        if (-not [uint32]::TryParse($match.Groups[2].Value, [ref]$length) -or $length -eq 0) {
+            continue
+        }
+
+        return @{
+            Start  = [long]$start
+            Length = [long]$length
+        }
+    }
+
+    return $null
 }
 
-function Get-SmartHomeDeployState {
-    # Returns the record only when every field is present and sane; $null otherwise.
-    # Every rejection here costs one full-size deploy -- the behaviour this script
-    # had before the record existed -- so the failure direction is the safe one, and
-    # nothing about a bad record should ever reach the flashing decision.
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$ComPort
-    )
+function Get-SmartHomeDeviceMonitorProject {
+    # tools\DeviceDebugMonitor is a host-side .NET app, NOT a nanoFramework project --
+    # it is the CLI equivalent of VS's debugger extension, and both the debug capture
+    # and the deployment erase go through it.
+    $projectPath = Join-Path (Get-SmartHomeRepoRoot) 'tools\DeviceDebugMonitor\DeviceDebugMonitor.csproj'
 
-    $stateFile = Get-SmartHomeDeployStatePath -ComPort $ComPort
-    if (-not (Test-Path $stateFile)) {
-        return $null
+    if (-not (Test-Path -LiteralPath $projectPath)) {
+        throw "DeviceDebugMonitor project not found: $projectPath"
     }
 
-    try {
-        $state = ConvertTo-SmartHomeHashtable -InputObject (Get-Content $stateFile -Raw | ConvertFrom-Json)
-    }
-    catch {
-        Write-Warning "Ignoring unreadable deploy-state file: $stateFile"
-        return $null
-    }
-
-    if ($null -eq $state -or -not ($state -is [System.Collections.IDictionary])) {
-        return $null
-    }
-
-    if ($state['Version'] -ne $SmartHomeDeployStateVersion) {
-        return $null
-    }
-
-    if ($state['ComPort'] -ne $ComPort) {
-        return $null
-    }
-
-    if ([string]::IsNullOrWhiteSpace([string]$state['DeployAddress'])) {
-        return $null
-    }
-
-    # Parsed rather than type-checked: ConvertFrom-Json hands back Int32, Int64 or
-    # Double depending on the literal, and the caller does arithmetic with this.
-    $staleBytes = 0
-    if (-not [int]::TryParse([string]$state['StaleBytes'], [ref]$staleBytes) -or $staleBytes -lt 0) {
-        return $null
-    }
-    $state['StaleBytes'] = $staleBytes
-
-    return $state
+    return $projectPath
 }
 
-function Save-SmartHomeDeployState {
+function Clear-SmartHomeDeviceDeployment {
+    <#
+        Asks the device to make everything past the first -KeepBytes bytes of its
+        deployment partition erased flash, so the caller can flash a bare image of
+        that length and be certain nothing older survives past its end.
+
+        Returns a hashtable: Ok, plus Start/Length when the device reported its
+        geometry and Detail when it did not work. Never throws for a device that would
+        not answer -- the caller decides what an unreachable device costs, and for a
+        deploy that is a slower fallback rather than a refusal.
+
+        On ESP32 an erase that IS needed takes the whole partition with it
+        (Esp32FlashDriver_EraseBlock ignores the address), so the device has no app at
+        all between this call and the flash that follows. Call it immediately before
+        the flash, not as a tidy-up step.
+    #>
     param(
         [Parameter(Mandatory = $true)]
         [string]$ComPort,
 
         [Parameter(Mandatory = $true)]
-        [string]$DeployAddress,
+        [int]$KeepBytes,
 
-        [Parameter(Mandatory = $true)]
-        [int]$StaleBytes,
-
-        # Purely for humans reading the file while working out what is on a device.
-        [string]$Image = ''
+        # The monitor is a host-side tool that does not change between calls, so a
+        # caller that already built it (Run-IntegrationTests.ps1 builds once up front)
+        # can skip the build.
+        [switch]$NoBuild
     )
 
-    # Deliberately returns nothing, same as Save-SmartHomeDevEnvState: callers only
-    # care that the record landed, and a returned path would leak into their output.
-    @{
-        Version       = $SmartHomeDeployStateVersion
-        ComPort       = $ComPort
-        DeployAddress = $DeployAddress
-        StaleBytes    = $StaleBytes
-        Image         = $Image
-        UpdatedUtc    = (Get-Date).ToUniversalTime().ToString('o')
-    } | ConvertTo-Json -Depth 3 |
-        Set-Content -Path (Get-SmartHomeDeployStatePath -ComPort $ComPort) -Encoding utf8
-}
-
-function Clear-SmartHomeDeployState {
-    # Without -ComPort, clears every port's record. That is the right default for the
-    # callers that need it: the nanoFramework test adapter picks its own device when
-    # nano.runsettings leaves RealHardwarePort empty, so which port it flashed is not
-    # knowable here. Clearing one record too many costs one full-size deploy.
-    param(
-        [string]$ComPort
-    )
-
-    # A clear that quietly did not happen is the one failure this whole mechanism has
-    # to avoid: it leaves a record SMALLER than what is actually on the device, and the
-    # next deploy pads to it. So a missing file is fine (nothing to clear) but a removal
-    # that fails is not swallowed -- callers run under $ErrorActionPreference = 'Stop'
-    # and should stop rather than flash against a record they were told was gone.
-    if ($ComPort) {
-        $stateFile = Get-SmartHomeDeployStatePath -ComPort $ComPort
-        if (Test-Path -LiteralPath $stateFile) {
-            Remove-Item -LiteralPath $stateFile -Force
-        }
-        return
+    try {
+        $projectPath = Get-SmartHomeDeviceMonitorProject
+    }
+    catch {
+        return @{ Ok = $false; Detail = $_.Exception.Message }
     }
 
-    # -LiteralPath on the directory plus -Filter, not a wildcard -Path: Get-ChildItem
-    # reads [ and ] in a -Path as wildcard metacharacters, so a temp directory whose
-    # name contains either would match nothing at all and clear silently.
-    $pattern = Split-Path (Get-SmartHomeDeployStatePath -ComPort '*') -Leaf
-    Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Filter $pattern -File -ErrorAction SilentlyContinue |
-        Remove-Item -Force
+    if (-not $NoBuild) {
+        dotnet build $projectPath --nologo -v quiet | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            return @{ Ok = $false; Detail = "DeviceDebugMonitor failed to build (exit code $LASTEXITCODE)." }
+        }
+    }
+
+    # stdout captured, stderr deliberately left to flow to the console: piping a native
+    # tool through 2>&1 in Windows PowerShell 5.1 wraps its ordinary stderr in a
+    # NativeCommandError and sets $? to false, which is how a healthy tool gets read as
+    # a failed one.
+    $output = dotnet run --project $projectPath --no-build -- $ComPort '--erase-deployment' $KeepBytes
+    $exitCode = $LASTEXITCODE
+
+    $result = @{ Ok = ($exitCode -eq 0) }
+
+    $geometry = Read-SmartHomeDeploymentGeometry -Output $output
+    if ($null -ne $geometry) {
+        $result['Start'] = $geometry['Start']
+        $result['Length'] = $geometry['Length']
+    }
+
+    if (-not $result['Ok']) {
+        $result['Detail'] = "DeviceDebugMonitor --erase-deployment exit code $exitCode"
+    }
+
+    return $result
 }

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1146,12 +1146,7 @@ function Clear-SmartHomeDeviceDeployment {
         [string]$ComPort,
 
         [Parameter(Mandatory = $true)]
-        [int]$KeepBytes,
-
-        # The monitor is a host-side tool that does not change between calls, so a
-        # caller that already built it (Run-IntegrationTests.ps1 builds once up front)
-        # can skip the build.
-        [switch]$NoBuild
+        [int]$KeepBytes
     )
 
     try {
@@ -1161,11 +1156,14 @@ function Clear-SmartHomeDeviceDeployment {
         return @{ Ok = $false; Detail = $_.Exception.Message }
     }
 
-    if (-not $NoBuild) {
-        dotnet build $projectPath --nologo -v quiet | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            return @{ Ok = $false; Detail = "DeviceDebugMonitor failed to build (exit code $LASTEXITCODE)." }
-        }
+    # Built every call rather than once per session. An up-to-date build is a ~2s no-op,
+    # and the alternative -- a switch the caller has to remember to pass -- is the shape
+    # of bookkeeping this whole change exists to delete. Issue #19 is the version worth
+    # having: resolve the built exe once and invoke it directly, for this and for the
+    # captures, rather than paying dotnet's project evaluation every time.
+    dotnet build $projectPath --nologo -v quiet | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        return @{ Ok = $false; Detail = "DeviceDebugMonitor failed to build (exit code $LASTEXITCODE)." }
     }
 
     # stdout captured, stderr deliberately left to flow to the console: piping a native

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1038,8 +1038,10 @@ function Stop-SmartHomeDevEnv {
 #   - It will NOT report how much of the partition is in use. Monitor_DeploymentMap,
 #     the command whose name promises exactly that, is a stub in the firmware that
 #     replies with an empty payload (Debugger.cpp), so nf-debugger's GetDeploymentMap()
-#     always hands back an empty list. Debugging_Deployment_Status reports the
-#     partition's start and length -- its geometry, not its contents.
+#     always hands back an empty list.
+#   - It WILL report the partition's geometry, through the flash sector map and not
+#     through Debugging_Deployment_Status -- which reads as the more direct question and
+#     answers with nothing usable on this ESP32. Geometry is not contents either way.
 #   - It will NOT let the region be read back. CheckPermission has no
 #     BLOCKTYPE_DEPLOYMENT case under AccessMemory_Read, so ReadMemory over the deploy
 #     partition comes back PermissionDenied. (Watch-DeviceDebugOutput.ps1 -DumpConfig

--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -153,10 +153,25 @@ if (-not (Test-Path $deployImage)) {
 
 $imageBytes = [System.IO.File]::ReadAllBytes($deployImage)
 
-# Ahead of the erase, deliberately: the erase takes the device's current app with it,
-# so an image that was never going to fit has to be refused while the device still has
-# something to run. Against the constant, because the device's own figure only arrives
-# with the erase -- the check below repeats this against that one.
+# Everything that can be checked without the device is checked here, ahead of the
+# erase, deliberately: the erase takes the device's current app with it, so a deploy
+# that was never going to work has to be refused while the device still has something
+# to run.
+#
+# -DeployAddress first, because parsing it is where this script would otherwise throw a
+# raw FormatException in the host's language -- and it would do so below, after the
+# erase, leaving an empty device and no mention of the parameter at fault.
+$deployAddressValue = 0L
+try {
+    $deployAddressValue = [Convert]::ToInt64($DeployAddress, 16)
+}
+catch {
+    Write-Error "-DeployAddress '$DeployAddress' is not a hexadecimal address (expected something like 0x1E0000)."
+    exit 1
+}
+
+# Against the constant, because the device's own figure only arrives with the erase --
+# the check below repeats this against that one.
 if ($imageBytes.Length -gt $DeployPartitionSize) {
     Write-Error @"
 Deploy image ($($imageBytes.Length) bytes) does not fit the deploy partition ($DeployPartitionSize bytes).
@@ -192,7 +207,7 @@ if ($erase.Contains('Start')) {
     # before it touches anything, so a failed erase still carries a usable answer, and a
     # wrong flash address is worth refusing either way.
     $reportedAddress = '0x{0:X}' -f $erase['Start']
-    if ([Convert]::ToInt64($DeployAddress, 16) -ne $erase['Start']) {
+    if ($deployAddressValue -ne $erase['Start']) {
         Write-Error @"
 The device reports its deploy partition at $reportedAddress, but -DeployAddress is $DeployAddress.
 Flashing at the wrong address writes into a partition the CLR never scans, and nanoff
@@ -221,7 +236,10 @@ Nothing was flashed; the device may already have been erased. Pass the real size
 }
 
 $flashImage = $deployImage
-$paddedImage = $null
+
+# Named whether or not this run writes one -- the cleanup after the flash is
+# unconditional, and needs the path either way.
+$paddedImage = Join-Path $binDir ($projectName + '.padded.bin')
 
 if ($erase.Ok) {
     Write-Host "  Deployment area past $($imageBytes.Length) bytes is erased; flashing the image as built." -ForegroundColor DarkGray
@@ -236,7 +254,6 @@ else {
     # device booting somebody else's assemblies.
     Write-Warning ("Could not clear the deployment area ({0}). Padding the image to the full partition instead -- slower, same guarantee." -f $erase.Detail)
 
-    $paddedImage = Join-Path $binDir ($projectName + '.padded.bin')
     $padded = New-Object byte[] $partitionSize
 
     # Fill with 0xFF by doubling an already-filled prefix rather than looping over
@@ -261,12 +278,14 @@ else {
 nanoff --deploy --serialport $comPort --image "$flashImage" --address $DeployAddress
 $nanoffExit = $LASTEXITCODE
 
-if ($null -ne $paddedImage) {
-    # nanoff has read the image by now, so the padded copy is dead weight in bin\Debug.
-    # Leaving it also puts a stale .padded.bin next to a freshly built .bin, which is the
-    # same shape as the stale-deployment problem the padding exists to fix.
-    Remove-Item -Path $paddedImage -Force -ErrorAction SilentlyContinue
-}
+# nanoff has read the image by now, so the padded copy is dead weight in bin\Debug.
+# Leaving it also puts a stale .padded.bin next to a freshly built .bin, which is the
+# same shape as the stale-deployment problem the padding exists to fix. Unconditional,
+# and not only when this run wrote one: the erase path is the common one now, and a run
+# killed between the write and this line -- or any deploy from before the erase existed
+# -- would otherwise leave one there for good, since MSBuild's Clean does not know about
+# a file it never produced.
+Remove-Item -LiteralPath $paddedImage -Force -ErrorAction SilentlyContinue
 
 if ($nanoffExit -ne 0) {
     Write-Error "nanoff deploy failed (exit code $nanoffExit)."

--- a/scripts/Deploy-ToDevice.ps1
+++ b/scripts/Deploy-ToDevice.ps1
@@ -5,8 +5,15 @@
 .DESCRIPTION
     1. Sources scripts\local.env.ps1 for machine-specific settings.
     2. Builds the RoomSensor nanoFramework project with MSBuild.
-    3. Flashes the compiled binaries to the device on the configured COM port
+    3. Asks the device to erase whatever sits past the end of the image about to
+       be flashed, so no previous app's tail survives it.
+    4. Flashes the compiled binaries to the device on the configured COM port
        using the nanoff CLI tool.
+
+    Step 3 needs the debugger connection, and so does Visual Studio -- close its
+    device window if a deploy reports it could not clear the deployment area.
+    That is a warning rather than a failure: the flash still goes ahead, padded
+    to the whole partition instead, which is slower and equally safe.
 
     ALTERNATIVE – Visual Studio deploy:
     Open SmartHome.sln, set RoomSensor as the startup project, choose the
@@ -28,7 +35,6 @@
     .\scripts\Deploy-ToDevice.ps1
     .\scripts\Deploy-ToDevice.ps1 -Verbose
     .\scripts\Deploy-ToDevice.ps1 -Project src\devices\IrrigationControl\IrrigationControl.nfproj
-    .\scripts\Deploy-ToDevice.ps1 -FullPad   # after a Visual Studio deploy: pad the worst case
 #>
 
 [CmdletBinding()]
@@ -52,25 +58,19 @@ param(
     # and read the "deploy" line's Offset column from the printed partition table.
     [string]$DeployAddress = '0x1E0000',
 
-    # Deployed images get padded with trailing 0xFF (erased-flash value) bytes
-    # before flashing. nanoff's erase+write only covers the image file's own byte
-    # length, not the full "deploy" partition -- so deploying a SMALLER app after a
-    # LARGER one leaves that previous app's trailing assembly bytes sitting unerased
-    # past the new image's end, and the CLR loads BOTH on boot (confirmed: saw
-    # WifiCheck's own small assembly list plus leftover Bmp280Check assemblies in
-    # the same resolution pass, failing to link because bytes past WifiCheck's real
-    # end were stale Bmp280Check data, not blank flash).
+    # The deploy partition's size. Every deploy has to leave the flash past its own
+    # image erased -- nanoff's erase+write only covers the image file's own byte
+    # length, so deploying a SMALLER app after a LARGER one leaves that previous app's
+    # trailing assembly bytes sitting unerased past the new image's end, and the CLR
+    # loads BOTH on boot (confirmed: saw WifiCheck's own small assembly list plus
+    # leftover Bmp280Check assemblies in the same resolution pass, failing to link
+    # because bytes past WifiCheck's real end were stale Bmp280Check data, not blank
+    # flash). The device does that erase itself now -- see the "Device deployment area"
+    # section of Common.ps1 -- and reports this same length while it is at it, so this
+    # value is the fit check, and the size of the 0xFF pad in the one case where the
+    # device could not be asked.
     #
-    # How far to pad is decided per deploy, from the size the previous one recorded
-    # for this COM port -- see the "Deploy state" section of Common.ps1 for the
-    # invariant, and for why trailing blank flash does not terminate the CLR's scan
-    # on its own. THIS value is the fallback used when no trustworthy record exists:
-    # the flat size every deploy used to pay unconditionally. It has to stay large
-    # enough to cover any image that could already be on the device, so lower it only
-    # with the whole of src\devices and src\integrationTests in mind.
-    [int]$FallbackPadSize = 409600,
-
-    # Refuse to pad past the deploy partition; nothing outside it is ours to erase.
+    # Measured 2026-08-30 off the device from the same boot-log partition table as
     # Measured 2026-08-30 off the device from the same boot-log partition table as
     # -DeployAddress above (.\scripts\Watch-DeviceSerial.ps1), this time the "deploy"
     # line's Length column rather than its Offset:
@@ -86,13 +86,7 @@ param(
     # Until this was measured the value had only ever been copied from a prose
     # comment of unclear provenance -- issue #47. Re-read that "deploy" line if a
     # firmware update changes the layout.
-    [int]$DeployPartitionSize = 0x1C0000,
-
-    # Ignore any recorded size and pad to -FallbackPadSize. Use this after something
-    # OTHER than this script has flashed the device -- a Visual Studio F5 deploy, most
-    # likely -- since the record then describes an image that is no longer the one on
-    # the device. Run-Tests.ps1 clears the record itself; Visual Studio cannot.
-    [switch]$FullPad
+    [int]$DeployPartitionSize = 0x1C0000
 )
 
 Set-StrictMode -Version Latest
@@ -159,157 +153,124 @@ if (-not (Test-Path $deployImage)) {
 
 $imageBytes = [System.IO.File]::ReadAllBytes($deployImage)
 
-# ── Decide how far to pad ─────────────────────────────────────────────────────
-# Only the PREVIOUS image's footprint has to be covered, and Common.ps1's deploy
-# state records exactly that, per COM port. Every reason the record cannot be
-# trusted falls back to the flat -FallbackPadSize rather than to the bare image
-# size: this is the flashing path, and over-padding costs seconds where
-# under-padding costs a device booting somebody else's assemblies.
-$sectorSize = 4096   # ESP32 flash erase granularity; keeps the write sector-aligned.
-
-# Read even under -FullPad. That switch distrusts how TIGHT the record is -- something
-# else has flashed the device since -- but a record proving a bigger image was written
-# to this same address is still a lower bound, and honouring it is what keeps -FullPad
-# the pessimistic option it is documented to be.
-$deployState   = Get-SmartHomeDeployState -ComPort $comPort
-$recordedBytes = $null
-$recordReason  = $null
-
-if ($null -eq $deployState) {
-    $recordReason = "no usable deploy record for $comPort"
-}
-elseif ($deployState['DeployAddress'] -ne $DeployAddress) {
-    # A different address is a different region: what that record describes says
-    # nothing about what is sitting at this one -- not even as a floor.
-    $recordReason = "the deploy record for $comPort covers $($deployState['DeployAddress']), not $DeployAddress"
-}
-elseif ($deployState['StaleBytes'] -gt $DeployPartitionSize) {
-    # Parseable but impossible: nothing this script flashed can be larger than the
-    # partition. Rejecting it here keeps a corrupt record costing one full-size deploy
-    # -- the documented failure direction -- instead of tripping the partition check
-    # below and refusing every deploy to this port until the file is deleted by hand.
-    $recordReason = "the deploy record for $comPort claims $($deployState['StaleBytes']) bytes, larger than the deploy partition ($DeployPartitionSize)"
-}
-else {
-    $recordedBytes = $deployState['StaleBytes']
-}
-
-$staleBytes = $null
-$padReason  = $null
-
-if ($FullPad) {
-    $padReason = '-FullPad was passed'
-}
-elseif ($null -eq $recordedBytes) {
-    $padReason = $recordReason
-}
-else {
-    $staleBytes = $recordedBytes
-}
-
-# -FallbackPadSize is a worst case only while every image fits under it. An image that
-# does not is padded to itself, which is correct for THIS deploy but leaves the fallback
-# unable to cover it later -- after Run-Tests.ps1 clears the record, or under -FullPad.
-if ($imageBytes.Length -gt $FallbackPadSize) {
-    Write-Warning @"
-This image is $($imageBytes.Length) bytes, larger than -FallbackPadSize ($FallbackPadSize).
-It deploys correctly, but once anything drops the deploy record for $comPort (a hardware
-Run-Tests.ps1 run, a corrupt record) the fallback no longer covers this image, and the next
-deploy of a smaller app will leave its tail on the device. Raise -FallbackPadSize.
-"@
-}
-
-$padFloor = if ($null -ne $staleBytes) {
-    $staleBytes
-}
-elseif ($null -ne $recordedBytes) {
-    # Falling back, but with a trustworthy floor to fall back to.
-    [Math]::Max($FallbackPadSize, $recordedBytes)
-}
-else {
-    $FallbackPadSize
-}
-
-$padTarget = [Math]::Max($imageBytes.Length, $padFloor)
-$paddedImageSize = [int][Math]::Ceiling($padTarget / [double]$sectorSize) * $sectorSize
-
-if ($paddedImageSize -gt $DeployPartitionSize) {
+# Ahead of the erase, deliberately: the erase takes the device's current app with it,
+# so an image that was never going to fit has to be refused while the device still has
+# something to run. Against the constant, because the device's own figure only arrives
+# with the erase -- the check below repeats this against that one.
+if ($imageBytes.Length -gt $DeployPartitionSize) {
     Write-Error @"
-Padded deploy image ($paddedImageSize bytes) does not fit the deploy partition ($DeployPartitionSize bytes).
-The image itself is $($imageBytes.Length) bytes, padded up to a floor of $padFloor bytes. Either the
-app has outgrown the partition, or -DeployPartitionSize is stale -- re-read the "deploy" line of the
-partition table printed by .\scripts\Watch-DeviceSerial.ps1 and pass the real size.
+Deploy image ($($imageBytes.Length) bytes) does not fit the deploy partition ($DeployPartitionSize bytes).
+Either the app has outgrown the partition, or -DeployPartitionSize is stale -- re-read the
+"deploy" line of the table printed by .\scripts\Watch-DeviceSerial.ps1 and pass the real size.
 "@
     exit 1
 }
 
-$paddedImage = Join-Path $binDir ($projectName + '.padded.bin')
-$padded = New-Object byte[] $paddedImageSize
+# ── Clear whatever is already on the device ───────────────────────────────────
+# The invariant is "nothing but erased flash past the end of the image about to be
+# written", and the device is the only thing that knows whether that already holds:
+# Visual Studio's F5 deploy and the nanoFramework test adapter write this same
+# partition without this script ever seeing it (issue #46). So it is asked, rather
+# than guessed at from a record of what THIS script last flashed.
+#
+# See the "Device deployment area" section of Common.ps1 for what the firmware will
+# and will not answer, and why this is an erase rather than a read.
+$erase = Clear-SmartHomeDeviceDeployment -ComPort $comPort -KeepBytes $imageBytes.Length
 
-# Fill with 0xFF by doubling an already-filled prefix rather than looping over
-# hundreds of KB one byte at a time: the scalar loop measured 560ms per deploy, this
-# is ~10ms. ([Array]::Fill would be simpler but is .NET Core only, and this runs on
-# Windows PowerShell 5.1.)
-$padded[0] = 0xFF
-$filled = 1
-while ($filled -lt $paddedImageSize) {
-    $chunk = [Math]::Min($filled, $paddedImageSize - $filled)
-    [Array]::Copy($padded, 0, $padded, $filled, $chunk)
-    $filled += $chunk
+# What the device says its deploy partition is, when it answered. Ground truth for the
+# two values this script otherwise carries as constants measured off a boot log.
+$partitionSize = $DeployPartitionSize
+
+if ($erase.Contains('Start')) {
+    # The failure this catches is the one that cost a full debugging session: nanoff's
+    # own default address landed in the "factory" partition on this device's layout, so
+    # every deploy silently never ran. Nothing about that is visible in nanoff's output
+    # -- it reports a successful write either way -- and until the device could be
+    # asked, the only way to notice was to read a boot log.
+    #
+    # Read whether or not the erase itself worked: the monitor prints the geometry
+    # before it touches anything, so a failed erase still carries a usable answer, and a
+    # wrong flash address is worth refusing either way.
+    $reportedAddress = '0x{0:X}' -f $erase['Start']
+    if ([Convert]::ToInt64($DeployAddress, 16) -ne $erase['Start']) {
+        Write-Error @"
+The device reports its deploy partition at $reportedAddress, but -DeployAddress is $DeployAddress.
+Flashing at the wrong address writes into a partition the CLR never scans, and nanoff
+reports success anyway -- so this stops here rather than producing a device that boots
+without the app that was just deployed. Pass -DeployAddress $reportedAddress, or re-read the
+"deploy" line of the partition table printed by .\scripts\Watch-DeviceSerial.ps1.
+"@
+        exit 1
+    }
+
+    if ($erase['Length'] -ne $DeployPartitionSize) {
+        # The device wins: -DeployPartitionSize is a value measured off a boot log on
+        # 2026-08-30, and a firmware update is free to lay the partitions out again.
+        Write-Warning ("The device reports a deploy partition of {0} bytes, not the -DeployPartitionSize {1}. Using the device's. Update the default if the firmware layout has changed for good." -f $erase['Length'], $DeployPartitionSize)
+        $partitionSize = $erase['Length']
+
+        if ($imageBytes.Length -gt $partitionSize) {
+            Write-Error @"
+Deploy image ($($imageBytes.Length) bytes) does not fit the deploy partition the device reports ($partitionSize bytes).
+-DeployPartitionSize said it would fit, so the partition layout has changed under this script.
+Nothing was flashed; the device may already have been erased. Pass the real size and redeploy.
+"@
+            exit 1
+        }
+    }
 }
 
-[Array]::Copy($imageBytes, $padded, $imageBytes.Length)
-[System.IO.File]::WriteAllBytes($paddedImage, $padded)
+$flashImage = $deployImage
+$paddedImage = $null
 
-# Names whichever input actually set the size: the pad floor only drives it while the
-# image is smaller than the floor, and a message crediting the floor for a size the
-# image chose misleads exactly the person reading this line to explain a pad.
-$padDriver = if ($imageBytes.Length -ge $padFloor) {
-    'the image itself is the larger of the two'
-}
-elseif ($null -ne $staleBytes) {
-    "covering the $staleBytes bytes the last deploy to $comPort left on the device"
+if ($erase.Ok) {
+    Write-Host "  Deployment area past $($imageBytes.Length) bytes is erased; flashing the image as built." -ForegroundColor DarkGray
 }
 else {
-    "full-size pad -- $padReason"
+    # The device could not be asked -- it is unreachable, or something else already
+    # holds the debugger connection (Visual Studio open on the same port is the usual
+    # one). Fall back to what this script did before it could ask: pad the image with
+    # 0xFF far enough that the write itself erases anything that could be behind it.
+    # The whole partition, because without the device there is no smaller number that
+    # is honestly a worst case -- over-padding costs seconds, under-padding costs a
+    # device booting somebody else's assemblies.
+    Write-Warning ("Could not clear the deployment area ({0}). Padding the image to the full partition instead -- slower, same guarantee." -f $erase.Detail)
+
+    $paddedImage = Join-Path $binDir ($projectName + '.padded.bin')
+    $padded = New-Object byte[] $partitionSize
+
+    # Fill with 0xFF by doubling an already-filled prefix rather than looping over
+    # hundreds of KB one byte at a time: the scalar loop measured 560ms per deploy, this
+    # is ~10ms. ([Array]::Fill would be simpler but is .NET Core only, and this runs on
+    # Windows PowerShell 5.1.)
+    $padded[0] = 0xFF
+    $filled = 1
+    while ($filled -lt $partitionSize) {
+        $chunk = [Math]::Min($filled, $partitionSize - $filled)
+        [Array]::Copy($padded, 0, $padded, $filled, $chunk)
+        $filled += $chunk
+    }
+
+    [Array]::Copy($imageBytes, $padded, $imageBytes.Length)
+    [System.IO.File]::WriteAllBytes($paddedImage, $padded)
+
+    Write-Host "  Padded deploy image: $($imageBytes.Length) -> $partitionSize bytes (0xFF fill)." -ForegroundColor DarkGray
+    $flashImage = $paddedImage
 }
-Write-Host "  Padded deploy image: $($imageBytes.Length) -> $paddedImageSize bytes (0xFF fill, $padDriver)." -ForegroundColor DarkGray
 
-# Recorded before the flash, and pessimistically: if nanoff dies partway, or the shell
-# is killed, anything up to $paddedImageSize may have landed and the next deploy has to
-# cover all of it. Tightened below once nanoff reports success. Deliberately not
-# wrapped -- $ErrorActionPreference is 'Stop', so a record that cannot be written
-# aborts before flashing rather than flashing against a stale, smaller number.
-Save-SmartHomeDeployState -ComPort $comPort `
-                          -DeployAddress $DeployAddress `
-                          -StaleBytes $paddedImageSize `
-                          -Image $projectName
-
-nanoff --deploy --serialport $comPort --image "$paddedImage" --address $DeployAddress
+nanoff --deploy --serialport $comPort --image "$flashImage" --address $DeployAddress
 $nanoffExit = $LASTEXITCODE
 
-# nanoff has read the image by now, so the padded copy is dead weight in bin\Debug.
-# Leaving it also puts a stale .padded.bin next to a freshly built .bin, which is the
-# same shape as the stale-deployment problem the padding exists to fix.
-Remove-Item -Path $paddedImage -Force -ErrorAction SilentlyContinue
+if ($null -ne $paddedImage) {
+    # nanoff has read the image by now, so the padded copy is dead weight in bin\Debug.
+    # Leaving it also puts a stale .padded.bin next to a freshly built .bin, which is the
+    # same shape as the stale-deployment problem the padding exists to fix.
+    Remove-Item -Path $paddedImage -Force -ErrorAction SilentlyContinue
+}
 
 if ($nanoffExit -ne 0) {
     Write-Error "nanoff deploy failed (exit code $nanoffExit)."
     exit $nanoffExit
-}
-
-# The write completed, so everything from the image's end up to $paddedImageSize is
-# 0xFF now and the next deploy only has to cover the image itself.
-try {
-    Save-SmartHomeDeployState -ComPort $comPort `
-                              -DeployAddress $DeployAddress `
-                              -StaleBytes $imageBytes.Length `
-                              -Image $projectName
-}
-catch {
-    # The pessimistic record written before the flash is still there and still
-    # correct, just bigger than it needs to be. Not worth failing a deploy that worked.
-    Write-Warning "Could not tighten the deploy record for $comPort ($($_.Exception.Message)). The next deploy will pad to $paddedImageSize bytes."
 }
 
 Write-Host ""

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -313,15 +313,18 @@ function Get-DeviceMarkerVerdict {
     #
     # Which has two causes, and the message names both because they send an investigation
     # in opposite directions. A flash that failed is visible in nanoff's own output. A
-    # flash that succeeded but under-padded is not: nanoff erases only the new image's
+    # deployment area that was never cleared is not: nanoff erases only the new image's
     # length and verifies its hash happily, while the CLR walks the whole deployment
     # partition and can still find the previous test past the new image's end (see the
-    # Deploy padding section of CLAUDE.md, and issue #46). Saying only "the flash did not
-    # take" would send that one to check output that looks perfectly healthy.
+    # Clearing the deployment area section of CLAUDE.md, and issue #46). Since #46 the
+    # deploy has the device erase that itself and warns when it could not, so the second
+    # cause now leaves a trace in the deploy output -- a warning, not a failure. Saying
+    # only "the flash did not take" would still send that one to check nanoff output that
+    # looks perfectly healthy.
     if ($reportedName -ne $ExpectedName) {
         return @{
             Outcome = 'WRONG-TEST'
-            Detail  = "device reported '$reportedName', not '$ExpectedName' -- a previous test is still answering, either because the flash did not take or because it left the old assembly in the deployment partition (check the deploy padding)"
+            Detail  = "device reported '$reportedName', not '$ExpectedName' -- a previous test is still answering, either because the flash did not take or because the deployment area was not cleared before it (check the deploy output for a warning about clearing it)"
         }
     }
 

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -88,29 +88,13 @@ if (-not (Test-Path $runSettings)) {
     exit 1
 }
 
-# ── Invalidate Deploy-ToDevice.ps1's padding record ───────────────────────────
-# On real hardware the nanoFramework test adapter puts the test assemblies on the
-# device itself, over the debugger's WireProtocol connection rather than through
-# Deploy-ToDevice.ps1 -- and it erases only its own footprint too
-# (DeploymentExecuteFull in nf-debugger's WireProtocol\Engine.cs erases exactly the
-# assemblies' combined length). Deploy-ToDevice.ps1 sizes its 0xFF padding from a
-# record of what IT last flashed, so after a hardware test run that record describes
-# an image that is no longer what is on the device. Drop it, and the next deploy pads
-# the full fallback size -- what the script did unconditionally before the record
-# existed. Costs one full-size deploy; the alternative is a device booting leftover
-# test assemblies.
-#
-# Read via SelectSingleNode rather than $xml.RunSettings.nanoFrameworkAdapter...:
-# Set-StrictMode makes a missing property on an XmlNode a terminating error, and
-# -RunSettings can point at any file.
-[xml]$runSettingsXml = Get-Content -Path $runSettings -Raw
-$isRealHardwareNode = $runSettingsXml.SelectSingleNode('/RunSettings/nanoFrameworkAdapter/IsRealHardware')
-if ($isRealHardwareNode -and $isRealHardwareNode.InnerText.Trim() -eq 'True') {
-    # Every port, not just $env:SMARTHOME_COM_PORT: nano.runsettings leaves
-    # RealHardwarePort empty, so the adapter flashes whichever device it detects first.
-    Clear-SmartHomeDeployState
-    Write-Host "  Cleared the deploy padding record -- the test adapter flashes the device itself." -ForegroundColor DarkGray
-}
+# Nothing to invalidate here any more. On real hardware the nanoFramework test adapter
+# puts the test assemblies on the device itself, over the debugger's WireProtocol
+# connection rather than through Deploy-ToDevice.ps1, and erases only its own footprint
+# doing it (DeploymentExecuteFull in nf-debugger's WireProtocol\Engine.cs erases exactly
+# the assemblies' combined length). That used to leave a stale padding record behind, so
+# this script dropped it; since #46 the next deploy asks the device what is actually
+# there instead of consulting a record, and a flash from any source is covered.
 
 # ── Locate vstest.console and the nanoFramework test adapter ─────────────────
 $vstest = Get-VsTestPath

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -88,14 +88,6 @@ if (-not (Test-Path $runSettings)) {
     exit 1
 }
 
-# Nothing to invalidate here any more. On real hardware the nanoFramework test adapter
-# puts the test assemblies on the device itself, over the debugger's WireProtocol
-# connection rather than through Deploy-ToDevice.ps1, and erases only its own footprint
-# doing it (DeploymentExecuteFull in nf-debugger's WireProtocol\Engine.cs erases exactly
-# the assemblies' combined length). That used to leave a stale padding record behind, so
-# this script dropped it; since #46 the next deploy asks the device what is actually
-# there instead of consulting a record, and a flash from any source is covered.
-
 # ── Locate vstest.console and the nanoFramework test adapter ─────────────────
 $vstest = Get-VsTestPath
 $vstestCmd = Get-Command $vstest -ErrorAction SilentlyContinue

--- a/scripts/Test-Setup.ps1
+++ b/scripts/Test-Setup.ps1
@@ -171,7 +171,7 @@ else {
 
 # ----------------------------------------------------------------------- tools --
 
-foreach ($tool in @('git', 'nanoff', 'gh')) {
+foreach ($tool in @('git', 'nanoff', 'gh', 'dotnet')) {
     $source = Test-OnPath $tool
     if ($source) {
         Add-Result -Name $tool -Status 'OK' -Detail $source
@@ -181,6 +181,11 @@ foreach ($tool in @('git', 'nanoff', 'gh')) {
             'git'    { 'Install Git and put it on PATH' }
             'nanoff' { 'dotnet tool install -g nanoff' }
             'gh'     { 'Install the GitHub CLI (https://cli.github.com/)' }
+            # Listed since #46. tools\DeviceDebugMonitor is a net8.0 project that both the
+            # debug capture and every deploy now build, and a machine that installed nanoff
+            # as a global tool has only the RUNTIME -- which is why this cannot be inferred
+            # from nanoff being present.
+            'dotnet' { 'Install the .NET SDK (https://dotnet.microsoft.com/download)' }
         }
         Add-Result -Name $tool -Status 'FAIL' -Detail 'not on PATH' -Fix $fix
     }

--- a/scripts/Watch-DeviceDebugOutput.ps1
+++ b/scripts/Watch-DeviceDebugOutput.ps1
@@ -64,11 +64,16 @@ $ErrorActionPreference = 'Stop'
 Import-SmartHomeLocalEnv
 
 $comPort = Get-RequiredEnvValue -Name 'SMARTHOME_COM_PORT'
-$repoRoot = Get-SmartHomeRepoRoot
-$toolProject = Join-Path $repoRoot 'tools\DeviceDebugMonitor\DeviceDebugMonitor.csproj'
 
-if (-not (Test-Path $toolProject)) {
-    Write-Error "DeviceDebugMonitor project not found: $toolProject"
+# Resolved through Common.ps1 rather than rebuilt here: the deployment erase reaches the
+# same project, and a second copy of the path had already drifted -- this one tested it
+# with a bare -Path, which reads [ and ] as wildcards and finds nothing in a checkout
+# whose path contains either (issue #80).
+try {
+    $toolProject = Get-SmartHomeDeviceMonitorProject
+}
+catch {
+    Write-Error $_.Exception.Message
     exit 1
 }
 

--- a/scripts/tests/Common.Tests.ps1
+++ b/scripts/tests/Common.Tests.ps1
@@ -612,115 +612,108 @@ Describe 'Dev-env state' {
     }
 }
 
-Describe 'Deploy state' {
-    # The record Deploy-ToDevice.ps1 pads from. Its contract is "the number of bytes from
-    # the deploy address the next flash must overwrite", and every rejection below costs
-    # one full-size deploy -- the behaviour the script had before the record existed --
-    # so the safe direction is $null. A synthetic port, for the reason above.
-    $comPort = 'COM-TEST-74'
+Describe 'Deployment geometry' {
+    # The one desk-provable piece of the deployment-area handling. Everything around it
+    # -- the erase itself, whether the device answers at all -- needs a device; this is
+    # the seam that was split out so at least the parsing can be pinned where CI runs.
+    #
+    # What it parses is DeviceDebugMonitor's --erase-deployment output. Deploy-ToDevice.ps1
+    # compares Start against its own -DeployAddress and refuses the flash when they
+    # disagree, so a parse that quietly produced the wrong number would be worse than one
+    # that produced none: it would stop a healthy deploy, or wave through the wrong-address
+    # flash the check exists to catch.
 
-    function Save-RawDeployState {
-        param([hashtable]$State)
-        $State | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath (Get-SmartHomeDeployStatePath -ComPort $comPort) -Encoding utf8
+    It 'reads the start and length out of the monitor line' {
+        $geometry = Read-SmartHomeDeploymentGeometry -Output @(
+            'Watching for a nanoFramework device on COM3...'
+            'Found device: ESP32. Connecting debug engine...'
+            'DEPLOYMENT start=0x001E0000 length=1835008'
+            'DEPLOYMENT blank-past=143360'
+        )
+
+        Assert-NotNull -Value $geometry
+        Assert-Equal -Expected 1966080 -Actual $geometry['Start'] -Because '0x1E0000'
+        Assert-Equal -Expected 1835008 -Actual $geometry['Length']
     }
 
-    It 'builds a path that cannot escape the temp directory' {
-        # The port comes from local.env.ps1, so something like \\.\COM10 would otherwise
-        # point the record somewhere else entirely.
-        $path = Get-SmartHomeDeployStatePath -ComPort '\\.\COM10'
+    It 'hands back numbers the caller can do arithmetic with' {
+        # Deploy-ToDevice.ps1 compares these against [Convert]::ToInt64($DeployAddress, 16)
+        # and against a byte count, so a string that merely prints the same would compare
+        # unequal and refuse every deploy.
+        $geometry = Read-SmartHomeDeploymentGeometry -Output @('DEPLOYMENT start=0x1E0000 length=1835008')
 
-        # '\\.\COM10' scrubs to '__._COM10': both backslashes and the leading one before
-        # COM10 become underscores, and the dot survives because it is legal in a name.
-        Assert-Equal -Expected ([System.IO.Path]::GetTempPath().TrimEnd('\')) -Actual (Split-Path -Parent $path)
-        Assert-Equal -Expected 'smarthome-deploy-__._COM10.json' -Actual (Split-Path -Leaf $path)
+        Assert-True -Condition ($geometry['Start'] -is [long])
+        Assert-True -Condition ($geometry['Length'] -is [long])
+        Assert-Equal -Expected 3801088 -Actual ($geometry['Start'] + $geometry['Length'])
     }
 
-    It 'keeps * unscrubbed, because the all-ports glob is built from this one rule' {
-        Assert-Match -Pattern '\*' -Actual (Get-SmartHomeDeployStatePath -ComPort '*')
-    }
+    It 'takes the address with or without leading zeroes, in either case' {
+        foreach ($rendering in '0x1E0000', '0x001e0000', '0X001E0000') {
+            $geometry = Read-SmartHomeDeploymentGeometry -Output @("DEPLOYMENT start=$rendering length=1835008")
 
-    It 'round-trips a saved record' {
-        Save-SmartHomeDeployState -ComPort $comPort -DeployAddress '0x1B000' -StaleBytes 409600 -Image 'RoomSensor.bin'
-
-        try {
-            $state = Get-SmartHomeDeployState -ComPort $comPort
-
-            Assert-NotNull -Value $state
-            Assert-Equal -Expected '0x1B000' -Actual $state['DeployAddress']
-            Assert-Equal -Expected 409600 -Actual $state['StaleBytes']
-            Assert-Equal -Expected 'RoomSensor.bin' -Actual $state['Image']
-        }
-        finally {
-            Clear-SmartHomeDeployState -ComPort $comPort
-        }
-    }
-
-    It 'returns $null when there is no record' {
-        Clear-SmartHomeDeployState -ComPort $comPort
-        Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort)
-    }
-
-    It 'rejects a record from another schema version' {
-        Save-RawDeployState -State @{ Version = 99; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = 4096 }
-        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
-        finally { Clear-SmartHomeDeployState -ComPort $comPort }
-    }
-
-    It 'rejects a record written for a different port' {
-        Save-RawDeployState -State @{ Version = 1; ComPort = 'COM9'; DeployAddress = '0x1B000'; StaleBytes = 4096 }
-        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
-        finally { Clear-SmartHomeDeployState -ComPort $comPort }
-    }
-
-    It 'rejects a record with no deploy address' {
-        # The record only vouches for a footprint at the address it was written for.
-        Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '   '; StaleBytes = 4096 }
-        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
-        finally { Clear-SmartHomeDeployState -ComPort $comPort }
-    }
-
-    It 'rejects a negative or unparseable StaleBytes' {
-        foreach ($bad in @(-1, 'lots')) {
-            Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = $bad }
-            try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) -Because "StaleBytes = $bad" }
-            finally { Clear-SmartHomeDeployState -ComPort $comPort }
+            Assert-NotNull -Value $geometry -Because $rendering
+            Assert-Equal -Expected 1966080 -Actual $geometry['Start'] -Because $rendering
         }
     }
 
-    It 'hands back StaleBytes as an int the caller can do arithmetic with' {
-        # ConvertFrom-Json returns Int32, Int64 or Double depending on the literal, and
-        # the padding decision multiplies and rounds this.
-        Save-RawDeployState -State @{ Version = 1; ComPort = $comPort; DeployAddress = '0x1B000'; StaleBytes = 4096.0 }
+    It 'returns $null when the line is not there' {
+        # The monitor prints this before it does anything that can fail, so its absence
+        # means the device never answered -- and the caller already has an exit code
+        # saying so. Failing here instead would turn one clear failure into two.
+        Assert-Null -Value (Read-SmartHomeDeploymentGeometry -Output @(
+            'Watching for a nanoFramework device on COM3...'
+            'No nanoFramework device found on COM3 after 15s.'
+        ))
+    }
 
-        try {
-            $state = Get-SmartHomeDeployState -ComPort $comPort
+    It 'returns $null for no output at all' {
+        Assert-Null -Value (Read-SmartHomeDeploymentGeometry -Output @())
+        Assert-Null -Value (Read-SmartHomeDeploymentGeometry -Output $null)
+    }
 
-            Assert-NotNull -Value $state
-            Assert-True -Condition ($state['StaleBytes'] -is [int])
-            Assert-Equal -Expected 8192 -Actual ($state['StaleBytes'] * 2)
+    It 'ignores a line that only looks like the geometry line' {
+        foreach ($bad in @(
+            'DEPLOYMENT start=0x1E0000'                       # no length
+            'DEPLOYMENT length=1835008'                       # no start
+            'DEPLOYMENT start=1E0000 length=1835008'          # no 0x, so not the format
+            'DEPLOYMENT start=0xZZZZ length=1835008'          # not hex
+            'DEPLOYMENT start=0x1E0000 length=nonsense'
+            'DEPLOYMENT start=0x1E0000 length=0'              # a partition of no size
+            'the DEPLOYMENT start=0x1E0000 length=1835008'    # prose that quotes the line
+        )) {
+            Assert-Null -Value (Read-SmartHomeDeploymentGeometry -Output @($bad)) -Because $bad
         }
-        finally {
-            Clear-SmartHomeDeployState -ComPort $comPort
-        }
     }
 
-    It 'ignores an unreadable record instead of throwing' {
-        Set-TestFileContent -Path (Get-SmartHomeDeployStatePath -ComPort $comPort) -Content '{ not json'
+    It 'takes the first geometry line and ignores the rest' {
+        # One call, one device, one partition. A second line would mean the monitor
+        # printed something this parser does not understand, and guessing which of two
+        # answers is right is worse than taking the one the tool documents itself as
+        # printing before anything else.
+        $geometry = Read-SmartHomeDeploymentGeometry -Output @(
+            'DEPLOYMENT start=0x1E0000 length=1835008'
+            'DEPLOYMENT start=0x1B0000 length=409600'
+        )
 
-        $WarningPreference = 'SilentlyContinue'
-        try { Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort) }
-        finally { Clear-SmartHomeDeployState -ComPort $comPort }
+        Assert-Equal -Expected 1966080 -Actual $geometry['Start']
     }
 
-    It 'clearing a record that is not there is a no-op, not an error' {
-        Clear-SmartHomeDeployState -ComPort $comPort
-        Clear-SmartHomeDeployState -ComPort $comPort
-        Assert-Null -Value (Get-SmartHomeDeployState -ComPort $comPort)
-    }
+    It 'skips blank lines rather than tripping over them' {
+        # dotnet run interleaves its own blank lines with the tool's output.
+        $geometry = Read-SmartHomeDeploymentGeometry -Output @('', '   ', $null, 'DEPLOYMENT start=0x1E0000 length=1835008')
 
-    # Not covered here: Clear-SmartHomeDeployState with no -ComPort. It globs every
-    # record in the real temp directory, which on a developer's machine includes the one
-    # for the device actually attached -- clearing it would silently cost that machine's
-    # next deploy its tight pad. The directory is hardcoded inside the function, so there
-    # is no way to point that branch at a fixture without changing it.
+        Assert-NotNull -Value $geometry
+    }
+}
+
+Describe 'Device monitor project' {
+    It 'resolves the monitor project inside this checkout' {
+        # Not a fixture: the point of the check is that the real project is where the
+        # deploy and the debug capture both expect it, in whichever worktree this is.
+        $projectPath = Get-SmartHomeDeviceMonitorProject
+
+        Assert-True -Condition (Test-Path -LiteralPath $projectPath)
+        Assert-Equal -Expected 'DeviceDebugMonitor.csproj' -Actual (Split-Path -Leaf $projectPath)
+        Assert-Equal -Expected (Get-SmartHomeRepoRoot) -Actual (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $projectPath)))
+    }
 }

--- a/tools/DeviceDebugMonitor/Program.cs
+++ b/tools/DeviceDebugMonitor/Program.cs
@@ -20,6 +20,7 @@
 
 using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.Debugger.Extensions;
+using nanoFramework.Tools.Debugger.WireProtocol;
 
 // --until <text>: stop as soon as a line containing <text> arrives, instead of
 // sitting out the whole duration. The duration then acts as a timeout rather than a
@@ -144,19 +145,54 @@ if (!connected)
 if (eraseDeployment)
 {
     // The deploy partition's real geometry, straight from the device, rather than the
-    // hand-measured constants Deploy-ToDevice.ps1 carries. Debugging_Deployment_Status
-    // reports the partition, NOT how much of it is in use: the firmware walks the
-    // DEPLOYMENT block stream and sums its length (Debugger.cpp). There is no command
-    // that reports the used extent -- Monitor_DeploymentMap, the one that looks like it
+    // hand-measured constants Deploy-ToDevice.ps1 carries.
+    //
+    // From the flash sector map and NOT from Debugging_Deployment_Status, which looks
+    // like the more direct question and does not work here: on this ESP32 it answers
+    // with no usable geometry, and nothing in nf-debugger's own ESP32 path depends on
+    // it either -- DeploymentExecuteFull is the only caller, and the ESP32 reports
+    // IncrementalDeployment, so DeploymentExecuteIncremental (which reads this same
+    // sector map) is what actually runs. Measured on the device, not reasoned about.
+    //
+    // Either way it is the partition that is being reported, NOT how much of it is in
+    // use. Nothing reports that: Monitor_DeploymentMap, the command that looks like it
     // would, is a stub in the firmware that replies with an empty payload, and reading
     // the region back is refused outright (CheckPermission has no DEPLOYMENT case for
     // AccessMemory_Read). Erasing it is permitted, so this asks the device to make the
     // region blank rather than asking it what is in there.
-    var (_, storageStart, storageLength, statusOk) = device.DebugEngine.DeploymentGetStatusWithResult();
+    var sectorMap = device.DebugEngine.GetFlashSectorMap();
+    var deploymentSectors = (sectorMap ?? [])
+        .Where(s => (s.Flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK)
+                    == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_DEPLOYMENT)
+        .OrderBy(s => s.StartAddress)
+        .ToList();
 
-    if (!statusOk || storageLength == 0)
+    if (deploymentSectors.Count == 0)
     {
-        Console.Error.WriteLine("Could not read the deployment partition's geometry from the device.");
+        Console.Error.WriteLine("The device's flash sector map lists no deployment region.");
+        return 1;
+    }
+
+    // Summed rather than "the first one": the map is a list of sector groups, and a
+    // target is free to describe its deployment area as several. Contiguity is checked
+    // rather than assumed -- a gap would make one length a lie about two regions, and
+    // erasing from the start of the first would then say nothing about the second.
+    uint storageStart = deploymentSectors[0].StartAddress;
+    uint storageLength = 0;
+    foreach (var sector in deploymentSectors)
+    {
+        if (sector.StartAddress != storageStart + storageLength)
+        {
+            Console.Error.WriteLine($"The device reports a deployment area in more than one piece (a gap before 0x{sector.StartAddress:X8}); this tool only handles a contiguous one.");
+            return 1;
+        }
+
+        storageLength += sector.NumBlocks * sector.BytesPerBlock;
+    }
+
+    if (storageLength == 0)
+    {
+        Console.Error.WriteLine("The device reports a deployment region of no size.");
         return 1;
     }
 

--- a/tools/DeviceDebugMonitor/Program.cs
+++ b/tools/DeviceDebugMonitor/Program.cs
@@ -11,6 +11,12 @@
 // right after a fresh nanoff flash (which already hardware-resets the device) --
 // rebooting again on top of that double-triggers execution and can leave native
 // peripherals (e.g. WiFi) in a busy state a single clean boot wouldn't hit.
+//
+// --erase-deployment <keep-bytes>: not a capture at all. Reports the deploy
+// partition's real geometry, and makes sure nothing but erased flash lies past the
+// first <keep-bytes> bytes of it. That is what lets Deploy-ToDevice.ps1 flash a bare
+// image instead of guessing how far to pad it -- see the "Deploy padding" section of
+// CLAUDE.md.
 
 using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.Debugger.Extensions;
@@ -26,18 +32,35 @@ if (untilIndex >= 0 && untilIndex + 1 < args.Length)
     until = args[untilIndex + 1];
 }
 
+// --erase-deployment <keep-bytes>: how many bytes from the start of the deploy
+// partition the caller is about to write itself. Everything past them has to be
+// erased flash for the CLR not to find a previous, larger app's tail there.
+long eraseKeepBytes = -1;
+var eraseIndex = Array.IndexOf(args, "--erase-deployment");
+if (eraseIndex >= 0)
+{
+    if (eraseIndex + 1 >= args.Length || !long.TryParse(args[eraseIndex + 1], out eraseKeepBytes) || eraseKeepBytes < 0)
+    {
+        Console.Error.WriteLine("--erase-deployment needs a non-negative byte count.");
+        return 1;
+    }
+}
+
 var positional = args
     .Where((a, i) => a != "--no-reboot"
                      && a != "--dump-config"
                      && a != "--until"
-                     && !(untilIndex >= 0 && i == untilIndex + 1))
+                     && a != "--erase-deployment"
+                     && !(untilIndex >= 0 && i == untilIndex + 1)
+                     && !(eraseIndex >= 0 && i == eraseIndex + 1))
     .ToArray();
 bool noReboot = args.Contains("--no-reboot");
 bool dumpConfig = args.Contains("--dump-config");
+bool eraseDeployment = eraseIndex >= 0;
 
 if (positional.Length < 1)
 {
-    Console.Error.WriteLine("Usage: DeviceDebugMonitor <COM port> [duration seconds] [--no-reboot] [--dump-config]");
+    Console.Error.WriteLine("Usage: DeviceDebugMonitor <COM port> [duration seconds] [--no-reboot] [--dump-config] [--erase-deployment <keep-bytes>]");
     return 1;
 }
 
@@ -116,6 +139,78 @@ if (!connected)
 {
     Console.Error.WriteLine("Failed to connect debug engine to the device.");
     return 1;
+}
+
+if (eraseDeployment)
+{
+    // The deploy partition's real geometry, straight from the device, rather than the
+    // hand-measured constants Deploy-ToDevice.ps1 carries. Debugging_Deployment_Status
+    // reports the partition, NOT how much of it is in use: the firmware walks the
+    // DEPLOYMENT block stream and sums its length (Debugger.cpp). There is no command
+    // that reports the used extent -- Monitor_DeploymentMap, the one that looks like it
+    // would, is a stub in the firmware that replies with an empty payload, and reading
+    // the region back is refused outright (CheckPermission has no DEPLOYMENT case for
+    // AccessMemory_Read). Erasing it is permitted, so this asks the device to make the
+    // region blank rather than asking it what is in there.
+    var (_, storageStart, storageLength, statusOk) = device.DebugEngine.DeploymentGetStatusWithResult();
+
+    if (!statusOk || storageLength == 0)
+    {
+        Console.Error.WriteLine("Could not read the deployment partition's geometry from the device.");
+        return 1;
+    }
+
+    // One machine-readable line, so the caller can cross-check its own flash address
+    // against what the device says -- a mismatch there is the failure that made every
+    // nanoff deploy silently never run (see -DeployAddress in Deploy-ToDevice.ps1).
+    Console.WriteLine($"DEPLOYMENT start=0x{storageStart:X8} length={storageLength}");
+
+    if (eraseKeepBytes > storageLength)
+    {
+        Console.Error.WriteLine($"Asked to keep {eraseKeepBytes} bytes, but the deployment partition is only {storageLength}.");
+        return 1;
+    }
+
+    // Same sequence VS's own deploy uses before it erases (DeploymentExecute in
+    // nf-debugger's WireProtocol\Engine.cs): stop the CLR first. It executes assemblies
+    // straight out of this memory-mapped flash, so erasing under a running app is not
+    // something to find out about halfway through.
+    var executionState = device.DebugEngine.GetExecutionMode();
+    if (executionState == nanoFramework.Tools.Debugger.WireProtocol.Commands.DebuggingExecutionChangeConditions.State.Unknown)
+    {
+        Console.Error.WriteLine("Could not read the device's execution state.");
+        return 1;
+    }
+
+    if (!executionState.IsDeviceInStoppedState() && !device.DebugEngine.PauseExecution())
+    {
+        Console.Error.WriteLine("Could not stop the CLR before erasing the deployment partition.");
+        return 1;
+    }
+
+    // The firmware short-circuits when the region is already blank (IsBlockErased runs
+    // from this address to the end of the partition), so this costs a round trip and
+    // nothing else on a device whose current app is at least as big as the next one.
+    // When it is NOT blank, ESP32 erases the WHOLE partition rather than the tail --
+    // Esp32FlashDriver_EraseBlock ignores the address and calls esp_partition_erase_range
+    // over the whole thing -- so the device is left with no app at all until the caller's
+    // flash lands. That is the caller's problem to sequence, and it is why this runs
+    // immediately before the flash rather than at some tidy-up point.
+    var (eraseError, eraseOk) = device.DebugEngine.EraseMemory(
+        (uint)(storageStart + eraseKeepBytes),
+        (uint)(storageLength - eraseKeepBytes));
+
+    if (!eraseOk || eraseError != nanoFramework.Tools.Debugger.WireProtocol.AccessMemoryErrorCodes.NoError)
+    {
+        Console.Error.WriteLine($"Erase of the deployment partition past {eraseKeepBytes} bytes failed: {eraseError}.");
+        return 1;
+    }
+
+    // Deliberately not "erased": the device does not report which of the two happened,
+    // and both leave the caller with the same guarantee. Claiming an erase that did not
+    // happen would be the more useful-sounding, less true line.
+    Console.WriteLine($"DEPLOYMENT blank-past={eraseKeepBytes}");
+    return 0;
 }
 
 if (dumpConfig)

--- a/tools/DeviceDebugMonitor/Program.cs
+++ b/tools/DeviceDebugMonitor/Program.cs
@@ -15,8 +15,9 @@
 // --erase-deployment <keep-bytes>: not a capture at all. Reports the deploy
 // partition's real geometry, and makes sure nothing but erased flash lies past the
 // first <keep-bytes> bytes of it. That is what lets Deploy-ToDevice.ps1 flash a bare
-// image instead of guessing how far to pad it -- see the "Deploy padding" section of
-// CLAUDE.md.
+// image instead of guessing how far to pad it -- see the "Clearing the deployment
+// area" section of CLAUDE.md. It stops the CLR and leaves it stopped, so the device
+// runs nothing again until it is flashed or reset.
 
 using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.Debugger.Extensions;
@@ -109,33 +110,42 @@ Console.WriteLine($"Found device: {device.Description}. Connecting debug engine.
 var matched = new ManualResetEventSlim(false);
 var seen = new System.Text.StringBuilder();
 
-device.DebugEngine!.OnMessage += (message, text) =>
+// Not subscribed in --erase-deployment mode. That mode's stdout is a contract -- the
+// caller parses `DEPLOYMENT start=...` with an anchored pattern -- and the device is
+// still running its app between Connect and the pause below. Console.Write emits no
+// trailing newline, so one Debug.WriteLine landing in that window would prefix the
+// geometry line and make it unparseable, which reads downstream as a device that
+// reported no geometry rather than as output that got mixed together.
+if (!eraseDeployment)
 {
-    Console.Write(text);
-
-    if (until is null || matched.IsSet)
+    device.DebugEngine!.OnMessage += (message, text) =>
     {
-        return;
-    }
+        Console.Write(text);
 
-    lock (seen)
-    {
-        seen.Append(text);
-        if (seen.ToString().Contains(until))
+        if (until is null || matched.IsSet)
         {
-            matched.Set();
+            return;
         }
 
-        // Keep the buffer bounded; anything older than a couple of lines cannot
-        // start a match that isn't already complete.
-        if (seen.Length > 4096)
+        lock (seen)
         {
-            seen.Remove(0, seen.Length - 1024);
-        }
-    }
-};
+            seen.Append(text);
+            if (seen.ToString().Contains(until))
+            {
+                matched.Set();
+            }
 
-bool connected = device.DebugEngine.Connect(5000, force: true, requestCapabilities: true);
+            // Keep the buffer bounded; anything older than a couple of lines cannot
+            // start a match that isn't already complete.
+            if (seen.Length > 4096)
+            {
+                seen.Remove(0, seen.Length - 1024);
+            }
+        }
+    };
+}
+
+bool connected = device.DebugEngine!.Connect(5000, force: true, requestCapabilities: true);
 if (!connected)
 {
     Console.Error.WriteLine("Failed to connect debug engine to the device.");
@@ -207,12 +217,26 @@ if (eraseDeployment)
         return 1;
     }
 
+    // Nothing lies past an image that fills the partition, so there is nothing to erase
+    // -- and asking anyway would be actively dangerous. EraseMemory(start + length, 0)
+    // addresses one byte past the region, and CheckPermission lists BLOCKTYPE_CONFIG
+    // alongside BLOCKTYPE_DEPLOYMENT under AccessMemory_Erase, so on a layout where
+    // config abuts deploy that call resolves into the config partition and takes the
+    // device's WiFi profiles and certificates with it. Handled here rather than left to
+    // the caller: Deploy-ToDevice.ps1's own fit check is `-gt` too, by design -- an image
+    // that exactly fills the partition is a legal deploy.
+    if (eraseKeepBytes == storageLength)
+    {
+        Console.WriteLine($"DEPLOYMENT blank-past={eraseKeepBytes}");
+        return 0;
+    }
+
     // Same sequence VS's own deploy uses before it erases (DeploymentExecute in
     // nf-debugger's WireProtocol\Engine.cs): stop the CLR first. It executes assemblies
     // straight out of this memory-mapped flash, so erasing under a running app is not
     // something to find out about halfway through.
     var executionState = device.DebugEngine.GetExecutionMode();
-    if (executionState == nanoFramework.Tools.Debugger.WireProtocol.Commands.DebuggingExecutionChangeConditions.State.Unknown)
+    if (executionState == Commands.DebuggingExecutionChangeConditions.State.Unknown)
     {
         Console.Error.WriteLine("Could not read the device's execution state.");
         return 1;
@@ -236,11 +260,17 @@ if (eraseDeployment)
         (uint)(storageStart + eraseKeepBytes),
         (uint)(storageLength - eraseKeepBytes));
 
-    if (!eraseOk || eraseError != nanoFramework.Tools.Debugger.WireProtocol.AccessMemoryErrorCodes.NoError)
+    if (!eraseOk || eraseError != AccessMemoryErrorCodes.NoError)
     {
         Console.Error.WriteLine($"Erase of the deployment partition past {eraseKeepBytes} bytes failed: {eraseError}.");
         return 1;
     }
+
+    // The CLR was stopped above and is deliberately left that way -- resuming one whose
+    // assemblies have just been erased is not something to do on a hunch. Said out loud
+    // because the caller that flashes next resets the device anyway, so it is only a
+    // hand-run of this mode that is left looking at a device doing nothing.
+    Console.WriteLine("The CLR is left stopped; flash the device or reset it to run again.");
 
     // Deliberately not "erased": the device does not report which of the two happened,
     // and both leave the caller with the same guarantee. Claiming an erase that did not


### PR DESCRIPTION
Closes #46.

`Deploy-ToDevice.ps1` padded every image with 0xFF as far as a per-COM-port record of what
*it* had last flashed, so a smaller app could not leave a larger one's tail where the CLR
still finds it. The record could only ever describe this script's own flashes: Visual
Studio's F5 deploy and the nanoFramework test adapter write the same partition over the
debugger connection and erase only their own footprint too. `Run-Tests.ps1` invalidated the
record for the adapter, Visual Studio could not, and `-FullPad` existed for the case only a
human could notice.

The device is asked now, immediately before the flash. Nothing on the host has to know what
is already there, so nothing can be wrong about it.

## What the device will and will not answer

Read out of the pinned sibling checkouts first, then measured on the device — and the two
disagreed on one point, which is why there are two commits.

| Route | Result |
|---|---|
| `Monitor_DeploymentMap` — the command whose name promises the used extent | **Stub in the firmware.** Replies with an empty payload (`Debugger.cpp`), so `GetDeploymentMap()` always returns an empty list |
| `AccessMemory_Read` over the deploy partition | **Refused.** `CheckPermission` lists no `BLOCKTYPE_DEPLOYMENT` case for reads. (`-DumpConfig` reads the *config* partition, which is permitted — that is why that one works) |
| `Debugging_Deployment_Status` | **Reads as the direct question, does not work here.** Answers with no usable geometry on this ESP32. Nothing in `nf-debugger`'s own ESP32 path depends on it either: `DeploymentExecuteFull` is its only caller, the ESP32 reports `IncrementalDeployment`, so `DeploymentExecuteIncremental` runs instead |
| `Monitor_FlashSectorMap` | **Works.** Its `c_MEMORY_USAGE_DEPLOYMENT` entry gives the partition's start and size |
| `AccessMemory_Erase` | **Permitted**, and the firmware skips the erase when the region from the given address to the end of the partition is already blank (`Esp32FlashDriver_IsBlockErased`). Same command Visual Studio's own deploy issues before it writes |

So nothing reports the used extent. The device is told to erase rather than asked what is
there — which is the same invariant, decided by the device.

## The change

- `DeviceDebugMonitor` gains `--erase-deployment <keep-bytes>`: reports the partition's
  geometry and has the device blank everything past the image about to be written. It stops
  the CLR first (`GetExecutionMode` / `PauseExecution`), the same sequence VS's deploy uses,
  because the CLR executes assemblies straight out of that memory-mapped flash.
- `Common.ps1`'s "Deploy state" section becomes `Clear-SmartHomeDeviceDeployment` plus
  `Read-SmartHomeDeploymentGeometry` — the parse of the monitor's one machine-readable line,
  split out so it can be proved at a desk. Everything else there needs a device.
- Gone: the record (`Get`/`Save`/`Clear-SmartHomeDeployState`), `-FullPad`,
  `-FallbackPadSize`, `Run-Tests.ps1`'s invalidation, and its second parse of
  `nano.runsettings` with it.
- The 0xFF pad survives for exactly one case: the device could not be reached at all (VS
  holding the debugger connection is the usual reason). The image is then padded to the whole
  partition and the flash goes ahead **with a warning** — slower, same guarantee. That case is
  not hypothetical; it is what the first hardware run did, before the geometry route was
  fixed, and it deployed correctly.
- The geometry the same call returns is ground truth for two constants this script had only
  ever carried as boot-log measurements. A **deploy address that disagrees with the device is
  now refused** rather than flashed — that mismatch is what once put every deploy into the
  *factory* partition, where `nanoff` reported success and the app silently never ran. A
  disagreeing partition *length* is a warning and the device's value wins.

The fit check runs **before** the erase, on purpose: the erase takes the device's current app
with it, so an image that was never going to fit is refused while the device still has
something to run.

## Verified on hardware (COM3, ESP32-D0WD-V3)

The device confirmed both constants: `DEPLOYMENT start=0x001E0000 length=1835008`, against
`-DeployAddress 0x1E0000` and `-DeployPartitionSize 0x1C0000`.

Run in this order, so the middle step reproduces #46's actual hole — a flash made by
something other than this script:

1. **`Deploy-ToDevice.ps1` (RoomSensor)** — took the erase path, flashed the bare 260132-byte
   image in 1.8s. The run before it, on the broken geometry route, had padded to 1835008 and
   taken 4.9s; both produced a working device.
2. **`Run-Tests.ps1` on the ESP32 — 57 of 57.** This leaves `NFUnitTest` on the device,
   flashed by the test adapter. Nothing cleared any record, because there is none.
3. **The erase, timed twice against that.** First call 3.7s, second 2.8s — the first erased,
   the second found it already blank. Then `Watch-DeviceDebugOutput.ps1` on the erased device:
   zero assemblies, zero of every table, `Error: a2000000`. The adapter's app was gone, which
   is the erase doing the thing the record could not have known to ask for.
4. **`Run-IntegrationTests.ps1 -Tests WifiCheck,MqttCheck,Bmp280Check` — all 3 PASS**, 72s.
   Every deploy took the erase path, no padding fallback, no warnings. `MqttCheck` is 142056
   bytes and `Bmp280Check` right after it is 132516 — smaller after larger, the stale-tail case
   itself.
5. **`Run-Tests.ps1 -RunSettings nano.ci.runsettings` — 57 of 57** on the nanoclr virtual
   device. CI's path.
6. **`Run-ScriptTests.ps1` — 146 passed, 0 failed**, ~7s, no device. Was 147: the 11
   deploy-record cases are gone and 10 cover the geometry parse and the monitor project
   resolution.

The suite costs ~3s per deploy more than before (72s against the 63s the same three tests took
on `origin/main`) — one debugger connection each. In exchange no deploy depends on anything
remembered.

The two host-decided integration tests were not run: they emit no marker and this change does
not touch their path. The device is left on `Bmp280Check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)