### PR TITLE
refactor(tests): lift the conformance attribute check out of its closure

### DIFF
--- a/.claude/skills/smarthome-script-tests/SKILL.md
+++ b/.claude/skills/smarthome-script-tests/SKILL.md
@@ -26,14 +26,19 @@ Useful switches:
 
 `scripts\` decides what the integration suite reports, and it is the half of the suite a desk can
 exercise: `Get-CatalogValidationError`, `ConvertFrom-HomieCaptureLine`, `ConvertTo-HomieSnapshot`,
-`Get-HomieLivePayloads`, `Wait-ForAnnounceWitnessed`, `Get-SubscriberLogLineCount`, plus
-`Common.ps1`'s path globs, dev-environment state and the deployment-geometry parse the deploy
-cross-checks its flash address against.
+`Get-HomieLivePayloads`, `Get-AttributeFailure`, `Wait-ForAnnounceWitnessed`,
+`Get-SubscriberLogLineCount`, plus `Common.ps1`'s path globs, dev-environment state and the
+deployment-geometry parse the deploy cross-checks its flash address against.
 
 It does **not** cover anything that needs a broker, a subscriber process or the device —
 `Start-HomieCapture`'s connect wait, `Invoke-BrokerOutageCheck`, `Invoke-HomieConformanceCheck`.
 Those still need `Run-IntegrationTests.ps1` on real hardware. Running this suite is not a
 substitute for saying what was verified on hardware in a pull request.
+
+`Get-AttributeFailure` is the first piece of the conformance verdict that is covered here at all.
+It was nested inside `Measure-HomieConformance` and closed over that scope's snapshot until issue
+#84 gave it the snapshot as a parameter; the rest of that function still needs a device, and the
+uncovered remainder is what #84 tracks.
 
 ## Adding a test
 

--- a/.claude/skills/smarthome-script-tests/SKILL.md
+++ b/.claude/skills/smarthome-script-tests/SKILL.md
@@ -26,18 +26,20 @@ Useful switches:
 
 `scripts\` decides what the integration suite reports, and it is the half of the suite a desk can
 exercise: `Get-CatalogValidationError`, `ConvertFrom-HomieCaptureLine`, `ConvertTo-HomieSnapshot`,
-`Get-HomieLivePayloads`, `Get-AttributeFailure`, `Wait-ForAnnounceWitnessed`,
-`Get-SubscriberLogLineCount`, plus `Common.ps1`'s path globs, dev-environment state and the
-deployment-geometry parse the deploy cross-checks its flash address against.
+`Get-HomieLivePayloads`, `Get-AttributeFailure`, `Get-ConformanceCaptureSeconds`,
+`Wait-ForAnnounceWitnessed`, `Get-SubscriberLogLineCount`, plus `Common.ps1`'s path globs,
+dev-environment state and the deployment-geometry parse the deploy cross-checks its flash
+address against.
 
 It does **not** cover anything that needs a broker, a subscriber process or the device —
 `Start-HomieCapture`'s connect wait, `Invoke-BrokerOutageCheck`, `Invoke-HomieConformanceCheck`.
 Those still need `Run-IntegrationTests.ps1` on real hardware. Running this suite is not a
 substitute for saying what was verified on hardware in a pull request.
 
-`Get-AttributeFailure` is the first piece of the conformance verdict that is covered here at all.
-It was nested inside `Measure-HomieConformance` and closed over that scope's snapshot until issue
-#84 gave it the snapshot as a parameter; the rest of that function still needs a device, and the
+`Get-AttributeFailure` is the first *assertion* inside `Measure-HomieConformance` that is covered
+here — the conformance machinery around it, `Get-ConformanceCaptureSeconds` and the lifecycle
+table, already was. It was nested inside that function and closed over its snapshot until issue
+#84 gave it the snapshot as a parameter; the rest of the assertions still need a device, and the
 uncovered remainder is what #84 tracks.
 
 ## Adding a test

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -1550,6 +1550,11 @@ function Get-AttributeFailure {
     # further is asserted about it, but a topic that is present can be both non-retained
     # and carrying the wrong payload, and a run reports everything that is wrong rather
     # than the first thing.
+    #
+    # The early return on a missing topic is load-bearing, not cosmetic: this file runs
+    # under Set-StrictMode -Version Latest, where $Snapshot[$absent].Retained throws
+    # PropertyNotFoundException instead of reading as $null. Without it, a device missing
+    # a single attribute takes the whole conformance run down with no verdict.
     param(
         [Parameter(Mandatory = $true)]
         [hashtable]$Snapshot,

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -896,7 +896,7 @@ function Get-MosquittoTool {
 #
 # Wait-ForRetainedValue now detects a mid-announce snapshot by its retain flag and retries,
 # so for that path the window is no longer the only defence. It still is for the callers
-# that read a snapshot without a flag guard -- Test-Attribute and the /set verification --
+# that read a snapshot without a flag guard -- Get-AttributeFailure and the /set verification --
 # which is why it stays at three.
 #
 # With the IPv6 timeout gone from Get-SmartHomeSubscriberArguments these are three seconds
@@ -940,7 +940,7 @@ function Get-HomieRetainedSnapshot {
     #
     # Both retained and live deliveries come back, flag intact. What the flag *means* is
     # the caller's decision, and the four callers deliberately differ: Wait-ForRetainedValue
-    # requires it when it hands the snapshot on, Test-Attribute reports it as data, the
+    # requires it when it hands the snapshot on, Get-AttributeFailure reports it as data, the
     # $retained=false check needs unretained messages to be present at all, and the /set
     # verification ignores it because a live echo is equally good evidence the command was
     # applied. Do not filter here.
@@ -1251,7 +1251,7 @@ function ConvertTo-HomieSnapshot {
     # message with DupFlag set, up to MqttSettings.MaximumAttemptsRetry (3). So a snapshot
     # can hold a live duplicate of a value the broker also replayed from its store,
     # arriving after the replayed copy. Overwriting on payload equality threw away the
-    # retain flag that replay had just proved, and Test-Attribute reported "not retained"
+    # retain flag that replay had just proved, and Get-AttributeFailure reported "not retained"
     # for three attributes of 53 that plainly were.
     #
     # Measured, not guessed: a 40s capture of one re-announce holds a retransmitted tail
@@ -1532,6 +1532,57 @@ function Add-ConformanceWarning {
     Write-Warning $Message
 }
 
+function Get-AttributeFailure {
+    # One retained attribute, checked against the snapshot it is supposed to be in, as a
+    # function that *returns* what is wrong with it rather than appending to a list it can
+    # only see from an enclosing scope.
+    #
+    # It lived inside Measure-HomieConformance until #84, closing over that scope's
+    # $snapshot -- which the /set round-trip further down reassigns. Every call happened
+    # before that reassignment, so no assertion was ever measured against the wrong store;
+    # but that was a property of where in a 500-line function the calls happened to be
+    # written, not of anything the code said. Taking the snapshot as a parameter makes
+    # every call name the store it asserts against, and is what lets scripts\tests reach
+    # the assertions of the verdict function with the worst record in this file -- two
+    # separate defects where the conformance check passed while lying (#34, #36).
+    #
+    # Returns zero, one or two strings. A missing topic is reported alone and nothing
+    # further is asserted about it, but a topic that is present can be both non-retained
+    # and carrying the wrong payload, and a run reports everything that is wrong rather
+    # than the first thing.
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Snapshot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Topic,
+
+        [string]$Expected,
+
+        # For an attribute whose value is the device's to choose ($name, $type). Presence
+        # and the retain flag are still asserted; only the payload comparison is skipped.
+        [switch]$AnyValue
+    )
+
+    if (-not $Snapshot.Contains($Topic)) {
+        return "missing: $Topic"
+    }
+
+    $failures = @()
+
+    if (-not $Snapshot[$Topic].Retained) {
+        $failures += "not retained: $Topic"
+    }
+
+    if (-not $AnyValue -and $Snapshot[$Topic].Payload -ne $Expected) {
+        $failures += "$Topic is '$($Snapshot[$Topic].Payload)', expected '$Expected'"
+    }
+
+    # An empty array unrolls to nothing, so a clean attribute contributes nothing to the
+    # caller's `+=` -- which is why no call site needs a count check.
+    return $failures
+}
+
 function Invoke-HomieConformanceCheck {
     # The verdict function the catalog names for HomieClientCheck: everything the
     # conformance measurement needs around it, so the run loop needs to know none of it.
@@ -1642,30 +1693,13 @@ function Measure-HomieConformance {
     $snapshot = $ready.Snapshot
     Write-Host ("  retained store holds {0} topics" -f $snapshot.Count) -ForegroundColor DarkGray
 
-    function Test-Attribute {
-        param([string]$Topic, [string]$Expected, [switch]$AnyValue)
-
-        if (-not $snapshot.Contains($Topic)) {
-            $script:conformanceFailures += "missing: $Topic"
-            return
-        }
-
-        if (-not $snapshot[$Topic].Retained) {
-            $script:conformanceFailures += "not retained: $Topic"
-        }
-
-        if (-not $AnyValue -and $snapshot[$Topic].Payload -ne $Expected) {
-            $script:conformanceFailures += "$Topic is '$($snapshot[$Topic].Payload)', expected '$Expected'"
-        }
-    }
-
     Start-ConformancePhase -Name 'attributes'
 
     # ── mandatory device attributes ──────────────────────────────────────────
-    Test-Attribute -Topic "$root/`$homie" -Expected '4'
-    Test-Attribute -Topic "$root/`$name" -AnyValue
-    Test-Attribute -Topic "$root/`$state" -Expected 'ready'
-    Test-Attribute -Topic "$root/`$nodes" -Expected $nodeId
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$root/`$homie" -Expected '4'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$root/`$name" -AnyValue
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$root/`$state" -Expected 'ready'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$root/`$nodes" -Expected $nodeId
     # $extensions is asserted from the LIVE log, not the retained store. The spec says
     # it "MUST be sent, even if it is just an empty string", but MQTT defines a
     # zero-length retained payload as a delete of the retained message -- so an empty
@@ -1677,9 +1711,9 @@ function Measure-HomieConformance {
     }
 
     # ── node attributes ──────────────────────────────────────────────────────
-    Test-Attribute -Topic "$node/`$name" -AnyValue
-    Test-Attribute -Topic "$node/`$type" -AnyValue
-    Test-Attribute -Topic "$node/`$properties" -AnyValue
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/`$name" -AnyValue
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/`$type" -AnyValue
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/`$properties" -AnyValue
 
     # ── one property per datatype, with its declared metadata ────────────────
     $expectedTypes = @{
@@ -1694,25 +1728,25 @@ function Measure-HomieConformance {
     }
 
     foreach ($property in $expectedTypes.Keys) {
-        Test-Attribute -Topic "$node/$property/`$name" -AnyValue
-        Test-Attribute -Topic "$node/$property/`$datatype" -Expected $expectedTypes[$property]
+        $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/$property/`$name" -AnyValue
+        $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/$property/`$datatype" -Expected $expectedTypes[$property]
     }
 
-    Test-Attribute -Topic "$node/integer-value/`$settable" -Expected 'true'
-    Test-Attribute -Topic "$node/integer-value/`$format" -Expected '0:100'
-    Test-Attribute -Topic "$node/enum-value/`$format" -Expected 'low,medium,high'
-    Test-Attribute -Topic "$node/color-value/`$format" -Expected 'rgb'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/integer-value/`$settable" -Expected 'true'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/integer-value/`$format" -Expected '0:100'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/enum-value/`$format" -Expected 'low,medium,high'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/color-value/`$format" -Expected 'rgb'
     # Built by HomieClientCheck from the State enum rather than spelled out there, so
     # that the vocabulary a controller is offered cannot drift from the vocabulary
     # $state is published in. This assertion is what notices if that derivation breaks.
-    Test-Attribute -Topic "$node/lifecycle/`$format" -Expected 'ready,alert,sleeping'
-    Test-Attribute -Topic "$node/lifecycle/`$settable" -Expected 'true'
-    Test-Attribute -Topic "$node/integer-value/`$unit" -Expected '#'
-    Test-Attribute -Topic "$node/float-value/`$unit" -AnyValue
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/lifecycle/`$format" -Expected 'ready,alert,sleeping'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/lifecycle/`$settable" -Expected 'true'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/integer-value/`$unit" -Expected '#'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/float-value/`$unit" -AnyValue
 
     # ── $retained=false is honoured, not just declared ───────────────────────
-    Test-Attribute -Topic "$node/counter/`$retained" -Expected 'false'
-    Test-Attribute -Topic "$node/counter/`$settable" -Expected 'false'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/counter/`$retained" -Expected 'false'
+    $script:conformanceFailures += Get-AttributeFailure -Snapshot $snapshot -Topic "$node/counter/`$settable" -Expected 'false'
     # The counter publishes every 2s, so a LIVE message can easily land inside the
     # snapshot window. Absence would be the wrong assertion; what matters is that the
     # broker never marks it retained.

--- a/scripts/tests/RunIntegrationTests.Tests.ps1
+++ b/scripts/tests/RunIntegrationTests.Tests.ps1
@@ -634,3 +634,116 @@ Describe 'The announce witness' {
         Assert-False -Condition (Wait-ForAnnounceWitnessed -Port '1883' -DeviceId 'd' -TimeoutSeconds 1 -Watermark 0)
     }
 }
+
+Describe 'Get-AttributeFailure' {
+    # The conformance check's attribute assertion. It was a nested function closing over
+    # Measure-HomieConformance's $snapshot until #84, so none of this could be asserted
+    # without a broker, a device and a 90s suite run -- in the verdict function with two
+    # prior defects that passed while lying (#34, #36).
+    #
+    # Snapshots are built with the real ConvertTo-HomieSnapshot rather than by hand, so a
+    # change to the entry shape breaks these cases instead of leaving them asserting
+    # against a shape the capture no longer produces.
+
+    It 'reports nothing for a retained attribute carrying the expected payload' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 1 4')
+
+        Assert-ArrayEqual -Expected @() -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'reports a topic the store never held' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$name 1 Office')
+
+        Assert-ArrayEqual -Expected @('missing: homie/d/$homie') `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'asserts nothing further about a missing topic' {
+        # The early return. Without it the payload comparison would run against a null
+        # entry and report a second failure about a topic that is simply not there.
+        $failures = @(Get-AttributeFailure -Snapshot (ConvertTo-HomieSnapshot -Lines @()) -Topic 'homie/d/$homie' -Expected '4')
+
+        Assert-Equal -Expected 1 -Actual $failures.Count
+    }
+
+    It 'reports an attribute the broker did not replay as retained' {
+        # Homie requires every attribute retained. The flag is only set on a replay from
+        # the store, so a live-only delivery is exactly what a non-retained attribute
+        # looks like here.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 0 4')
+
+        Assert-ArrayEqual -Expected @('not retained: homie/d/$homie') `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'reports the payload it saw and the one it wanted' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 1 3')
+
+        Assert-ArrayEqual -Expected @("homie/d/`$homie is '3', expected '4'") `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'reports both faults of one attribute rather than the first' {
+        # One run reports everything that is wrong: an attribute can be non-retained and
+        # carry the wrong value, and stopping at the flag would hide the value until the
+        # next 90s hardware run.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 0 3')
+
+        Assert-ArrayEqual -Expected @('not retained: homie/d/$homie', "homie/d/`$homie is '3', expected '4'") `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'skips the payload comparison for -AnyValue' {
+        # $name and $type are the device's to choose, so only presence and the retain
+        # flag are the convention's business.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$name 1 whatever the device likes')
+
+        Assert-ArrayEqual -Expected @() -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$name' -AnyValue)
+    }
+
+    It 'still asserts the retain flag for -AnyValue' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$name 0 Office')
+
+        Assert-ArrayEqual -Expected @('not retained: homie/d/$name') `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$name' -AnyValue)
+    }
+
+    It 'still reports a missing topic for -AnyValue' {
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 1 4')
+
+        Assert-ArrayEqual -Expected @('missing: homie/d/$name') `
+                          -Actual @(Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$name' -AnyValue)
+    }
+
+    It 'reads the snapshot it was passed, not one the caller happens to have in scope' {
+        # The case #84 is about. Until then the function was nested inside
+        # Measure-HomieConformance and closed over a $snapshot the /set round-trip
+        # reassigns further down that same scope: every call happened before the
+        # reassignment, so the assertions were right by position rather than by
+        # construction.
+        #
+        # The local $snapshot below is the trap, and it deliberately holds the topic that
+        # would make this case pass. PowerShell variable names are case-insensitive, so a
+        # $snapshot written inside the function binds to the -Snapshot parameter and this
+        # case cannot be fooled that way -- but a parameter renamed while the body still
+        # says $Snapshot resolves to a caller's variable instead, silently, and that is
+        # what the trap catches. Checked by deleting the parameter outright: this is the
+        # case that then fails.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 1 4')
+        $other = ConvertTo-HomieSnapshot -Lines @('homie/d/$name 1 Office')
+
+        Assert-ArrayEqual -Expected @('missing: homie/d/$homie') `
+                          -Actual @(Get-AttributeFailure -Snapshot $other -Topic 'homie/d/$homie' -Expected '4')
+    }
+
+    It 'appends nothing to a caller collecting a clean attribute with +=' {
+        # How every call site uses it. An empty array unrolls to nothing, so a clean
+        # attribute must not grow the failure list -- a single $null slipping in would
+        # be counted as a conformance failure with no message.
+        $snapshot = ConvertTo-HomieSnapshot -Lines @('homie/d/$homie 1 4')
+        $collected = @()
+        $collected += Get-AttributeFailure -Snapshot $snapshot -Topic 'homie/d/$homie' -Expected '4'
+
+        Assert-Equal -Expected 0 -Actual $collected.Count
+    }
+}

--- a/scripts/tests/RunIntegrationTests.Tests.ps1
+++ b/scripts/tests/RunIntegrationTests.Tests.ps1
@@ -659,11 +659,14 @@ Describe 'Get-AttributeFailure' {
     }
 
     It 'asserts nothing further about a missing topic' {
-        # The early return. Without it the payload comparison would run against a null
-        # entry and report a second failure about a topic that is simply not there.
+        # The early return, and it is a crash guard rather than a tidier of messages:
+        # `Set-StrictMode -Version Latest` is on, so $Snapshot[$absent].Retained throws
+        # PropertyNotFoundException rather than reading as $null. Folding the return away
+        # to shorten the function would take a device missing one attribute and turn it
+        # into a conformance run that dies with no verdict at all.
         $failures = @(Get-AttributeFailure -Snapshot (ConvertTo-HomieSnapshot -Lines @()) -Topic 'homie/d/$homie' -Expected '4')
 
-        Assert-Equal -Expected 1 -Actual $failures.Count
+        Assert-ArrayEqual -Expected @('missing: homie/d/$homie') -Actual $failures
     }
 
     It 'reports an attribute the broker did not replay as retained' {


### PR DESCRIPTION
First slice of #84 — deliberately that slice only. The issue names it as the thing to do first
because it is what decides whether the conformance assertions can ever be covered.

## What was wrong

`Test-Attribute` was defined *inside* `Measure-HomieConformance` and closed over that scope's
`$snapshot`, which the `/set` round-trip reassigns further down the same function. Every call
happened before that reassignment, so no assertion was ever measured against the wrong store —
but that was a property of where in a 500-line function the calls were written rather than of
anything the code said. And it could not be called from a test at all, which is why the largest
verdict function in the repository, and the one with two prior defects that passed while lying
(#34, #36), had no host-side coverage of any kind.

## What changed

`Get-AttributeFailure`, at file scope, taking the snapshot as a parameter and *returning* what is
wrong with the attribute instead of appending to a list it can only see from an enclosing scope.

The 19 call sites collect with `$script:conformanceFailures += …`, which is the idiom every other
assertion in that function already uses. The attribute assertions were the only ones hiding their
append inside a closure, so this is a consistency gain rather than added noise.

Renamed on the way out: a `Test-` verb returning strings reads as a boolean predicate.
`Get-CatalogValidationError` is the file's precedent for "returns what is wrong". Three comments
elsewhere in the file that named `Test-Attribute` were updated with it.

Behaviour is unchanged. The early return on a missing topic, the retain-flag check, the payload
comparison and `-AnyValue`'s meaning are all as they were.

## Tests

11 new cases in `scripts\tests\RunIntegrationTests.Tests.ps1`, built on the real
`ConvertTo-HomieSnapshot` rather than hand-rolled hashtables so a change to the entry shape breaks
them instead of leaving them asserting against a shape the capture no longer produces:

- a clean attribute reports nothing
- a missing topic is reported, and nothing further is asserted about it
- an attribute the broker did not replay as retained
- a payload mismatch, naming both values
- both faults of one attribute reported together rather than the first
- `-AnyValue` skips the payload comparison, still asserts the retain flag, still reports a missing topic
- the snapshot read is the one passed in, not one the caller happens to have in scope
- a clean attribute appends nothing to a caller's `+=`

The snapshot case was checked to be load-bearing by deleting the `-Snapshot` parameter: it is the
case that then fails. Worth recording that a smaller mutation — lowercasing `$Snapshot` to
`$snapshot` in the body — does **not** fail, because PowerShell variable names are case-insensitive
and it still binds to the parameter. The test's comment says so rather than claiming a mechanism
it does not have.

`.claude\skills\smarthome-script-tests\SKILL.md` records the new coverage and that this is the
first piece of the conformance verdict covered at all.

## Verification

**Desk:** `Run-ScriptTests.ps1` — **157 passed, 0 failed** (was 146 on `origin/main`).

**Hardware:** the full integration suite on the ESP32 on COM3 with a local Mosquitto —
**all 5 PASS, 200s**.

| Test | Result | Time |
|---|---|---|
| WifiCheck | PASS | 26s |
| MqttCheck | PASS | 23s |
| Bmp280Check | PASS | 25s |
| **HomieClientCheck** | **PASS** | 71s |
| MqttReconnectCheck | PASS | 55s |

`HomieClientCheck` is the one that matters here: 53 topics in the retained store, and every
rewritten call site produced a clean verdict — "attributes, datatypes, retained flags, /set
round-trip, refused out-of-format payloads, alert/sleeping, a refused transition and re-announce
all conform". Phase breakdown was normal (announce 10.1s, `/set` 3.8s, out-of-format 4.3s,
lifecycle 17.8s, re-announce 13.8s).

The device is left on `SmartHome.IntegrationTests.MqttReconnectCheck`, as a suite run always leaves
it. Redeploy RoomSensor when it should go back to its real job.

## Filed, not fixed here

Extracting the function put its comparisons under a lens: both the topic lookup and the payload
comparison are case-insensitive, so a device publishing `$state` as `READY` passes an assertion
that wants `ready`, and two topics differing only in case collapse to one snapshot entry. Measured
against the shipped function, not reasoned about. Pre-existing and out of this slice's scope, so
it is an issue rather than a rider on this diff.

## Not in this change

The rest of #84 — `Start-HomieCapture`/`Stop-HomieCapture`, `Wait-ForRetainedValue`,
`Test-DeviceConstant`, the log-reading half of `Invoke-BrokerOutageCheck` — needs the scripted
fake-subscriber technique and is its own project. #84 stays open.

One item of #84 is now moot rather than done: the `Clear-SmartHomeDeployState` temp-directory seam
it asks for went away with the whole deploy record in #91. Noted on the issue.

Part of #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
