### PR TITLE
refactor(scripts): share the mosquitto lookup and the subscriber quoting

### DIFF
--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -682,6 +682,55 @@ function Get-SmartHomeSubscriberArguments {
     return @('-h', $SmartHomeLocalBrokerHost, '-p', $Port, '-t', $SmartHomeHomieTopic, '-F', '%t %r %p')
 }
 
+function Get-SmartHomeSubscriberArgumentString {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Port
+    )
+
+    # The arguments above, rendered as one string for cmd.exe. Both scripts that start a
+    # subscriber redirect its output, and both do the redirect in cmd.exe rather than with
+    # Start-Process -RedirectStandardOutput (see Start-DevEnv.ps1's header for why), so
+    # both need the argument list flattened.
+    #
+    # Quoting is the part worth sharing. Only the values carrying whitespace, a slash or a
+    # '#' need it -- 'homie/#' is the one that does today -- and the rule lived character
+    # for character in both files, in the half that breaks first if the argument list ever
+    # grows a value needing different quoting.
+    return (Get-SmartHomeSubscriberArguments -Port $Port |
+        ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
+}
+
+function Get-SmartHomeMosquittoTool {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        # Defaulted from SMARTHOME_MOSQUITTO_DIR rather than read unconditionally, so a
+        # caller -- a test, above all -- can ask about a directory without the machine's
+        # own configuration deciding the answer.
+        [string]$Directory
+    )
+
+    if (-not $PSBoundParameters.ContainsKey('Directory')) {
+        $Directory = Get-RequiredEnvValue -Name 'SMARTHOME_MOSQUITTO_DIR'
+    }
+
+    $path = Join-Path $Directory $Name
+
+    # Without this guard a wrong SMARTHOME_MOSQUITTO_DIR surfaced as a raw
+    # CommandNotFoundException -- or, for Run-IntegrationTests.ps1's retained snapshot, as
+    # an empty read reported as a conformance FAIL, i.e. a machine-config problem blamed on
+    # the device. exit rather than throw, matching Get-RequiredEnvValue above: this is a
+    # setup fault, and every caller's answer to it is to stop.
+    if (-not (Test-Path $path)) {
+        Write-Error ("Not found: {0}`nCheck SMARTHOME_MOSQUITTO_DIR in local.env.ps1." -f $path)
+        exit 1
+    }
+
+    return $path
+}
+
 # ── Dev environment: state ────────────────────────────────────────────────────
 # Start-DevEnv.ps1 records what it spawned so Stop-DevEnv.ps1 (or the
 # integration-test runner) can shut it down from a different shell. Keyed by

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -708,11 +708,17 @@ function Get-SmartHomeMosquittoTool {
 
         # Defaulted from SMARTHOME_MOSQUITTO_DIR rather than read unconditionally, so a
         # caller -- a test, above all -- can ask about a directory without the machine's
-        # own configuration deciding the answer.
+        # own configuration deciding the answer. Empty and unsupplied mean the same thing
+        # here; see below.
         [string]$Directory
     )
 
-    if (-not $PSBoundParameters.ContainsKey('Directory')) {
+    # Tested by value rather than with $PSBoundParameters.ContainsKey, because a caller
+    # reading the directory out of a config file and passing it straight through binds the
+    # parameter with an empty string. That satisfies ContainsKey, skips the fallback, and
+    # dies in Join-Path's parameter binding -- a raw ParameterBindingValidationException
+    # naming Join-Path, which is the kind of message the guard below exists to replace.
+    if ([string]::IsNullOrWhiteSpace($Directory)) {
         $Directory = Get-RequiredEnvValue -Name 'SMARTHOME_MOSQUITTO_DIR'
     }
 
@@ -723,7 +729,12 @@ function Get-SmartHomeMosquittoTool {
     # an empty read reported as a conformance FAIL, i.e. a machine-config problem blamed on
     # the device. exit rather than throw, matching Get-RequiredEnvValue above: this is a
     # setup fault, and every caller's answer to it is to stop.
-    if (-not (Test-Path $path)) {
+    #
+    # -LiteralPath, not -Path: an install directory carrying [ or ] is a wildcard pattern
+    # to Test-Path, so a mosquitto.exe that demonstrably exists reads as missing and the
+    # remediation then points at a path that is already correct (issue #71's defect class,
+    # which is why Set-TestFileContent and Import-SmartHomeLocalEnv are -LiteralPath too).
+    if (-not (Test-Path -LiteralPath $path)) {
         Write-Error ("Not found: {0}`nCheck SMARTHOME_MOSQUITTO_DIR in local.env.ps1." -f $path)
         exit 1
     }

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -857,24 +857,6 @@ function Wait-ForAnnounceWitnessed {
     return $false
 }
 
-function Get-MosquittoTool {
-    param([string]$Name)
-
-    $dir = Get-RequiredEnvValue -Name 'SMARTHOME_MOSQUITTO_DIR'
-    $path = Join-Path $dir $Name
-
-    # Same guard and remediation Start-DevEnv.ps1 gives the same two binaries. Without
-    # it a wrong SMARTHOME_MOSQUITTO_DIR surfaced as a raw CommandNotFoundException --
-    # or, for the retained snapshot, as an empty read reported as a conformance FAIL,
-    # i.e. a machine-config problem blamed on the device.
-    if (-not (Test-Path $path)) {
-        Write-Error ("Not found: {0}`nCheck SMARTHOME_MOSQUITTO_DIR in local.env.ps1." -f $path)
-        exit 1
-    }
-
-    return $path
-}
-
 # How long a snapshot subscriber listens. Three seconds, and it stays three seconds --
 # a fixed value rather than a parameter, because there is nothing here for a caller to
 # choose. Two attempts at shortening it both broke the conformance check, and the
@@ -1007,15 +989,15 @@ function Start-HomieCapture {
         Start-Sleep -Milliseconds 50
     }
 
-    $sub = Get-MosquittoTool -Name 'mosquitto_sub.exe'
+    $sub = Get-SmartHomeMosquittoTool -Name 'mosquitto_sub.exe'
 
-    # Arguments come from Common.ps1, not from a second copy of them here. The parser
-    # depends on the exact '%t %r %p' layout, and that layout is chosen and explained in
-    # Get-SmartHomeSubscriberArguments -- spelling it out again meant a one-line change in
-    # the file that owns it would silently break this reader.
-    # Quoting idiom matches Start-DevEnv.ps1's subscriber launch.
-    $subscriberArgs = (Get-SmartHomeSubscriberArguments -Port $Port |
-        ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
+    # Arguments and their cmd.exe quoting both come from Common.ps1, not from a second
+    # copy of them here. The parser depends on the exact '%t %r %p' layout, and that layout
+    # is chosen and explained in Get-SmartHomeSubscriberArguments -- spelling it out again
+    # meant a one-line change in the file that owns it would silently break this reader.
+    # The rendering used to be duplicated character for character in Start-DevEnv.ps1 with
+    # only a comment saying so, which is issue #85's second item.
+    $subscriberArgs = Get-SmartHomeSubscriberArgumentString -Port $Port
     $command = '/c ""{0}" {1} > "{2}" 2>&1"' -f $sub, $subscriberArgs, $out
     $process = Start-Process -FilePath 'cmd.exe' -ArgumentList $command -PassThru -WindowStyle Hidden
 
@@ -1330,7 +1312,7 @@ function Publish-HomieCommand {
 
     # Non-retained, as the convention requires of a controller: "A Homie controller
     # publishes to the set command topic with non-retained messages only."
-    $pub = Get-MosquittoTool -Name 'mosquitto_pub.exe'
+    $pub = Get-SmartHomeMosquittoTool -Name 'mosquitto_pub.exe'
     # Host from Common.ps1, which owns the reasoning. Not a literal here: the broker
     # address is shared vocabulary, and a second spelling is one a future change to the
     # listener binding would miss.
@@ -1426,8 +1408,15 @@ function Wait-ForRetainedValue {
 # Start/stop rather than a scriptblock wrapper: the phases share $snapshot and the
 # failure list, and & { } would run them in a child scope where those assignments are
 # invisible to the phases that follow.
+#
+# Only the list is declared here. $script:currentPhase, which these two functions are the
+# sole writers of, is declared with $script:snapshotsTaken further up, because the reason
+# it has to exist before any conformance check runs belongs to a reader outside this
+# block: Save-SnapshotEvidence reads it on every window of every test, and under
+# Set-StrictMode -Version Latest an unset variable there is a terminating error inside a
+# finally. This block used to redeclare it, leaving one variable with two rationale
+# comments to reconcile (issue #85's fifth item).
 $script:conformancePhases = @()
-$script:currentPhase = $null
 
 function Start-ConformancePhase {
     param([Parameter(Mandatory = $true)][string]$Name)

--- a/scripts/Run-IntegrationTests.ps1
+++ b/scripts/Run-IntegrationTests.ps1
@@ -2316,6 +2316,19 @@ foreach ($testName in $Tests) {
     }
 }
 
+# Both mosquitto clients this script runs, resolved here for the same reason the marker
+# names are: it is a desk operation, and a machine that cannot produce them is a mistake
+# worth hearing about before the first 90-second flash rather than after it. Nothing else
+# catches them this early -- Start-DevEnv.ps1 resolves mosquitto.exe and mosquitto_sub.exe
+# but never mosquitto_pub.exe, and with -NoBroker it does not run at all, so the first
+# report of a missing client used to come from Start-HomieCapture mid-run or from
+# Publish-HomieCommand inside HomieClientCheck's /set phase, ~90s in. The paths are
+# deliberately discarded: the call sites resolve their own, and this is the check, not a
+# cache of it.
+foreach ($mosquittoClient in 'mosquitto_sub.exe', 'mosquitto_pub.exe') {
+    Get-SmartHomeMosquittoTool -Name $mosquittoClient | Out-Null
+}
+
 # Build the debug monitor once up front. Watch-DeviceDebugOutput.ps1 would otherwise
 # rebuild this host-side tool before every capture -- ~1.8s of no-op build per test.
 Write-Host "Building the device debug monitor..." -ForegroundColor DarkGray

--- a/scripts/Start-DevEnv.ps1
+++ b/scripts/Start-DevEnv.ps1
@@ -32,8 +32,10 @@
     The wrapper means the recorded subscriber pid is cmd's, so it is stopped as a
     process TREE rather than a single pid.
 
-    File names and the subscriber's argument list come from Common.ps1, which also
-    uses them to recognise leftover processes -- see the file-vocabulary section there.
+    File names, the subscriber's argument list and its cmd.exe quoting all come from
+    Common.ps1, which also uses the file names to recognise leftover processes -- see
+    the file-vocabulary section there. So does the mosquitto binary lookup, guard and
+    remediation message, which Run-IntegrationTests.ps1 reads from the same place.
 
 .PARAMETER NoSync
     Skip the companion-repo sync and go straight to the broker. Use when the siblings
@@ -79,17 +81,14 @@ if (-not $NoSync) {
 
 Import-SmartHomeLocalEnv
 
-$mosquittoDir = Get-RequiredEnvValue -Name 'SMARTHOME_MOSQUITTO_DIR'
 $mqttPort = Get-OptionalEnvValue -Name 'SMARTHOME_MQTT_PORT' -DefaultValue '1883'
-$mosquittoExe = Join-Path $mosquittoDir 'mosquitto.exe'
-$mosquittoSub = Join-Path $mosquittoDir 'mosquitto_sub.exe'
 
-foreach ($exe in @($mosquittoExe, $mosquittoSub)) {
-    if (-not (Test-Path $exe)) {
-        Write-Error ("Not found: {0}`nCheck SMARTHOME_MOSQUITTO_DIR in local.env.ps1." -f $exe)
-        exit 1
-    }
-}
+# Resolved and guarded here, before anything is started, rather than where each is first
+# run: both are needed by a healthy start, and a missing one is a machine-config fault
+# whose remediation is the same for either. Get-SmartHomeMosquittoTool owns that guard and
+# its message; Run-IntegrationTests.ps1 had a byte-identical copy of both until issue #85.
+$mosquittoExe = Get-SmartHomeMosquittoTool -Name 'mosquitto.exe'
+$mosquittoSub = Get-SmartHomeMosquittoTool -Name 'mosquitto_sub.exe'
 
 # ── Existing environment ──────────────────────────────────────────────────────
 # A state file alone doesn't mean anything is running: a Ctrl+C at the wrong
@@ -219,8 +218,7 @@ if ($Detached) {
     # cmd.exe does the redirect so this script doesn't have to (see header). The
     # outer pair of quotes is what cmd /c needs to keep the inner quoted paths
     # intact.
-    $subscriberArgs = (Get-SmartHomeSubscriberArguments -Port $mqttPort |
-        ForEach-Object { if ($_ -match '[\s/#]') { '"{0}"' -f $_ } else { $_ } }) -join ' '
+    $subscriberArgs = Get-SmartHomeSubscriberArgumentString -Port $mqttPort
     $subscriberCommand = '/c ""{0}" {1} > "{2}" 2> "{3}""' -f `
         $mosquittoSub, $subscriberArgs, $subscriberLog, $subscriberErrLog
 

--- a/scripts/tests/Common.Tests.ps1
+++ b/scripts/tests/Common.Tests.ps1
@@ -520,6 +520,140 @@ Describe 'Get-SmartHomeSubscriberArguments' {
     }
 }
 
+Describe 'Get-SmartHomeSubscriberArgumentString' {
+    It 'renders the argument list cmd.exe expects, quoting only what needs it' {
+        # The whole string, not a property of it. This rendering used to live character for
+        # character in both Start-DevEnv.ps1 and Run-IntegrationTests.ps1 with nothing but a
+        # comment reconciling them (issue #85), so what is worth pinning is the exact text
+        # both of them now hand to cmd.exe.
+        Assert-Equal -Expected '-h 127.0.0.1 -p 1883 -t "homie/#" -F "%t %r %p"' `
+                     -Actual (Get-SmartHomeSubscriberArgumentString -Port '1883')
+    }
+
+    It 'quotes every value carrying whitespace, a slash or a #, and no others' {
+        # Derived from the argument list rather than from the expectation above, so this
+        # case still holds if the list grows: it says which values the quoting rule picks,
+        # not what today's list happens to contain.
+        $rendered = Get-SmartHomeSubscriberArgumentString -Port '1883'
+
+        foreach ($argument in Get-SmartHomeSubscriberArguments -Port '1883') {
+            $expected = if ($argument -match '[\s/#]') { '"{0}"' -f $argument } else { $argument }
+            Assert-True -Condition ($rendered.Contains($expected)) `
+                        -Because "'$argument' should render as '$expected', in '$rendered'"
+        }
+    }
+
+    It 'keeps the order the argument list is in' {
+        # -F and its format string are a pair, and so are -t and the topic. A rendering that
+        # sorted or dropped a value would leave mosquitto_sub reading a flag's value as a
+        # flag -- and the capture parser depends on that '%t %r %p' reaching it intact.
+        $arguments = @(Get-SmartHomeSubscriberArguments -Port '1883')
+        $rendered = Get-SmartHomeSubscriberArgumentString -Port '1883'
+
+        $position = -1
+        foreach ($argument in $arguments) {
+            $next = $rendered.IndexOf($argument, $position + 1)
+            Assert-True -Condition ($next -gt $position) -Because "'$argument' must appear after the one before it, in '$rendered'"
+            $position = $next
+        }
+    }
+
+    It 'passes the port through' {
+        Assert-Match -Pattern '-p 1884( |$)' -Actual (Get-SmartHomeSubscriberArgumentString -Port '1884')
+    }
+}
+
+Describe 'Get-SmartHomeMosquittoTool' {
+    It 'returns the tool inside the directory it was given' {
+        $dir = New-TestDirectory -Name 'mosquitto'
+        Set-TestFileContent -Path (Join-Path $dir 'mosquitto_sub.exe') -Content 'not really an executable'
+
+        Assert-Equal -Expected (Join-Path $dir 'mosquitto_sub.exe') `
+                     -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto_sub.exe' -Directory $dir)
+    }
+
+    It 'reads SMARTHOME_MOSQUITTO_DIR when no directory is given' {
+        $dir = New-TestDirectory -Name 'mosquitto-from-env'
+        Set-TestFileContent -Path (Join-Path $dir 'mosquitto.exe') -Content 'not really an executable'
+
+        $previous = [Environment]::GetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR')
+        try {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $dir)
+            Assert-Equal -Expected (Join-Path $dir 'mosquitto.exe') `
+                         -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto.exe')
+        }
+        finally {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $previous)
+        }
+    }
+
+    It 'lets an explicit directory beat the environment' {
+        # The seam that makes every case here independent of this machine's local.env.ps1.
+        # Without it the cases above would pass or fail on how Mosquitto happens to be
+        # installed here, which is the opposite of what a desk suite is for.
+        $wanted = New-TestDirectory -Name 'mosquitto-wanted'
+        $ignored = New-TestDirectory -Name 'mosquitto-ignored'
+        Set-TestFileContent -Path (Join-Path $wanted 'mosquitto.exe') -Content 'not really an executable'
+        Set-TestFileContent -Path (Join-Path $ignored 'mosquitto.exe') -Content 'not really an executable'
+
+        $previous = [Environment]::GetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR')
+        try {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $ignored)
+            Assert-Equal -Expected (Join-Path $wanted 'mosquitto.exe') `
+                         -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory $wanted)
+        }
+        finally {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $previous)
+        }
+    }
+
+    It 'names the missing path and SMARTHOME_MOSQUITTO_DIR when the tool is not there' {
+        # The remediation is the point of the guard. Without it a wrong directory reached
+        # the call site as a raw CommandNotFoundException, or -- for the conformance
+        # snapshot -- as an empty read reported as a FAIL against the device.
+        $dir = New-TestDirectory -Name 'mosquitto-empty'
+
+        $message = Assert-Throws -Body { Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory $dir }
+        Assert-Match -Pattern 'Not found' -Actual $message
+        Assert-Match -Pattern 'SMARTHOME_MOSQUITTO_DIR in local\.env\.ps1' -Actual $message
+        Assert-Match -Pattern ([regex]::Escape((Join-Path $dir 'mosquitto.exe'))) -Actual $message
+    }
+
+    It 'stops the calling script rather than returning a path that is not there' {
+        # In a child process because that is the only place the claim can be made: both
+        # callers treat the return value as a runnable path, so a missing tool has to end
+        # the run, and "ends the run" means a non-zero exit code and nothing after the call.
+        #
+        # Note which mechanism actually stops it. Common.ps1 sets $ErrorActionPreference to
+        # Stop at file scope, so the Write-Error terminates before the exit 1 below it is
+        # reached; the exit is what a caller that relaxed the preference would fall back on.
+        # Both land on exit code 1, which is what this asserts.
+        $probeDir = New-TestDirectory -Name 'mosquitto-exit'
+        $probe = Join-Path $probeDir 'probe.ps1'
+        $common = Join-Path (Split-Path -Parent $PSScriptRoot) 'Common.ps1'
+        Set-TestFileContent -Path $probe -Content @(
+            'Set-StrictMode -Version Latest'
+            '$ErrorActionPreference = ''Stop'''
+            ". '$common'"
+            "Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory '$probeDir' | Out-Null"
+            'Write-Output ''REACHED-AFTER'''
+        )
+
+        $stdout = Join-Path $probeDir 'out.txt'
+        $stderr = Join-Path $probeDir 'err.txt'
+        $powershell = (Get-Process -Id $PID).Path
+        $process = Start-Process -FilePath $powershell `
+                                 -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $probe) `
+                                 -NoNewWindow -Wait -PassThru `
+                                 -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+
+        Assert-Equal -Expected 1 -Actual $process.ExitCode
+        Assert-Equal -Expected '' -Actual ((Get-Content -LiteralPath $stdout -ErrorAction SilentlyContinue) -join '') `
+                     -Because 'nothing after the guard may run'
+        Assert-Match -Pattern 'SMARTHOME_MOSQUITTO_DIR' -Actual ((Get-Content -LiteralPath $stderr) -join ' ')
+    }
+}
+
 Describe 'ConvertTo-SmartHomeHashtable' {
     It 'turns a PSCustomObject into a hashtable whose missing keys read as $null' {
         # The whole reason it exists: ConvertFrom-Json hands back PSCustomObjects, and

--- a/scripts/tests/Common.Tests.ps1
+++ b/scripts/tests/Common.Tests.ps1
@@ -534,10 +534,17 @@ Describe 'Get-SmartHomeSubscriberArgumentString' {
         # Derived from the argument list rather than from the expectation above, so this
         # case still holds if the list grows: it says which values the quoting rule picks,
         # not what today's list happens to contain.
+        #
+        # The predicate is spelled as a character set rather than by reusing the function's
+        # own '[\s/#]' regex. Copying that regex would put a second, unreconciled statement
+        # of the rule right next to the one this change exists to remove -- and an edit
+        # applied to both (the natural response to this case failing) would then pass
+        # silently. Two independent formulations disagree loudly instead.
+        $needsQuoting = " `t`n/#".ToCharArray()
         $rendered = Get-SmartHomeSubscriberArgumentString -Port '1883'
 
         foreach ($argument in Get-SmartHomeSubscriberArguments -Port '1883') {
-            $expected = if ($argument -match '[\s/#]') { '"{0}"' -f $argument } else { $argument }
+            $expected = if ($argument.IndexOfAny($needsQuoting) -ge 0) { '"{0}"' -f $argument } else { $argument }
             Assert-True -Condition ($rendered.Contains($expected)) `
                         -Because "'$argument' should render as '$expected', in '$rendered'"
         }
@@ -581,6 +588,38 @@ Describe 'Get-SmartHomeMosquittoTool' {
             [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $dir)
             Assert-Equal -Expected (Join-Path $dir 'mosquitto.exe') `
                          -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto.exe')
+        }
+        finally {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $previous)
+        }
+    }
+
+    It 'finds a tool under a directory whose name contains [ or ]' {
+        # Test-Path -Path would read the brackets as a wildcard pattern and report a
+        # mosquitto.exe that demonstrably exists as missing -- then blame
+        # SMARTHOME_MOSQUITTO_DIR for a path that is already correct. Issue #71's defect
+        # class, which is why New-TestDirectory accepts a bracketed name at all.
+        $dir = New-TestDirectory -Name 'mosquitto[2]'
+        Set-TestFileContent -Path (Join-Path $dir 'mosquitto.exe') -Content 'not really an executable'
+
+        Assert-Equal -Expected (Join-Path $dir 'mosquitto.exe') `
+                     -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory $dir)
+    }
+
+    It 'treats an empty directory as no directory rather than as a path' {
+        # A caller reading the value out of a config file and passing it straight through
+        # binds the parameter with ''. Keying the fallback off $PSBoundParameters instead
+        # of the value sent that into Join-Path, which failed its own parameter binding --
+        # a raw exception naming Join-Path, in place of the remediation this guard exists
+        # to give.
+        $dir = New-TestDirectory -Name 'mosquitto-empty-argument'
+        Set-TestFileContent -Path (Join-Path $dir 'mosquitto.exe') -Content 'not really an executable'
+
+        $previous = [Environment]::GetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR')
+        try {
+            [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $dir)
+            Assert-Equal -Expected (Join-Path $dir 'mosquitto.exe') `
+                         -Actual (Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory '')
         }
         finally {
             [Environment]::SetEnvironmentVariable('SMARTHOME_MOSQUITTO_DIR', $previous)
@@ -631,26 +670,47 @@ Describe 'Get-SmartHomeMosquittoTool' {
         $probeDir = New-TestDirectory -Name 'mosquitto-exit'
         $probe = Join-Path $probeDir 'probe.ps1'
         $common = Join-Path (Split-Path -Parent $PSScriptRoot) 'Common.ps1'
+
+        # Doubled for the single-quoted literals below. The fixture root is under
+        # GetTempPath(), which carries the user name, and an apostrophe is legal there
+        # (C:\Users\O'Brien\...) -- an unescaped one makes the probe a parse error, which
+        # still exits non-zero and so would satisfy the exit-code assertion below while
+        # proving nothing about the function.
+        $probeCommon = $common -replace "'", "''"
+        $probeDirLiteral = $probeDir -replace "'", "''"
+
         Set-TestFileContent -Path $probe -Content @(
             'Set-StrictMode -Version Latest'
             '$ErrorActionPreference = ''Stop'''
-            ". '$common'"
-            "Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory '$probeDir' | Out-Null"
+            ". '$probeCommon'"
+            "Get-SmartHomeMosquittoTool -Name 'mosquitto.exe' -Directory '$probeDirLiteral' | Out-Null"
             'Write-Output ''REACHED-AFTER'''
         )
 
         $stdout = Join-Path $probeDir 'out.txt'
         $stderr = Join-Path $probeDir 'err.txt'
         $powershell = (Get-Process -Id $PID).Path
+
+        # -Redirect* here, which CLAUDE.md tells Start-DevEnv.ps1 never to use: those
+        # switches force UseShellExecute=false, and .NET then hands the child every
+        # inheritable handle including this runner's stdout, so a child that OUTLIVES the
+        # call leaves 'Run-ScriptTests.ps1 | tail' waiting forever for an EOF. -Wait is
+        # what makes it safe -- this probe is gone before the assertion below runs, so no
+        # handle survives it. Do not copy these switches into a case that backgrounds
+        # anything.
         $process = Start-Process -FilePath $powershell `
                                  -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $probe) `
                                  -NoNewWindow -Wait -PassThru `
                                  -RedirectStandardOutput $stdout -RedirectStandardError $stderr
 
+        # Both reads are -ErrorAction SilentlyContinue: a probe that never started leaves
+        # neither file behind, and a Get-Content path error would then be reported in place
+        # of whichever assertion actually says what went wrong.
         Assert-Equal -Expected 1 -Actual $process.ExitCode
         Assert-Equal -Expected '' -Actual ((Get-Content -LiteralPath $stdout -ErrorAction SilentlyContinue) -join '') `
                      -Because 'nothing after the guard may run'
-        Assert-Match -Pattern 'SMARTHOME_MOSQUITTO_DIR' -Actual ((Get-Content -LiteralPath $stderr) -join ' ')
+        Assert-Match -Pattern 'SMARTHOME_MOSQUITTO_DIR' `
+                     -Actual ((Get-Content -LiteralPath $stderr -ErrorAction SilentlyContinue) -join ' ')
     }
 }
 


### PR DESCRIPTION
Items **1, 2 and 5** of #85 — the two cross-file duplications and the dead duplicate declaration. Items 3 and 4 (the polling helper behind the three waits, the retry helper behind the two rounds) are deliberately **not** here; they are the next two slices.

Does not close #85.

## What was duplicated

`Run-IntegrationTests.ps1` and `Start-DevEnv.ps1` each resolved a mosquitto binary under `SMARTHOME_MOSQUITTO_DIR` with a byte-identical guard and remediation message, and each rendered the subscriber's argument list for `cmd.exe` with the same two lines. Both files carried a comment admitting it — *"Same guard and remediation Start-DevEnv.ps1 gives the same two binaries"*, *"Quoting idiom matches Start-DevEnv.ps1's subscriber launch"* — and nothing reconciled them, so a change to the quoting rule or the guard in one file would have kept the old behaviour in the other, silently.

## What replaces it

Two functions in `Common.ps1`, beside `Get-SmartHomeSubscriberArguments`, which already owned the argument list the rendering flattens:

- **`Get-SmartHomeSubscriberArgumentString -Port`** — the arguments as one `cmd.exe` string, quoting only the values carrying whitespace, a slash or a `#`.
- **`Get-SmartHomeMosquittoTool -Name [-Directory]`** — the path, or the run stops with the same message. `-Directory` defaults from `SMARTHOME_MOSQUITTO_DIR`.

`-Directory` is the seam that makes the guard testable at all: without it every case would pass or fail on how Mosquitto happens to be installed on the machine running them. The new cases pass on a checkout with no `SMARTHOME_MOSQUITTO_DIR` set — which is CI's condition, and was this session's, confirmed by a mutation that removed the parameter and made three cases fail with `Missing environment variable: SMARTHOME_MOSQUITTO_DIR`.

`Test-Setup.ps1` deliberately does **not** read `Get-SmartHomeMosquittoTool`: it reports rather than aborts, by design, and reads values parsed out of `local.env.ps1` rather than the environment. Left alone.

## The declaration (#85 item 5), and the half of it that is not a defect

`$script:currentPhase = $null` did appear twice at file scope, both assigning `$null`. One is gone. The one kept is the earlier one — **not** the one #85 suggested — because its comment carries the reason the declaration has to exist before any conformance check does: `Save-SnapshotEvidence` reads it from `Stop-HomieCapture`'s `finally` on **every window of every test**, including runs that never enter the conformance check, and an unset variable there is a terminating error under `Set-StrictMode -Version Latest` — inside a `finally`, where it would replace the exception already in flight. The phase-timing block now points at it.

**`$script:conformancePhases` is not a duplicate and was left alone.** #85 says both pairs are at file scope; the second assignment is inside `Measure-HomieConformance` (confirmed with the AST, not by reading indentation), so it is a per-run reset. The file-scope one is load-bearing separately: `Write-ConformancePhaseBreakdown` runs from `Invoke-HomieConformanceCheck`'s `finally` and reads `.Count`, which is reached when the check fails *before* the measurement starts. Deleting either would have been a defect. Recorded on #85 as a correction to its own body.

## Verified

**Behaviour is unchanged, and that was measured rather than assumed.** The rendered subscriber arguments were compared against the old expression, evaluated side by side for two ports: byte-identical (`-ceq`) both times — `-h 127.0.0.1 -p 1883 -t "homie/#" -F "%t %r %p"`. The missing-tool path still ends the run with exit code 1 and the same message.

- **`.\scripts\Run-ScriptTests.ps1` — 168 passed, 0 failed**, ~9s, no device. Up from 157: 4 cases for the rendering, 7 for the tool lookup (5, plus 2 regression cases from the review pass below).
- **Three mutations, all caught**, because a case that cannot fail proves nothing:
  - narrowing the quoting rule from `[\s/#]` to `[\s]` → 2 failures, naming `-t homie/#` unquoted;
  - deleting the `-Directory` parameter → 3 failures;
  - replacing the not-found guard with `if ($false)` → 2 failures, including the child-process case reporting `expected 1, got 0`.
- **The dev environment, started and stopped for real** (no device): broker up, two publishes, both back out of the `homie/#` subscriber's log in the `%t %r %p` layout — which is the wildcard subscription surviving the quoting end to end, not just the string matching an expectation.
- **Both rewired call sites inside `Run-IntegrationTests.ps1`, exercised at desk against a live broker and no device**, by dot-sourcing the script through its own guard: `Get-HomieRetainedSnapshot` returned 2 entries with the retain flag set, and `Publish-HomieCommand` produced a command seen live inside a window that had waited for its subscriber. Two evidence files were written, so `Save-SnapshotEvidence` read `$script:currentPhase` with only the one declaration left.
- **Hardware: the full suite, all 5 PASS — twice.** Once on `0cd59f8` (201s) and again on `7483a28` after the review fixes (**197s** — WifiCheck 26s, MqttCheck 24s, Bmp280Check 24s, HomieClientCheck 70s, MqttReconnectCheck 53s), so the result stands for the diff as it is now rather than for an earlier version of it. `HomieClientCheck` is the one that matters here: 53 topics in the retained store both times, every phase normal, and the re-announce after the broker was replaced. Every deploy took the #46 erase path with no fallback and no warnings, and the new mosquitto-client pre-flight passed silently ahead of the first build.

The suite leaves `MqttReconnectCheck` flashed, as it always does. RoomSensor has not been redeployed.

## Filed

[#95](https://github.com/JojoEffect/SmartHome/issues/95) — `Test-Setup.ps1` checks `mosquitto.exe` only, so a Mosquitto install missing `mosquitto_sub.exe` or `mosquitto_pub.exe` passes the preflight and then fails inside `Start-DevEnv.ps1` or a conformance snapshot, which is the exact failure the preflight exists to pre-empt. Noticed while giving those two binaries a shared lookup; verified against the source, not fixed here.
